### PR TITLE
New hook to alter ebook generation options

### DIFF
--- a/lib/generate/ebook/index.js
+++ b/lib/generate/ebook/index.js
@@ -56,30 +56,38 @@ Generator.prototype.finish = function() {
                 "--pdf-default-font-size": String(pdfOptions.fontSize),
                 "--pdf-mono-font-size": String(pdfOptions.fontSize),
                 "--paper-size": String(pdfOptions.paperSize),
-                "--pdf-page-numbers": Boolean(pdfOptions.pageNumbers),
+                "--pdf-page-numbers": Boolean(pdfOptions.pageNumbers)
             });
         }
+        
+        return Q()
+            .then(function() {
+                // Send content to plugins
+                return that.callHook("ebook:options", _options);
+            })
+            .then(function(_options) {
 
-        var command = [
-            "ebook-convert",
-            path.join(that.options.output, "index.html"),
-            path.join(that.options.output, "index."+format),
-            stringUtils.optionsToShellArgs(_options)
-        ].join(" ");
+                var command = [
+                    "ebook-convert",
+                    path.join(that.options.output, "index.html"),
+                    path.join(that.options.output, "index."+format),
+                    stringUtils.optionsToShellArgs(_options)
+                ].join(" ");
 
-        exec(command, function (error, stdout, stderr) {
-            if (error) {
-                if (error.code == 127) {
-                    error.message = "Need to install ebook-convert from Calibre";
-                } else {
-                    error.message = error.message + " "+stdout;
-                }
-                return d.reject(error);
-            }
-            d.resolve();
-        });
+                exec(command, function (error, stdout, stderr) {
+                    if (error) {
+                        if (error.code == 127) {
+                            error.message = "Need to install ebook-convert from Calibre";
+                        } else {
+                            error.message = error.message + " "+stdout;
+                        }
+                        return d.reject(error);
+                    }
+                    d.resolve();
+                });
 
-        return d.promise;
+                return d.promise;
+            });
     });
 };
 


### PR DESCRIPTION
Added a hook that allows users to change ebook generations options.

The hook is named `ebook:options` and can be used like the following:

``` js
module.exports = {
    hooks: {
        "ebook:options": function(options) {
            options["--disable-font-rescaling"] = true;
            return options;
        }
    }
};
```
