### PR TITLE
Disable automatic highlighting

### DIFF
--- a/lib/parse/page.js
+++ b/lib/parse/page.js
@@ -23,11 +23,13 @@ function render(section, _options) {
 
         // Synchronous highlighting with highlight.js
         highlight: function (code, lang) {
+            if(!lang) return code;
+
             try {
                 return hljs.highlight(lang, code).value;
-            } catch(e) {
-                return hljs.highlightAuto(code).value;
-            }
+            } catch(e) { }
+
+            return code;
         }
     });
 


### PR DESCRIPTION
Fallback to no highlighting rather that potentially funky highlighting.

Fixes #103 
