### PR TITLE
Allowing for custom chapter-mark and page-break in PDF.

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -246,6 +246,14 @@ Configuration.DEFAULT = {
         // Choices are [u’a0’, u’a1’, u’a2’, u’a3’, u’a4’, u’a5’, u’a6’, u’b0’, u’b1’, u’b2’, u’b3’, u’b4’, u’b5’, u’b6’, u’legal’, u’letter’]
         "paperSize": "a4",
 
+        // How to mark detected chapters.
+        // Choices are “pagebreak”, “rule”, "both" or “none”.
+        "chapterMark" : "pagebreak",
+
+        // An XPath expression. Page breaks are inserted before the specified elements.
+        // To disable use the expression: "/"
+        "pageBreaksBefore": "/",
+
         // Margin (in pts)
         // Note: 72 pts equals 1 inch
         "margin": {

--- a/lib/generators/ebook.js
+++ b/lib/generators/ebook.js
@@ -68,8 +68,6 @@ Generator.prototype.finish = function() {
             "--book-producer": "GitBook",
             "--publisher": "GitBook",
             "--chapter": "descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter ')]",
-            "--chapter-mark": "pagebreak",
-            "--page-breaks-before": "/",
             "--level1-toc": "descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-1 ')]",
             "--level2-toc": "descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-2 ')]",
             "--level3-toc": "descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' book-chapter-3 ')]",
@@ -82,6 +80,8 @@ Generator.prototype.finish = function() {
             var pdfOptions = that.options.pdf;
 
             _.extend(_options, {
+                "--chapter-mark": String(pdfOptions.chapterMark),
+                "--page-breaks-before": String(pdfOptions.pageBreaksBefore),
                 "--margin-left": String(pdfOptions.margin.left),
                 "--margin-right": String(pdfOptions.margin.right),
                 "--margin-top": String(pdfOptions.margin.top),


### PR DESCRIPTION
I'm building a gitbook that needs to compile pretty cleanly to PDF, and the trouble I've been having is with line breaks, and chapter marks.  

I would love to be able able to specify these options in book.json, but because they're hard coded in the generator, I am unable to.  

So I thought I'd make this PR to get the convo started.  The natural progression of this though is be able to take a lot of the ebook-convert PDF options and be able to specify them in book.json.  But I didn't want to go down that route yet before discussing it with the project leads.