### PR TITLE
Highlight active page in summary

### DIFF
--- a/theme/templates/includes/book/summary.html
+++ b/theme/templates/includes/book/summary.html
@@ -1,7 +1,7 @@
 {% macro articles(_articles) %}
     {% for item in _articles %}
         {% set externalLink = item.path|isExternalLink %}
-        <li class="chapter {% if item._path == _input %}active{% endif %}" data-level="{{ item.level }}" {% if item.path && !externalLink %}data-path="{{ item.path|mdLink }}"{% endif %}>
+        <li class="chapter {% if item.path == _input %}active{% endif %}" data-level="{{ item.level }}" {% if item.path && !externalLink %}data-path="{{ item.path|mdLink }}"{% endif %}>
             {% if item.path %}
                 {% if !externalLink %}
                     <a href="{{ basePath }}/{{ item.path|mdLink }}">


### PR DESCRIPTION
Fixes the bug where the `active` class should be applied to the current page, but isn't.
