### PR TITLE
Created a glossaryExclusions config item

### DIFF
--- a/lib/config_default.js
+++ b/lib/config_default.js
@@ -105,5 +105,8 @@ module.exports = {
 
         // Footer HTML template. Available variables: _PAGENUM_, _TITLE_, _AUTHOR_ and _SECTION_.
         'footerTemplate': null
-    }
+    },
+    // used by page.js to determine which elements will not have their glossary matches
+    // marked (useful for excluding headings 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' for instance)
+    'glossaryExclusions': ['code', 'pre', 'a', 'script']
 };

--- a/lib/utils/page.js
+++ b/lib/utils/page.js
@@ -277,7 +277,7 @@ function normalizeHtml(src, options) {
 
         $('*').each(function() {
             // Ignore codeblocks
-            if (_.contains(['code', 'pre', 'a', 'script'], this.name.toLowerCase())) return;
+            if (_.contains(options.book.config.options.glossaryExclusions, this.name.toLowerCase())) return;
 
             replaceText($, this, r, function(match) {
                 // Add to files index in glossary


### PR DESCRIPTION
modified page.js to use this instead of hardcoding the elements that will match the exclusions

used by page.js to determine which elements will not have their glossary matches
marked (useful for excluding headings 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' for instance)