### PR TITLE
Convert links with fragments from md to html

### DIFF
--- a/lib/parse/renderer.js
+++ b/lib/parse/renderer.js
@@ -56,7 +56,7 @@ GitBookRenderer.prototype.link = function(href, title, text) {
 
     // Relative link, rewrite it to point to github repo
     if(links.isRelative(_href)) {
-        if (path.extname(_href) == ".md") {
+        if (path.extname(parsed.path) == ".md") {
             _href = links.toAbsolute(_href, o.dir || "./", o.outdir || "./");
 
             if (o.singleFile) {


### PR DESCRIPTION
E.g. `foo.md#fragment` gets converted to `foo.html#fragment`
