### PR TITLE
Fixes #524: gitbook serve exit immediately

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -52,10 +52,13 @@ var makeBuildFunc = function(converter) {
             // Exit process with failure code
             process.exit(-1);
         })
-        .then(function() {
+        .then(function(output) {
             // Prevent badly behaving plugins
             // from making the process hang
-            process.exit(0);
+            if(!options.keepRunning){
+                process.exit(0);
+            }
+            return output;
         });
     };
 };

--- a/bin/gitbook.js
+++ b/bin/gitbook.js
@@ -46,7 +46,8 @@ build.command(prog.command('serve [source_dir]'))
         server.stop()
         .then(function() {
             return build.folder(dir, _.extend(options || {}, {
-                defaultsPlugins: ["livereload"]
+                defaultsPlugins: ["livereload"],
+                keepRunning: true
             }));
         })
         .then(function(_options) {


### PR DESCRIPTION
Added a `keepRunning` option to prevent exit when running `gitbook serve`.
