### PR TITLE
Latest Chrome Bug

### DIFF
--- a/theme/stylesheets/website.less
+++ b/theme/stylesheets/website.less
@@ -38,7 +38,6 @@ html {
 }
 
 body {
-    text-rendering: optimizeLegibility;
     font-smoothing: antialiased;
     font-family: @font-family-base;
     font-size: @font-size-base;


### PR DESCRIPTION
In latest version of chrome (48.0.2564.82 (64-bit)) , all gitbook pages with chinese characters will blocked while switching chapters,such as [this one](https://yeasy.gitbooks.io/docker_practice/content/install/ubuntu.html), or [this one](https://zonble.gitbooks.io/kkbox-ios-dev/content/design_patterns/index.html), just clicked the side navigator,the page looks frozen.
But,remove this style will fix this: `body{text-rendering: optimizeLegibility;}`
This only happens in the latest chrome (48.0.2564.82 (64-bit)) , for now we can just remove this style to fix this problem.