### PR TITLE
add X-UA-Compatible meta tag for IE

### DIFF
--- a/theme/templates/layout.html
+++ b/theme/templates/layout.html
@@ -4,6 +4,7 @@
     <head>
         {{ htmlSnippet("head:start")|default("") }}
         <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=11; IE=10; IE=9; IE=8; IE=7; IE=EDGE" />
         <title>{% block title %}{% endblock %}</title>
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
         <meta name="description" content="{% block description %}{% endblock %}">


### PR DESCRIPTION
This add the "X-UA-Compatible" meta tag for IE 7 to 11 to stop IE from switching to _Compatibility View_. The sidebar is hidden if IE is in _Compatibility View_!
