### PR TITLE
Use tiny-lr instead of old unmaintained fork.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var Q = require("q");
 var _ = require("lodash");
 var path = require("path");
-var tinylr = require('tiny-lr-fork');
+var tinylr = require('tiny-lr');
 var color = require('bash-color');
 
 var Book = require("./book");

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "gitbook-plugin-livereload": "0.0.1",
         "gaze": "~0.5.1",
         "send": "0.2.0",
-        "tiny-lr-fork": "0.0.5",
+        "tiny-lr": "0.1.5",
         "tmp": "0.0.24",
         "crc": "3.2.1",
         "bash-color": "0.0.3",


### PR DESCRIPTION
tiny-lr-fork has been dead for almost two years. Development is back on the main project. The API is unchanged, they’ve been doing mostly bug fixes.