### PR TITLE
Version 2.0.0

### DIFF
--- a/lib/book.js
+++ b/lib/book.js
@@ -507,13 +507,20 @@ Book.prototype.parsePage = function(filename, options) {
         return interpolate(options.interpolateTemplate);
     })
 
+    // Prepare page markup
+    .then(function() {
+        return filetype.page.prepare(page.content)
+        .then(function(content) {
+            page.content = content;
+        });
+    })
+
     // Generate template
     .then(function() {
         return that.template.renderPage(page);
     })
 
     // Prepare and Parse markup
-    .then(filetype.page.prepare)
     .then(function(content) {
         page.content = content;
 

--- a/lib/generators/ebook.js
+++ b/lib/generators/ebook.js
@@ -64,6 +64,8 @@ Generator.prototype.finish = function() {
             "--comments": that.options.description,
             "--isbn": that.options.isbn,
             "--authors": that.options.author,
+            "--language": that.options.language,
+            "--book-producer": "GitBook",
             "--publisher": "GitBook",
             "--chapter": "descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter ')]",
             "--chapter-mark": "pagebreak",
@@ -90,6 +92,10 @@ Generator.prototype.finish = function() {
                 "--pdf-page-numbers": Boolean(pdfOptions.pageNumbers),
                 "--pdf-header-template": String(pdfOptions.headerTemplate) || "<p class='header'><span>"+that.options.title+"</span></p>",
                 "--pdf-footer-template": String(pdfOptions.footerTemplate) || "<p class='footer'><span>_SECTION_</span> <span style='float:right;'>_PAGENUM_</span></p>"
+            });
+        } else if (that.ebookFormat == "epub") {
+            _.extend(_options, {
+                "--dont-split-on-page-breaks": true
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "resolve": "0.6.3",
         "fs-extra": "0.16.3",
         "fstream-ignore": "1.0.2",
-        "gitbook-parsers": "0.5.0",
+        "gitbook-parsers": "0.5.1",
         "nunjucks": "git+https://github.com/mozilla/nunjucks.git#42d2b9f5c0ad5db8ca3a1fdbba5bde9fc4cc2c45",
         "nunjucks-autoescape": "0.1.1",
         "nunjucks-filter": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "resolve": "0.6.3",
         "fs-extra": "0.16.3",
         "fstream-ignore": "1.0.2",
-        "gitbook-parsers": "0.5.1",
+        "gitbook-parsers": "0.5.2",
         "nunjucks": "git+https://github.com/mozilla/nunjucks.git#42d2b9f5c0ad5db8ca3a1fdbba5bde9fc4cc2c45",
         "nunjucks-autoescape": "0.1.1",
         "nunjucks-filter": "0.1.0",


### PR DESCRIPTION
# Version 2.0.0

### How to test it?

Uninstall GitBook 1.x.x:

```
$ npm uninstall gitbook -g
```

Install **GitBook CLI**:

```
$ npm install gitbook-cli -g
```

You can now build a book using the version 2.0.0 (this will download the latest alpha version of GitBook):

```
$ gitbook build ./mybook
```

### Changes:

- [x] Externalize the CLI into another [module](https://github.com/GitbookIO/gitbook-cli) (#554)
	- [x] Build command
	- [x] Serve command
        - [x] eBook commands
        - [x] init command
- [x] Use `gitbook` from book.json to define the version of gitbook to use
- [x] Glossary terms are handled correctly in ebook
- [x] Custom styles to style ebook and website (#543, #523)
- [x] Content templating using nunjucks
- [x] Content reference
	- [x] Internal content reference using `{% include "./test.md" %}` (#226)
	- [x] External content reference using `{% include "git+https://github.com/GitBookIO/markdown.git/test.md#sha" %}` or using variables `{% include book.markdownBook+"/test.md#sha" %}`
- [x] i18n support (#556,  #64 and #504)
	- [x] i18n in website and ebook
	- [x] Use `language` parameter or detect for multilingual books
- [x] Other input markup than Markdown
	- [x] AsciiDoc (#239)
	- [x] Support other markdown extensions (`.md`, `.mdown`, `.markdown`) (#307 and #436)
	- [x] ReStructuredText (#515)
        - [x] Maybe LaTex (#151)
- [x] Nice URLs: `README.html` => `/` (really `/index.html`)
- [x] Allow structure to be configured, to change the readme, summary ans glossary files used (#392, #476 and #416)
- [x] Better tests
- [x] Add back `page:before` hook
- [x] Fix `segmentation fault: 11`, maybe due to asciidoc
- [x] Complete README documentation
- [x] Translate it (https://github.com/GitbookIO/gitbook/tree/version/2.0/theme/i18n)
- [x] Don't remove `.git` and `.svn` when cleaning output folder (#273)
- [x] Transform svg as png before converting to ebook (#190)
- [x] Download remote images in ebook format (#570)
- [x] Fail hard if book.json is invalid or plugins is loaded with error (#567)
- [x] Rewrite filename in ebook format (#585)

### Plugins Compatibility

- [x] MathJax
- [x] KaTeX
- [x] [Richquotes](https://github.com/erixtekila/gitbook-plugin-richquotes)

### Related:

- [gitbook-parsers](https://github.com/GitbookIO/gitbook-parsers)
- [gitbook-markdown](https://github.com/GitbookIO/gitbook-markdown)
- [gitbook-asciidoc](https://github.com/GitbookIO/gitbook-asciidoc)
- [gitbook-cli](https://github.com/GitbookIO/gitbook-cli)
