### PR TITLE
Accessibility: aria-label added to navigation links

### DIFF
--- a/theme/templates/site.html
+++ b/theme/templates/site.html
@@ -28,10 +28,10 @@
         </div>
 
         {% if progress.current.prev and progress.current.prev.path %}
-        <a href="{{ basePath }}/{{ progress.current.prev.path|mdLink }}" class="navigation navigation-prev {% if !progress.current.next or !progress.current.next.path %}navigation-unique{% endif %}"><i class="fa fa-angle-left"></i></a>
+        <a href="{{ basePath }}/{{ progress.current.prev.path|mdLink }}" class="navigation navigation-prev {% if !progress.current.next or !progress.current.next.path %}navigation-unique{% endif %}" aria-label="Previous page: {{ progress.current.prev.title }}"><i class="fa fa-angle-left"></i></a>
         {% endif %}
         {% if progress.current.next and progress.current.next.path %}
-        <a href="{{ basePath }}/{{ progress.current.next.path|mdLink }}" class="navigation navigation-next {% if !progress.current.prev or !progress.current.prev.path %}navigation-unique{% endif %}"><i class="fa fa-angle-right"></i></a>
+        <a href="{{ basePath }}/{{ progress.current.next.path|mdLink }}" class="navigation navigation-next {% if !progress.current.prev or !progress.current.prev.path %}navigation-unique{% endif %}" aria-label="Next page: {{ progress.current.next.title }}"><i class="fa fa-angle-right"></i></a>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
Current behavior: Screenreader just reads ‘link’ when landing on the previous and next navigation links, giving the user no indication of what the link does or where it goes.

New behaviour: Screenreader reads "Previous page: {page title}” and “Next page: {page title}” respectively.
