### PR TITLE
Don't show divider even if githubId is present.

### DIFF
--- a/theme/templates/includes/book/summary.html
+++ b/theme/templates/includes/book/summary.html
@@ -21,7 +21,7 @@
         </li>
         {% endif %}
 
-        {% if options.links.contribute || options.links.issues || options.links.about || githubId %}
+        {% if options.links.contribute || options.links.issues || options.links.about %}
         <li class="divider"></li>
         {% endif %}
 


### PR DESCRIPTION
![screen shot 2014-05-08 at 1 40 37 pm](https://cloud.githubusercontent.com/assets/840464/2918360/81eab7fa-d6cf-11e3-9560-bfacf9bae0a0.png)
