### PR TITLE
Switch from gaze to chokidar.

### DIFF
--- a/lib/utils/watch.js
+++ b/lib/utils/watch.js
@@ -1,7 +1,7 @@
 var Q = require('q');
 var _ = require('lodash');
 var path = require('path');
-var Gaze = require('gaze').Gaze;
+var chokidar = require('chokidar');
 
 var parsers = require('gitbook-parsers')
 
@@ -17,17 +17,18 @@ function watch(dir) {
         toWatch.push("**/*"+ext);
     });
 
-    var gaze = new Gaze(toWatch, {
-        cwd: dir
+    var watcher = chokidar.watch(toWatch, {
+        cwd: dir,
+        ignoreInitial: true
     });
 
-    gaze.once("all", function(e, filepath) {
-        gaze.close();
+    watcher.once("all", function(e, filepath) {
+        watcher.close();
 
         d.resolve(filepath);
     });
-    gaze.once("error", function(err) {
-        gaze.close();
+    watcher.once("error", function(err) {
+        watcher.close();
 
         d.reject(err);
     });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "npmi": "0.1.1",
         "cheerio": "0.19.0",
         "gitbook-plugin-livereload": "0.0.1",
-        "gaze": "~0.5.1",
+        "chokidar": "~1.0.1",
         "send": "0.2.0",
         "tiny-lr": "0.1.5",
         "tmp": "0.0.24",


### PR DESCRIPTION
Hey there.

This commits switches `gaze` to a better file watcher, chokidar.

To summarize: chokidar is *very* stable, and is much faster on OSX, with less CPU usage because of `fsevents`.

Chokidar has been downloaded over 1.2M times last month and is used by very popular projects.