### PR TITLE
Fix small font rendering issue on Macs

### DIFF
--- a/theme/stylesheets/website.less
+++ b/theme/stylesheets/website.less
@@ -22,7 +22,6 @@
     -webkit-tap-highlight-color: transparent;
     -webkit-text-size-adjust: none;
     -webkit-touch-callout: none;
-    -webkit-font-smoothing: antialiased;
 }
 
 a {
@@ -39,7 +38,6 @@ html {
 
 body {
     text-rendering: optimizeLegibility;
-    font-smoothing: antialiased;
     font-family: @font-family-base;
     font-size: @font-size-base;
     letter-spacing: .2px;


### PR DESCRIPTION
Removed the `antialias` setting which tells Chrome to not use native font rendering and instead use something from the late 2010's that isn't subpixel-friendly and looks very blocky. This used to be required when OS X browsers didn't antialias by default because it made fonts look bolder than on Windows. This has since been fixed and we are advised to not use `-webkit-font-smooth`. 

https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth

## Before
![screen shot 2015-11-17 at 4 14 36 pm](https://cloud.githubusercontent.com/assets/51505/11225133/81ba5572-8d46-11e5-98d4-f45ede9fd2a8.png)

## After
![screen shot 2015-11-17 at 4 14 44 pm](https://cloud.githubusercontent.com/assets/51505/11225141/8da0b110-8d46-11e5-9410-51e2f3a3c9e0.png)

As you can see this is very apparent with small fonts. The above is rendered with gitbook-plugin-mermaid, which has the same issue, and I've provided a PR that for that repo as well: https://github.com/JozoVilcek/gitbook-plugin-mermaid/pull/14

*Note: The above example will only be fixed when both repos has removed `-webkit-font-smothing: antialias` from their CSS.*

Thanks! 