### PR TITLE
Use container-based Travis CI stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.11"


### PR DESCRIPTION
The build can run on the new [container based infrastructure](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) of Travis CI. This should speed up things. At least that is what they say.