### PR TITLE
Fix URL creation on windows

### DIFF
--- a/lib/parse/renderer.js
+++ b/lib/parse/renderer.js
@@ -76,10 +76,8 @@ GitBookRenderer.prototype.image = function(href, title, text) {
 
     // Relative image, rewrite it depending output
     if(!parsed.protocol && parsed.path && parsed.path[0] != '/' && o && o.dir && o.outdir) {
-        _href = path.relative(o.outdir, path.normalize(path.join(
-            o.dir,
-            href
-        )));
+        var outdir = o.outdir.charAt(o.outdir.length - 1) === '/' ? o.outdir : o.outdir + '/';
+        _href = url.resolve(outdir, [o.dir, href].join('/'));
     }
 
     return GitBookRenderer.super_.prototype.image.call(this, _href, title, text);

--- a/test/fixtures/PAGE.md
+++ b/test/fixtures/PAGE.md
@@ -31,6 +31,9 @@ Some more nice content ....
 
 [Link to another Markdown file](./xyz/file.md)
 
+And look at this pretty picture:
+![Pretty](../assets/my-pretty-picture.png "Pretty")
+
 Lets go for another exercise but this time with some context :
 
 ---

--- a/test/page.js
+++ b/test/page.js
@@ -6,7 +6,10 @@ var page = require('../').parse.page;
 
 
 var CONTENT = fs.readFileSync(path.join(__dirname, './fixtures/PAGE.md'), 'utf8');
-var LEXED = page(CONTENT);
+var LEXED = page(CONTENT, {
+    dir: 'course',
+    outdir: '_book'
+});
 
 var HR_CONTENT = fs.readFileSync(path.join(__dirname, './fixtures/HR_PAGE.md'), 'utf8');
 var HR_LEXED = page(HR_CONTENT);
@@ -29,6 +32,10 @@ describe('Page parsing', function() {
         assert(LEXED[0].content);
         assert(LEXED[2].content);
     });
+
+    it('should make image URLs relative', function() {
+        assert(LEXED[2].content.indexOf('_book/assets/my-pretty-picture.png') !== -1);
+    })
 
     it('should gen code and content for exercise sections', function() {
         assert(LEXED[1].content);
@@ -67,7 +74,7 @@ describe('Relative links', function() {
             repo: 'GitBookIO/javascript',
 
             // Imaginary folder of markdown file
-            dir: 'course',
+            dir: 'course'
         });
 
         assert(LEXED[0].content.indexOf('https://github.com/GitBookIO/javascript/blob/src/something.cpp') !== -1);


### PR DESCRIPTION
The node `path` library is for OS specific paths, and does not support relative unix style paths being created/normalized on windows. Using the `url` API instead to fix mocha tests.
