### PR TITLE
Fix page.path for plugins

### DIFF
--- a/lib/generate/site/index.js
+++ b/lib/generate/site/index.js
@@ -102,6 +102,7 @@ Generator.prototype.convertFile = function(content, _input) {
 
     var page = {
         path: _input,
+	rawPath: input, // path to raw md file
         content: content,
         progress: parse.progress(this.options.navigation, _input)
     };


### PR DESCRIPTION
The current value of `page.path` is relative to the book repository. I'm writing a plugin which inserts files into the page; in order to open these files I need to know the path relative to the gitbook command.

This PR sets `page.path` relative to the directory in which gitbook is run.
