### PR TITLE
Add `npmConfig` field for configuration

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -268,6 +268,11 @@ Configuration.DEFAULT = {
 
         //Footer HTML template. Available variables: _PAGENUM_, _TITLE_, _AUTHOR_ and _SECTION_.
         "footerTemplate": ""
+    },
+
+    // Options passed through to npm
+    "npmConfig": {
+        "registry": "https://registry.npmjs.org"
     }
 };
 

--- a/lib/pluginslist.js
+++ b/lib/pluginslist.js
@@ -206,11 +206,11 @@ PluginsList.prototype.install = function() {
                     'name': fullname,
                     'version': version,
                     'path': that.book.root,
-                    'npmLoad': {
+                    'npmLoad': _.merge({
                         'loglevel': 'silent',
                         'loaded': true,
                         'prefix': that.book.root
-                    }
+                    }, that.book.options.npmConfig || {})
                 });
             })
             .then(function() {


### PR DESCRIPTION
**Background**

Somewhere in this world there is a country which is not in favour of freely access of internet, many oversea websites have been blocked for no reason, and unfortunately npm is one of them.

So in this country when developer run `npm install`, they got stuck forever. Some warm hearted companies build mirrors of npm to make developers use npm without pain.

Since gitbook has encapsulated npm internally, the usage of `npm install --registry=http://kind-npm-mirror-url` will be unavailable. 

**What's been changed**

In `book.json`, added a new field call `npmConfig`, which will be passed to `npmi` directly as its `npmLoad` parameter.