### PR TITLE
Transfer files one by one insted of all at the same time

### DIFF
--- a/lib/book.js
+++ b/lib/book.js
@@ -217,10 +217,10 @@ Book.prototype.generate = function(generator) {
 
             // Then, let's copy other files
             .then(function() {
-                return Q.all(_.map(ops.files || [], function(file) {
+                return _.reduce(ops.files || [] , function(prev, file) {
                     that.log.debug.ln('transferring file', file);
-                    return Q(generator.transferFile(file));
-                }));
+                    return prev.then(generator.transferFile(file))
+                }, Q());
             })
 
             // Finally let's generate content


### PR DESCRIPTION
When the amount of pending transfer files is large, copying them
all at the same time cause Node to quit on error
	ENFILE: File table overflow.
Do it slowly, we are not in a hurry, are we?