### PR TITLE
align lrport on backend & front-end

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -130,7 +130,12 @@ module.exports = {
                     .then(function() {
                         var book = new Book(input, _.extend({}, {
                             'config': {
-                                'defaultsPlugins': ['livereload']
+                                'defaultsPlugins': ['livereload'],
+                                'pluginsConfig': {
+                                    'livereload': {
+                                        'port': kwargs.lrport
+                                    }
+                                }
                             },
                             'logLevel': kwargs.log
                         }));

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "semver": "5.0.1",
         "npmi": "0.1.1",
         "cheerio": "0.19.0",
-        "gitbook-plugin-livereload": "0.0.1",
+        "gitbook-plugin-livereload": "0.1.0",
         "chokidar": "~1.0.5",
         "send": "0.2.0",
         "tiny-lr": "0.2.1",


### PR DESCRIPTION
this commit contains 2 changes:

- upgrade plugin-livereload to 0.1.0, which supports custom port.
- add config for plugin-livereload, set port to kwargs.lrport

therefore lrport of both backend & front-end are aligned.