### PR TITLE
Optional contribute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Here are the options that can be stored in this file:
             "google": null,
             "facebook": null,
             "twitter": null
+        },
+
+        // Contribute links
+        "contribute": {
+            "watch" : null,
+            "star": null
         }
     }
 }

--- a/theme/templates/includes/book/header.html
+++ b/theme/templates/includes/book/header.html
@@ -22,9 +22,11 @@
     <a href="#" target="_blank" class="btn pull-right twitter-sharing-link sharing-link" data-sharing="twitter" aria-label="Share on Twitter"><i class="fa fa-twitter"></i></a>
     {% endif %}
 
-    {% if githubId %}
-    <a href="{{ githubHost }}{{ githubId }}/stargazers" target="_blank" class="btn pull-right count-star hidden-xs"><i class="fa fa-star-o"></i> Star (<span>-</span>)</a>
-    <a href="{{ githubHost }}{{ githubId }}/watchers" target="_blank" class="btn pull-right count-watch hidden-xs"><i class="fa fa-eye"></i> Watch (<span>-</span>)</a>
+    {% if options.links.contribute.star !== false and (options.links.contribute.star != null or githubId) %}
+    <a href="{{ options.links.contribute.star|default(githubHost+githubId+"/stargazers") }}" target="_blank" class="btn pull-right count-star hidden-xs"><i class="fa fa-star-o"></i> Star (<span>-</span>)</a>
+    {% endif %}
+    {% if options.links.contribute.watch !== false and (options.links.contribute.watch != null or githubId) %}
+    <a href="{{ options.links.contribute.watch|default(githubHost+githubId+"/watchers") }}" target="_blank" class="btn pull-right count-watch hidden-xs"><i class="fa fa-eye"></i> Watch (<span>-</span>)</a>
     {% endif %}
 
     <!-- Title -->


### PR DESCRIPTION
Make "Star" / "Watch" links optional, manually editable in book.json.

Useful in case of nonuse of Github (e.g. Gitlab, Gitorious, ...) or if the author doesn't want to show these links.
