### PR TITLE
Adding config option for github host

### DIFF
--- a/bin/gitbook.js
+++ b/bin/gitbook.js
@@ -28,6 +28,7 @@ prog
 .option('-t, --title <name>', 'Name of the book to generate, defaults to repo name')
 .option('-i, --intro <intro>', 'Description of the book to generate')
 .option('-g, --github <repo_path>', 'ID of github repo like : username/repo')
+.option('-gh, --githubHost <url>', 'The url of the github host (defaults to https://github.com/')
 .action(buildFunc = function(dir, options) {
     dir = dir || process.cwd();
     outputDir = options.output || path.join(dir, '_book');
@@ -78,6 +79,7 @@ prog
 .option('-o, --output <directory>', 'Path to output directory, defaults to ./_book')
 .option('-t, --title <name>', 'Name of the book to generate, defaults to repo name')
 .option('-g, --github <repo_path>', 'ID of github repo like : username/repo')
+.option('-gh, --githubHost <url>', 'The url of the github host (defaults to https://github.com/')
 .action(function(dir, options) {
     buildFunc(dir, options)
     .then(function(outputDir) {

--- a/lib/generate/index.js
+++ b/lib/generate/index.js
@@ -11,16 +11,18 @@ var generate = function(root, output, options) {
     var files, summary, navigation, tpl;
 
     options = _.defaults(options || {}, {
-        // Book title, description
+        // Book title, keyword, description
         title: null,
         description: "Book generated using GitBook",
 
         // Origin github repository id
-        github: null
+        github: null,
+        githubHost: 'https://github.com/'
     });
 
-    if (!options.github || !options.title) return Q.reject(new Error("Need options.github and options.title"));
-
+    if (!options.github || !options.title) {
+        return Q.reject(new Error("Need options.github and options.title"));
+    }
 
     // Clean output folder
     return fs.remove(output)
@@ -39,7 +41,7 @@ var generate = function(root, output, options) {
         files = _files;
 
         if (!_.contains(files, "SUMMARY.md") || !_.contains(files, "README.md")) {
-            return Q.reject(new Error("Invalid gitbook repository: need SUMMARY.md and README.md"));
+            return Q.reject(new Error("Invalid gitbook repository, need SUMMARY.md and README.md"));
         }
     })
 
@@ -65,7 +67,8 @@ var generate = function(root, output, options) {
 
                 githubAuthor: options.github.split("/")[0],
                 githubId: options.github,
-                
+                githubHost: options.githubHost,
+
                 summary: summary,
                 allNavigation: navigation
             }

--- a/templates/includes/book/exercise.html
+++ b/templates/includes/book/exercise.html
@@ -20,5 +20,5 @@
 <div class="btn-group btn-group-justified">
     <a href="#" class="btn btn-default action-submit">Submit</a>
     <a href="#" class="btn btn-default action-solution">Solution</a>
-    <a href="https://github.com/{{ githubId }}/issues/new" target="_blank" class="btn btn-default">Have a Question?</a>
+    <a href="{{ githubHost }}{{ githubId }}/issues/new" target="_blank" class="btn btn-default">Have a Question?</a>
 </div>

--- a/templates/includes/book/header.html
+++ b/templates/includes/book/header.html
@@ -1,6 +1,6 @@
 <div class="book-header">
     <!-- Actions Left -->
-    <a href="https://github.com/{{ githubId }}" target="_blank" class="btn pull-left"><i class="fa fa-github-alt"></i></a>
+    <a href="{{ githubHost }}{{ githubId }}" target="_blank" class="btn pull-left"><i class="fa fa-github-alt"></i></a>
     <a href="#" class="btn pull-left toggle-summary"><i class="fa fa-align-justify"></i></a>
 
     <!-- Actions Right -->
@@ -8,8 +8,8 @@
     <a href="#" target="_blank" class="btn pull-right" data-sharing="facebook"><i class="fa fa-facebook"></i></a>
     <a href="#" target="_blank" class="btn pull-right" data-sharing="twitter"><i class="fa fa-twitter"></i></a>
 
-    <a href="https://github.com/{{ githubId }}/stargazers" target="_blank" class="btn pull-right count-star"><i class="fa fa-star-o"></i> Star (<span>-</span>)</a>
-    <a href="https://github.com/{{ githubId }}/watchers" target="_blank" class="btn pull-right count-watch"><i class="fa fa-eye"></i> Watch (<span>-</span>)</a>
+    <a href="{{ githubHost }}{{ githubId }}/stargazers" target="_blank" class="btn pull-right count-star"><i class="fa fa-star-o"></i> Star (<span>-</span>)</a>
+    <a href="{{ githubHost }}{{ githubId }}/watchers" target="_blank" class="btn pull-right count-watch"><i class="fa fa-eye"></i> Watch (<span>-</span>)</a>
 
 
     <!-- Title -->

--- a/templates/includes/book/summary.html
+++ b/templates/includes/book/summary.html
@@ -1,13 +1,13 @@
 <div class="book-summary">
     <ul class="summary">
         <li>
-            <a href="https://github.com/{{ githubAuthor }}" target="blank">About the author</a>
+            <a href="{{ githubHost }}{{ githubAuthor }}" target="blank">About the author</a>
         </li>
         <li>
-            <a href="https://github.com/{{ githubId }}/issues" target="blank">Questions and Issues</a>
+            <a href="{{ githubHost }}{{ githubId }}/issues" target="blank">Questions and Issues</a>
         </li>
         <li>
-            <a href="https://github.com/{{ githubId }}/edit/master/{{ _input }}" target="blank">Edit and Contribute</a>
+            <a href="{{ githubHost }}{{ githubId }}/edit/master/{{ _input }}" target="blank">Edit and Contribute</a>
         </li>
         <li class="divider"></li>
         <li data-level="0">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -24,9 +24,9 @@
         <meta property="og:type" content="book">
         <meta property="og:locale" content="en_US">
 
-        <meta property="book:author" content="https://github.com/{{ githubAuthor }}">
+        <meta property="book:author" content="{{ githubHost }}{{ githubAuthor }}">
         <meta property="book:tag" content="GitBook">
-        
+
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
- this config option allows the github host url to be set to
  something other than github.com, mainly so that github enterprise
  users can change the url to their private host but will also
  work with bitbucket
