### PR TITLE
Force forward slashes on SUMMARY.md path for articles

### DIFF
--- a/lib/parse/summary.js
+++ b/lib/parse/summary.js
@@ -82,7 +82,7 @@ function parseTitle(src, nums) {
         level: level,
 
         // Replace .md references with .html
-        path: matches[2],
+        path: matches[2].replace(/\\/g, '/'),
     };
 }
 


### PR DESCRIPTION
this prevent windows user to generate invalid path on unix OS
Reference to issue #39 on gitbook-editor.
