### PR TITLE
add ebook-convert pdf options 'custom-size' and 'unit'

### DIFF
--- a/lib/generators/ebook.js
+++ b/lib/generators/ebook.js
@@ -121,6 +121,8 @@ Generator.prototype.finish = function() {
                 '--pdf-default-font-size': String(pdfOptions.fontSize),
                 '--pdf-mono-font-size': String(pdfOptions.fontSize),
                 '--paper-size': String(pdfOptions.paperSize),
+                '--custom-size': String(pdfOptions.customSize),
+                '--unit': String(pdfOptions.unit),
                 '--pdf-page-numbers': Boolean(pdfOptions.pageNumbers),
                 '--pdf-header-template': that.getPDFTemplate('header'),
                 '--pdf-footer-template': that.getPDFTemplate('footer'),


### PR DESCRIPTION
description from http://manual.calibre-ebook.com/cli/ebook-convert.html#pdf-output-options

--custom-size
Custom size of the document. Use the form widthxheight EG. 123x321 to specify the width and height. This overrides any specified paper-size.

--unit, -u
The unit of measure for page sizes. Default is inch. Choices are [‘millimeter’, ‘centimeter’, ‘point’, ‘inch’, ‘pica’, ‘didot’, ‘cicero’, ‘devicepixel’] Note: This does not override the unit for margins!