### PR TITLE
highlight search keyword in current page

### DIFF
--- a/theme/javascript/core/search.js
+++ b/theme/javascript/core/search.js
@@ -3,9 +3,10 @@ define([
     "lodash",
     "lunr",
     "utils/storage",
+    "utils/highlight",
     "core/state",
     "core/sidebar"
-], function($, _, lunr, storage, state, sidebar) {
+], function($, _, lunr, storage, highlight, state, sidebar) {
     var index = null;
 
     // Use a specific idnex
@@ -50,6 +51,7 @@ define([
             $searchInput.blur();
             $searchInput.val("");
             sidebar.filter(null);
+            highlight.clearHighlight();
         }
     };
 
@@ -88,6 +90,7 @@ define([
                     _.pluck(results, "path")
                 );
                 storage.set("keyword", q);
+                highlight.highlight($('div.book-body')[0], q);
             }
         })
 
@@ -97,12 +100,13 @@ define([
     var recoverSearch = function() {
         var keyword = storage.get("keyword", "");
         if(keyword.length > 0) {
-            if(!isSearchOpen()){
+            if(!isSearchOpen()) {
                 toggleSearch();
             }
             sidebar.filter(_.pluck(search(keyword), "path"));
         }
         $(".book-search input").val(keyword);
+        highlight.highlight($('div.book-body')[0], keyword);
     };
 
     return {

--- a/theme/javascript/utils/highlight.js
+++ b/theme/javascript/utils/highlight.js
@@ -1,0 +1,82 @@
+// based on http://bartaz.github.io/sandbox.js/jquery.highlight.html#how
+// only do little customisation
+define([
+        "jQuery"
+], function($) {
+
+    var defaultWrapNodeName = "span";
+    var defaultHighlightClass = "book-search-highlight";
+
+    var highlight = function(node, keyword, wrapNodeName, className) {
+        var regex = generateRegex(keyword);
+        if (typeof node === 'undefined' || regex === null) {
+            return;
+        }
+        wrapNodeName = wrapNodeName || defaultWrapNodeName;
+        className = className || defaultHighlightClass;
+        highlightText(node, regex);
+
+        function highlightText(node, regex) {
+            if (node.nodeType === 3) {
+                var highlightElement = document.createElement(wrapNodeName);
+                highlightElement.className = className;
+                var match = regex.exec(node.data);
+                if(match) {
+                    // split text nodes
+                    node.splitText(match.index + match[0].length);
+                    var matchedTextNode = node.splitText(match.index);
+                    var cloneMatchedTextNode = matchedTextNode.cloneNode(true);
+                    // wrap matched text node
+                    highlightElement.appendChild(cloneMatchedTextNode);
+                    matchedTextNode.parentNode.replaceChild(highlightElement, matchedTextNode);
+                    return 1;
+                }
+            } else if ((node.nodeType === 1 && node.childNodes) && !/(script|style)/i.test(node.tagName)) {
+                for(var index = 0; index < node.childNodes.length; index++) {
+                    if (!(node.tagName === wrapNodeName.toUpperCase() && node.className === className)) { 
+                        // skip new node created by text nodes splitting 
+                        index += highlightText(node.childNodes[index], regex, wrapNodeName, className);
+                    }
+                }
+            }
+            return 0;
+        }
+
+        function generateRegex(keyword) {
+            var words = [];
+            if (keyword.constructor === String) {
+                words = keyword.split(' ');
+            } else {
+                return null;
+            }
+            // filter empty string
+            words = $.grep(words, function(value, index) {
+                return value !== '';
+            });
+            // escape reserved word
+            words = jQuery.map(words, function(value, index) {
+                return value.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+            });
+            if (words.length === 0) {
+               return null;
+            }
+            var pattern = "(?:" + words.join("|") + ")";
+            return new RegExp(pattern, "i");
+        }
+    };
+
+    var clearHighlight = function(wrapNodeName, className) {
+        wrapNodeName = wrapNodeName || defaultWrapNodeName;
+        className = className || defaultHighlightClass;
+        return $(wrapNodeName + "." + className).each(function () {
+            var parent = this.parentNode;
+            parent.replaceChild(this.firstChild, this);
+            parent.normalize();
+        }).end();
+    };
+
+    return {
+        highlight: highlight,
+        clearHighlight: clearHighlight
+    };
+});

--- a/theme/stylesheets/website.less
+++ b/theme/stylesheets/website.less
@@ -16,6 +16,7 @@
 @import "website/buttons.less";
 @import "website/markdown.less";
 @import "website/navigation.less";
+@import "website/search-highlight.less";
 
 * {
     .box-sizing(border-box);

--- a/theme/stylesheets/website/search-highlight.less
+++ b/theme/stylesheets/website/search-highlight.less
@@ -1,0 +1,15 @@
+.book .book-body {
+    .book-search-highlight {
+        background-color: #FFFF04;
+    }
+}
+.book.color-theme-1 .book-body {
+    .book-search-highlight {
+        background-color: #FFFF04;
+    }
+}
+.book.color-theme-2 .book-body {
+    .book-search-highlight {
+        background-color: #FFFF04;
+    }
+}


### PR DESCRIPTION
highlight.js based on http://bartaz.github.io/sandbox.js/jquery.highlight.html#how.
add search-highlight.less to custom style for different theme,default is
yellow,same as the osx's search result style.
when toggle the search input element to close,current page's highlight
elements will be cleared.
use space to split search keywords,highlight all the results.
use regex to match the content,ignorance case.
havn't add any options to custom the default behaver,see if any issue
announce this.
