### PR TITLE
generate header id the same as github

### DIFF
--- a/lib/parse/renderer.js
+++ b/lib/parse/renderer.js
@@ -135,5 +135,10 @@ GitBookRenderer.prototype.listitem = function(text) {
     return GitBookRenderer.super_.prototype.listitem(this._createCheckboxAndRadios(text));
 };
 
+GitBookRenderer.prototype.heading = function(text, level, raw) {
+    var id = this.options.headerPrefix + raw.toLowerCase().replace(/[^\w -]+/g, '').replace(/ /g, '-');
+    return '<h' + level + ' id="' + id + '">' + text + '</h' + level + '>\n';
+}
+
 // Exports
 module.exports = GitBookRenderer;


### PR DESCRIPTION
for example:

Original marked:

``` js
var marked = require('marked');

var input = '### CollectionView\'s `getItemView`';

console.log(marked.parse(input));
//=> <h3 id="collectionview-s-getitemview-">CollectionView&#39;s <code>getItemView</code></h3>
```

the `h3`'s id is `collectionview-s-getitemview-`

but in github, the id is `collectionviews-getitemview`
github just ignore all non word characters 
