### PR TITLE
Plugin hooks for summary data

### DIFF
--- a/lib/generate/index.js
+++ b/lib/generate/index.js
@@ -271,13 +271,31 @@ var generateBook = function(options) {
 
         // Get summary
         .then(function() {
-            return fs.readFile(path.join(options.input, "SUMMARY.md"), "utf-8")
-            .then(function(_summary) {
-                options.summary = parse.summary(_summary);
+            var summary = {
+                path: path.join(options.input, "SUMMARY.md")
+            };
 
-                // Parse navigation
-                options.navigation = parse.navigation(options.summary);
-            });
+            var _callHook = function(name) {
+                return generator.callHook(name, summary)
+                .then(function(_summary) {
+                    summary = _summary;
+                    return summary;
+                });
+            };
+
+            return fs.readFile(summary.path, "utf-8")
+                .then(function(_content) {
+                    summary.content = _content;
+                    return _callHook("summary:before");
+                })
+                .then(function() {
+                    summary.content = parse.summary(summary.content);
+                    return _callHook("summary:after");
+                })
+                .then(function() {
+                    options.summary = summary.content;
+                    options.navigation = parse.navigation(options.summary);
+                })
         })
 
         // Skip processing some files


### PR DESCRIPTION
Provide `"summary:before"` and `"summary:after"` hooks for plugins to allow manipulating the summary data in the same way plugins can manipulate page data.

The `"summary:before"` hook is called after reading the `SUMMARY.md` file, but before parsing. It passes in an object with a `content` property that contains the raw content of the `SUMMARY.md` file. A plugin hook can edit or replace this text.

The `"summary:after"` hook is called after parsing the summary text. It receives an object with a `content` property that contains the parsed summary object model - nested arrays of chapters and articles. The plugin can modify or replace this object.

This is useful so a plugin can allow the `SUMMARY.md` file to be in a different format (e.g. multiple lists split by `##` h2 headers - see #306), or it can manipulate the object model to add or remove nodes, perhaps based on the contents of the files being pointed to (e.g. add chapters for sub-headings in a single file - see #331)
