### PR TITLE
use a relative symlink for index.html

### DIFF
--- a/lib/generate/index.js
+++ b/lib/generate/index.js
@@ -107,7 +107,7 @@ var generate = function(root, output, options) {
     // Symlink index.html to README.html
     .then(function() {
         return fs.symlink(
-            path.join(output, 'README.html'),
+            'README.html',
             path.join(output, 'index.html')
         );
     })


### PR DESCRIPTION
Use a relative symlink for the index.html link in generated books rather than a non-portable absolute symlink. Should fix #19.
