### PR TITLE
Add updated instructions for installing ebook-convert.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ A small version of the cover can also be set by creating a file: **/cover_small.
 
 #### Publish your book
 
-The platform [GitBook.io](https://www.gitbook.io/) is like an "Heroku for books": you can create a book on it (public, paid, or private) and update it using **git push**.
+The platform [GitBook.io](https://www.gitbook.io/) is like a "Heroku for books": you can create a book on it (public, paid, or private) and update it using **git push**.
 
 #### Plugins
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,19 @@ You can publish your books to our index by visiting [GitBook.io](http://www.gitb
 GitBook can generate your book in the following formats:
 
 * **Static Website**: This is the default format. It generates a complete interactive static website that can be, for example, hosted on GitHub Pages.
-* **eBook**: A complete eBook with exercise solutions at the end of the book. Generate this format using: ```gitbook ebook ./myrepo```. You need to have [ebook-convert](http://manual.calibre-ebook.com/cli/ebook-convert.html) installed. The output format could be **PDF**, **ePub** or **MOBI**.
+* **eBook**: A complete eBook with exercise solutions at the end of the book. Generate this format using: ```gitbook ebook ./myrepo```. You need to have [ebook-convert](#installing-ebook-convert) installed. The output format could be **PDF**, **ePub** or **MOBI**.
 * **Single Page**: The book will be stored in a single printable HTML page. This format is used for conversion to PDF or eBook. Generate this format using: ```gitbook build ./myrepo -f page```.
 * **JSON**: This format is used for debugging or extracting metadata from a book. Generate this format using: ```gitbook build ./myrepo -f json```.
+
+### Installing ebook-convert
+
+Download the Calibre app [here](http://calibre-ebook.com/download). After moving the `calibre.app` to your Applications folder create a symbolic link to the `ebook-convert` tool:
+
+```
+$ sudo ln -s ~/Applications/calibre.app/Contents/MacOS/ebook-convert /usr/bin
+```
+
+You can replace `/usr/bin` with any directory that is in your `$PATH`.
 
 ## Book Format
 


### PR DESCRIPTION
The calibre app no longer has a menu option for installing the command line tools. Added instructions for doing this manually since a few issues were opened asking how.