### PR TITLE
Adding options to set header and footer in PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ Here are the options that can be stored in this file:
             "left": 62,
             "top": 36,
             "bottom": 36
-        }
+        },
+        
+        //Header HTML template. Available variables: _PAGENUM_, _TITLE_, _AUTHOR_ and _SECTION_.
+        "headerTemplate": null,
+        
+        //Footer HTML template. Available variables: _PAGENUM_, _TITLE_, _AUTHOR_ and _SECTION_.
+        "footerTemplate": null
     }
 }
 ```

--- a/lib/generate/config.js
+++ b/lib/generate/config.js
@@ -83,7 +83,13 @@ var CONFIG = {
             "left": 62,
             "top": 36,
             "bottom": 36
-        }
+        },
+        
+        //Header HTML template. Available variables: _PAGENUM_, _TITLE_, _AUTHOR_ and _SECTION_.
+        "headerTemplate": null,
+        
+        //Footer HTML template. Available variables: _PAGENUM_, _TITLE_, _AUTHOR_ and _SECTION_.
+        "footerTemplate": null
     }
 };
 

--- a/lib/generate/ebook/index.js
+++ b/lib/generate/ebook/index.js
@@ -55,7 +55,9 @@ Generator.prototype.finish = function() {
                 "--pdf-default-font-size": String(pdfOptions.fontSize),
                 "--pdf-mono-font-size": String(pdfOptions.fontSize),
                 "--paper-size": String(pdfOptions.paperSize),
-                "--pdf-page-numbers": Boolean(pdfOptions.pageNumbers)
+                "--pdf-page-numbers": Boolean(pdfOptions.pageNumbers),
+                "--pdf-header-template": pdfOptions.headerTemplate,
+                "--pdf-footer-template": pdfOptions.footerTemplate
             });
         }
 


### PR DESCRIPTION
If the user wants to add a header or footer in each page of a generated PDF, he will be able to configure `book.json` like the following:

```
"pdf": {
    "pageNumbers": true,
    "paperSize": "a5",
    "headerTemplate": "<p><span>My Book</span><span>_SECTION_</span></p>",
    "footerTemplate": "<p>_PAGENUM_</p>"
}
```

The `ebook-convert` call will have the `--pdf-header-template` and `--pdf-footer-template` arguments if needed.

The user will be able to use Calibre's variables: `_PAGENUM_`, `_TITLE_`, `_AUTHOR_` and `_SECTION_`.
