### PR TITLE
Change nunjucks dependency to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "fstream-ignore": "1.0.2",
         "gitbook-parsers": "0.8.3",
         "gitbook-plugin-highlight": "1.0.3",
-        "nunjucks": "mozilla/nunjucks#dc89bf91611a2101731c2c06afcf5c32160b4dc9",
+        "nunjucks": "2.1.0",
         "nunjucks-autoescape": "1.0.0",
         "nunjucks-filter": "1.0.0",
         "i18n": "0.5.0",


### PR DESCRIPTION
Looks like mozilla/nunjucks#504 was merged and released in v2.1.0, so this changes `package.json` to no longer depend on a specific commit. Incidentally, this also solves a problem where corporate firewalls blocks npm from pulling in straight from github repos.