### PR TITLE
Add Dockerfile for gitbook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:14.10
+MAINTAINER tobe tobeg3oogle@gmail.com
+
+RUN apt-get -y update
+
+RUN apt-get install -y curl && \
+    curl -sL https://deb.nodesource.com/setup | bash - && \
+    apt-get install -y nodejs && \
+    npm install gitbook -g
+
+RUN mkdir /gitbook
+WORKDIR /gitbook
+
+CMD ["gitbook", "serve", "/gitbook"]


### PR DESCRIPTION
Refer to https://github.com/GitbookIO/gitbook/issues/527, we can run gitbook commands without installing anything.

Usage: `docker run -d -p 4000:4000 gitbook/gitbook $gitbook_command`