### PR TITLE
keep the search result list after user click a link

### DIFF
--- a/theme/javascript/core/navigation.js
+++ b/theme/javascript/core/navigation.js
@@ -6,8 +6,9 @@ define([
     "core/progress",
     "core/exercise",
     "core/quiz",
-    "core/loading"
-], function($, URL, events, state, progress, exercises, quiz, loading) {
+    "core/loading",
+    "core/search"
+], function($, URL, events, state, progress, exercises, quiz, loading, search) {
     var prev, next;
 
     var usePushState = (typeof history.pushState !== "undefined");
@@ -55,6 +56,8 @@ define([
 
             // Update state
             state.update($("html"));
+            // recover search keyword
+            search.recover();
             preparePage();
         })
         .fail(function (e) {
@@ -147,3 +150,4 @@ define([
         goPrev: goPrev
     };
 });
+

--- a/theme/javascript/core/search.js
+++ b/theme/javascript/core/search.js
@@ -81,18 +81,34 @@ define([
             }
             if (q.length == 0) {
                 sidebar.filter(null);
+                storage.remove("keyword");
             } else {
                 var results = search(q);
                 sidebar.filter(
                     _.pluck(results, "path")
                 );
+                storage.set("keyword", q);
             }
         })
+
+    };
+
+    // filter sidebar menu with current search keyword
+    var recoverSearch = function() {
+        var keyword = storage.get("keyword", "");
+        if(keyword.length > 0) {
+            if(!isSearchOpen()){
+                toggleSearch();
+            }
+            sidebar.filter(_.pluck(search(keyword), "path"));
+        }
+        $(".book-search input").val(keyword);
     };
 
     return {
         init: init,
         search: search,
-        toggle: toggleSearch
+        toggle: toggleSearch,
+        recover:recoverSearch
     };
 });


### PR DESCRIPTION
Record search keyword to LocalStorage, when navigate to a new url,fetch
keyword from LocalStorage, init the search input element,then filter the
sidebar menu.
So User can iterator the result list without type the keyword every
time.
