### PR TITLE
Bug fix for issue#493: 2-level or more deep relative links go wrong when in win32

### DIFF
--- a/lib/generate/site/index.js
+++ b/lib/generate/site/index.js
@@ -154,7 +154,12 @@ Generator.prototype.convertFile = function(content, _input) {
     if (_output == "README.html") _output = "index.html";
     var output = path.join(this.options.output, _output);
     var basePath = path.relative(path.dirname(output), this.options.output) || ".";
-
+	
+	// Bug fix for issue #493 which would occur when relative-links are 2-level or more deep in win32
+	if (process.platform === 'win32') {
+		basePath = basePath.replace(/\\/g, '/');
+	}
+	
     return this.prepareFile(content, _input)
     .then(function(page) {
         // Index page in search


### PR DESCRIPTION
I've checked the HTML source file and found the basePath is wrong in relative link when it is build in Windows.

I checked the gitbook source and modified the basePath if the env equals win32.
