### PR TITLE
add sharing to weibo.com.

### DIFF
--- a/theme/javascript/utils/sharing.js
+++ b/theme/javascript/utils/sharing.js
@@ -13,6 +13,9 @@ define([
         },
         "google-plus": function($el) {
             window.open("https://plus.google.com/share?url="+encodeURIComponent(url))
+        },
+        "weibo": function($el) {
+            window.open("http://service.weibo.com/share/share.php?content=utf-8&url="+encodeURIComponent(url)+"&title="+encodeURIComponent(title))
         }
     };
 

--- a/theme/templates/includes/book/header.html
+++ b/theme/templates/includes/book/header.html
@@ -21,6 +21,9 @@
     {% if options.links.sharing.twitter !== false %}
     <a href="#" target="_blank" class="btn pull-right twitter-sharing-link sharing-link" data-sharing="twitter" aria-label="Share on Twitter"><i class="fa fa-twitter"></i></a>
     {% endif %}
+    {% if options.links.sharing.weibo === true %}
+    <a href="#" target="_blank" class="btn pull-right twitter-sharing-link sharing-link" data-sharing="weibo" aria-label="Share on Weibo"><i class="fa fa-weibo"></i></a>
+    {% endif %}
 
     <!-- Title -->
     <h1>


### PR DESCRIPTION
google、facebook and twitter are block by GFW in China，Chinese can
not visit these websites.
add 'weibo' config in option links.sharing,the share link will not be
used by default,users should set the value of 'weibo' to true to turn
on sharing to weibo.com.
