### PR TITLE
Plugins that don't have assets should be skipped

### DIFF
--- a/lib/generate/site/index.js
+++ b/lib/generate/site/index.js
@@ -204,7 +204,9 @@ Generator.prototype.copyAssets = function() {
     // Copy plugins assets
     .then(function() {
         return Q.all(
-            _.map(that.plugins.list, function(plugin) {
+            _.filter(that.plugins.list,  function(plugin) {
+                return plugin.infos.book && plugin.infos.book.assets;
+            }).map(function(plugin) {
                 var pluginAssets = path.join(that.options.output, "gitbook/plugins/", plugin.name);
 
                 return plugin.copyAssets(pluginAssets)


### PR DESCRIPTION
An error is given when a plugin that doesn't have any assets is processed. This fixes it so that those are filtered out.
