### PR TITLE
Add code filepath to code blocks

### DIFF
--- a/lib/parse/renderer.js
+++ b/lib/parse/renderer.js
@@ -137,7 +137,16 @@ GitBookRenderer.prototype.listitem = function(text) {
 };
 
 GitBookRenderer.prototype.code = function(code, lang, escaped) {
-    return GitBookRenderer.super_.prototype.code.call(
+    var filepathTest = lang.match(/.*\.([a-zA-Z]+)/);
+    var filenameOutput = '';
+
+    if (filepathTest) {
+        var filename = filepathTest[0];
+        lang = filepathTest[1];
+        filenameOutput = '<div class="code-filename">'+ filename +'</div>\n';
+    }
+
+    return filenameOutput + GitBookRenderer.super_.prototype.code.call(
         this,
         // Import code snippets
         codeInclude(code, this._extra_options.dir),


### PR DESCRIPTION
This is something I've needed forever when writing books and training
material with code samples: the ability to easily list where a file
should go on the reader's machine:

e.g.

input

```
``app/models/person.rb
class Person
end
``
```

output

```
<div class="code-filename">app/models/person.rb</div>
<pre><code>
  ...
</pre></code>
```

Barring putting it into the parser directly, being able to override the
kramed callbacks before render would be nice (probably better).
