### PR TITLE
Fix isMobile(): Use .width() instead of obsolete document.width

### DIFF
--- a/theme/javascript/platform.js
+++ b/theme/javascript/platform.js
@@ -1,5 +1,5 @@
 module.exports = {
     isMobile: function() {
-        return (document.width <= 600);
+        return ($(document).width() <= 600);
     }
 };


### PR DESCRIPTION
The ``isMobile()`` function for detecting small-width window size was not working on modern browsers, because of obsolete ``document.width``: https://developer.mozilla.org/en-US/docs/Web/API/Document/width

I think that using jQuery is the safest option.