### PR TITLE
Process markdown nested in html on presence of data-markdown attribute

### DIFF
--- a/lib/parse/lex.js
+++ b/lib/parse/lex.js
@@ -42,6 +42,12 @@ function lexPage(src) {
     // Lex file
     var nodes = marked.lexer(src);
 
+    _.each(nodes, function(n) {
+        if (n.type === 'html' && / data-markdown[ >]/.test(n.text.substring(0, n.text.indexOf('>') + 1))) {
+            n.type = 'nested-markdown';
+        }
+    });
+
     return _.chain(splitSections(nodes))
     .map(function(section, idx) {
         // Detect section type

--- a/lib/parse/page.js
+++ b/lib/parse/page.js
@@ -42,6 +42,17 @@ function parsePage(src, options) {
     // Lex if not already lexed
     return (_.isArray(src) ? src : lex(src))
     .map(function(section) {
+        _.filter(section, { type: 'nested-markdown' }).map(function(node) {
+            var bodyStart = node.text.indexOf('>') + 1;
+            var bodyEnd = node.text.lastIndexOf('<');
+            var body = node.text.substring(bodyStart, bodyEnd);
+            var content = parsePage(lex(body), options);
+            node.text = node.text.substring(0, bodyStart) + content[0].content + node.text.substring(bodyEnd);
+            node.type = 'html';
+        });
+        return section;
+    })
+    .map(function(section) {
         // Transform given type
         if(section.type === 'exercise') {
             var nonCodeNodes = _.reject(section, {


### PR DESCRIPTION
In order to be able to lay out some pages more flexibly, it is nice to be able to wrap some HTML around the markdown content. The user must add a `data-markdown` attribute to any HTML element they want the content of to be processed by marked.
