### PR TITLE
Fixes --githubHost option for use with Github Enterprise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Options for commands `build` and `serve` are:
 -o, --output <directory>  Path to output directory, defaults to ./_book
 -f, --format <name>       Change generation format, defaults to site, availables are: site, page, pdf, json
 -i, --intro <intro>       Description of the book to generate
--gh, --githubHost <url>   The url of the github host (defaults to https://github.com/)
+--githubHost <url>   The url of the github host (defaults to https://github.com/)
 --theme <path>            Path to theme directory
 ```
 

--- a/bin/build.js
+++ b/bin/build.js
@@ -42,6 +42,7 @@ var buildFunc = function(dir, options) {
                 title: title,
                 description: options.intro,
                 github: githubID,
+                githubHost: options.githubHost,
                 generator: options.format,
                 theme: options.theme
             })

--- a/bin/gitbook.js
+++ b/bin/gitbook.js
@@ -23,7 +23,7 @@ var buildCommand = function(command, action) {
     .option('-t, --title <name>', 'Name of the book to generate, defaults to repo name')
     .option('-i, --intro <intro>', 'Description of the book to generate')
     .option('-g, --github <repo_path>', 'ID of github repo like : username/repo')
-    .option('-gh, --githubHost <url>', 'The url of the github host (defaults to https://github.com/')
+    .option('--githubHost <url>', 'The url of the github host (defaults to https://github.com/')
     .option('--theme <path>', 'Path to theme directory')
     .action(action);
 }


### PR DESCRIPTION
Hello, sweet project.

When I try to compile a book using the `--githubHost` option my value isn't acknowledged:

![screen shot 2014-04-07 at 1 11 04 pm](https://cloud.githubusercontent.com/assets/461249/2634267/a5d063fa-be78-11e3-99fe-8a5d9ba582be.png)

Furthermore, if you try to compile a book using the shorter `-gh` option gitbook errors out:

![screen shot 2014-04-07 at 1 20 40 pm](https://cloud.githubusercontent.com/assets/461249/2634296/fce0cfe0-be78-11e3-8084-fe7adbb39174.png)

This PR attempts to the resolve the issue(s).

The `--githubHost` option wasn't being passed to the generator. After passing that along it works:

![screen shot 2014-04-07 at 1 26 19 pm](https://cloud.githubusercontent.com/assets/461249/2634366/c692af70-be79-11e3-9304-0ad9751ab89d.png)

 However, the shorter `-gh` still doesn't work correctly. I am not sure if it's an issue with commander and defining options for both `-g` and `-gh` or something else. It works when renamed to `-e` for example. Anyways, I just removed the `-gh` option in favor of the longer `--githubHost` similar to the `--theme` option. 

Please review and let me know what you guys think or if you'd like additional information/changes.
