### PR TITLE
Add title for language overview

### DIFF
--- a/lib/book.js
+++ b/lib/book.js
@@ -416,6 +416,12 @@ Book.prototype.parseLangs = function() {
                     name: err.name || "Langs Parse Error",
                     fileName: that.langsFile
                 });
+            }).then(function(langlist) {
+                return langs.parser.readme(content)
+                .then(function(readme) {
+                    that.options.langTitle = that.options.langTitle || that.options.title || readme.title;
+                    return langlist;
+                });
             });
         });
     })

--- a/lib/generators/website.js
+++ b/lib/generators/website.js
@@ -156,7 +156,8 @@ Generator.prototype.writeLangsIndex = function() {
     var that = this;
     if (!this.book.langs.length) return Q();
     return this._writeTemplate(this.templates["langs"], {
-        langs: this.book.langs
+        langs: this.book.langs,
+        title: this.options.langTitle
     }, path.join(this.options.output, "index.html"));
 };
 


### PR DESCRIPTION
When having multilingual books, there's a problem with the book title:
- If you do not specify a `title` in your `book.json`, the language overview page will have an empty `<title>` attribute.
- If you do specify a title, it will be applied to all languages (=> untranslatable).

This PR attempts to solve this by
 1. Add a new option `langTitle` to `book.json`. If set, it will be used for the language overview `<title>` instead of the `title` option.
 2. Parse the `LANGS.md` and find the first headline as a title, same as done for the book content.

If neither `langTitle` nor `title` option is set and the `LANGS.md` does not have a headline, the behavior is not changed (=> empty `<title>` in language overview).