### PR TITLE
Ignore config files by default in fs.list

### DIFF
--- a/lib/generate/fs.js
+++ b/lib/generate/fs.js
@@ -30,6 +30,11 @@ var getFiles = function(path) {
         '*.pdf',
         '*.epub',
         '*.mobi',
+
+        // Skip config files
+        '.ignore',
+        '.bookignore',
+        'book.json',
     ], '__custom_stuff');
 
     // Push each file to our list


### PR DESCRIPTION
As mentioned in #93, .ignore, .bookignore and book.json should not be copied.
