### PR TITLE
Hooks before and after ebook generation 

### DIFF
--- a/lib/generate/ebook/index.js
+++ b/lib/generate/ebook/index.js
@@ -60,27 +60,37 @@ Generator.prototype.finish = function() {
                 "--pdf-footer-template": String(pdfOptions.footerTemplate)
             });
         }
+        
+        return Q()
+            .then(function() {
+                return that.callHook("ebook:before", _options);
+            })
+            .then(function(_options) {
+                var command = [
+                    "ebook-convert",
+                    path.join(that.options.output, "SUMMARY.html"),
+                    path.join(that.options.output, "index."+format),
+                    stringUtils.optionsToShellArgs(_options)
+                ].join(" ");
 
-        var command = [
-            "ebook-convert",
-            path.join(that.options.output, "SUMMARY.html"),
-            path.join(that.options.output, "index."+format),
-            stringUtils.optionsToShellArgs(_options)
-        ].join(" ");
+                exec(command, function (error, stdout, stderr) {
+                    if (error) {
+                        if (error.code == 127) {
+                            error.message = "Need to install ebook-convert from Calibre";
+                        } else {
+                            error.message = error.message + " "+stdout;
+                        }
+                        return d.reject(error);
+                    }
+                    d.resolve();
+                });
 
-        exec(command, function (error, stdout, stderr) {
-            if (error) {
-                if (error.code == 127) {
-                    error.message = "Need to install ebook-convert from Calibre";
-                } else {
-                    error.message = error.message + " "+stdout;
-                }
-                return d.reject(error);
-            }
-            d.resolve();
-        });
+                return d.promise;
 
-        return d.promise;
+            }).then(function(_promise) {
+                that.callHook("ebook:after");
+                return _promise;
+            });
     });
 };
 


### PR DESCRIPTION
Solves issue #474.

Hooks `ebook:before` and `ebook:after` are called, respectively, before and after the call to Calibre's `ebook-convert`. The object with `ebook-convert`  options is passed to `ebook:before`.  

Than, an user can create a plugin to change `ebook-convert` default options, among other things.

Example of use:
```
module.exports = {
	hooks: {
		"ebook:before": function(options) {
			options["--disable-font-rescaling"] = true;
			options["--chapter-mark"] = "none";
			options["--level2-toc"] = "//h:h2",
			options["--level3-toc"] = "";
			options["-d debug"] = true;

			console.log("ebook:before");

			return options;
		},
		"ebook:after": function() {
			console.log("ebook:after");
		}
	}
};
```