### PR TITLE
Fix path operator in Windows for index.html with multi lang

### DIFF
--- a/lib/generate/template.js
+++ b/lib/generate/template.js
@@ -41,7 +41,7 @@ swig.setFilter('lvl', function(lvl) {
 
 // Join path
 swig.setFilter('pathJoin', function(base, _path) {
-    return path.join(base, _path);
+    return links.join(base, _path);
 });
 
 // Is a link an absolute link


### PR DESCRIPTION
In Windows:

currently `path.join` used in `template.js` results in index.html for multi lang gitbooks generated such as:

```
<li>
    <a href="./en\index.html">English</a>
</li>

<li>
    <a href="./de\index.html">Deutsch</a>
</li>

<li>
    <a href="./fr\index.html">Français</a>
</li>
```

This pull request uses `links.join` instead of `path.join` to resolve this issue.
