### PR TITLE
Add HTML classes to make plugins easier to write

### DIFF
--- a/theme/templates/includes/book/header.html
+++ b/theme/templates/includes/book/header.html
@@ -1,7 +1,7 @@
 <div class="book-header">
     <!-- Actions Left -->
     {% if options.links.home !== false and (options.links.home != null or githubId) %}
-    <a href="{{ options.links.home|default(githubHost+githubId) }}" target="_blank" class="btn pull-left" aria-label="GitHub home"><i class="fa fa-bookmark-o"></i></a>
+    <a href="{{ options.links.home|default(githubHost+githubId) }}" target="_blank" class="btn pull-left home-bookmark" aria-label="GitHub home"><i class="fa fa-bookmark-o"></i></a>
     {% endif %}
     <a href="#" class="btn pull-left toggle-summary" aria-label="Toggle summary"><i class="fa fa-align-justify"></i></a>
     <a href="#" class="btn pull-left toggle-search" aria-label="Toggle search"><i class="fa fa-search"></i></a>
@@ -13,13 +13,13 @@
 
     <!-- Actions Right -->
     {% if options.links.sharing.google !== false %}
-    <a href="#" target="_blank" class="btn pull-right" data-sharing="google-plus" aria-label="Share on Google Plus"><i class="fa fa-google-plus"></i></a>
+    <a href="#" target="_blank" class="btn pull-right google-plus-sharing-link sharing-link" data-sharing="google-plus" aria-label="Share on Google Plus"><i class="fa fa-google-plus"></i></a>
     {% endif %}
     {% if options.links.sharing.facebook !== false %}
-    <a href="#" target="_blank" class="btn pull-right" data-sharing="facebook" aria-label="Share on Facebook"><i class="fa fa-facebook"></i></a>
+    <a href="#" target="_blank" class="btn pull-right facebook-sharing-link sharing-link" data-sharing="facebook" aria-label="Share on Facebook"><i class="fa fa-facebook"></i></a>
     {% endif %}
     {% if options.links.sharing.twitter !== false %}
-    <a href="#" target="_blank" class="btn pull-right" data-sharing="twitter" aria-label="Share on Twitter"><i class="fa fa-twitter"></i></a>
+    <a href="#" target="_blank" class="btn pull-right twitter-sharing-link sharing-link" data-sharing="twitter" aria-label="Share on Twitter"><i class="fa fa-twitter"></i></a>
     {% endif %}
 
     {% if githubId %}

--- a/theme/templates/includes/book/summary.html
+++ b/theme/templates/includes/book/summary.html
@@ -5,19 +5,19 @@
     <ul class="summary">
         {% if options.links.about !== false && (options.links.about != null || githubId) %}
         <li>
-            <a href="{{ options.links.about|default(githubHost+githubAuthor) }}" target="blank">About the author</a>
+            <a href="{{ options.links.about|default(githubHost+githubAuthor) }}" target="blank" class="author-link">About the author</a>
         </li>
         {% endif %}
 
         {% if options.links.issues !== false && (options.links.issues != null || githubId) %}
         <li>
-            <a href="{{ options.links.issues|default(githubHost+githubId+"/issues") }}" target="blank">Questions and Issues</a>
+            <a href="{{ options.links.issues|default(githubHost+githubId+"/issues") }}" target="blank"class="issues-link">Questions and Issues</a>
         </li>
         {% endif %}
 
         {% if options.links.contribute !== false && (options.links.contribute != null || githubId) %}
         <li>
-            <a href="{{ options.links.contribute|default(githubHost+githubId+"/edit/master/"+_input) }}" target="blank">Edit and Contribute</a>
+            <a href="{{ options.links.contribute|default(githubHost+githubId+"/edit/master/"+_input) }}" target="blank" class="contribute-link">Edit and Contribute</a>
         </li>
         {% endif %}
 
@@ -29,7 +29,7 @@
             <a href="{{ basePath }}/"><i class="fa fa-check"></i> Introduction</a>
         </li>
         {% for item in summary.chapters %}
-            <li {% if item._path == _input %}class="active"{% endif %} data-level="{{ item.level }}" {% if item.path %}data-path="{{ item.path|mdLink }}"{% endif %}>
+            <li class="chapter {% if item._path == _input %}active{% endif %}" data-level="{{ item.level }}" {% if item.path %}data-path="{{ item.path|mdLink }}"{% endif %}>
                 {% if item.path %}
                 <a href="{{ basePath }}/{{ item.path|mdLink }}">
                     <i class="fa fa-check"></i> <b>{{ item.level }}.</b> {{ item.title }}
@@ -58,7 +58,7 @@
         {% if options.links.gitbook !== false %}
         <li class="divider"></li>
         <li>
-            <a href="http://www.gitbook.io/" target="blank">Generated using GitBook</a>
+            <a href="http://www.gitbook.io/" target="blank" class="gitbook-link">Generated using GitBook</a>
         </li>
         {% endif %}
     </ul>


### PR DESCRIPTION
Right now, writing a CSS/JS plugin ends up depending on some very fragile CSS selectors to alter different elements on the page -- this attempts to solve this problem in general by adding classes to header and summary sidebar links and buttons for easier selection. Ideally these class names would also be persisted in future versions so as not to break existing plugins.
