### PR TITLE
Limit splitting plugin name for git with authentication

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -20,7 +20,7 @@ function normalizePluginsList(plugins) {
     plugins = _.map(plugins, function(plugin) {
         if (plugin.name) return plugin;
 
-        var parts = plugin.split('@');
+        var parts = plugin.split('@', 1);
         var name = parts[0];
         var version = parts[1];
         return {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -81,6 +81,21 @@ describe('Plugins', function() {
             })
             .should.be.fulfilledWith(1);
         });
+        it('should correctly install dependencies from GitHub via ssh', function() {
+            return mock.setupBook({
+                'book.json': {
+                    plugins: ['ga@git@github.com:GitbookIO/plugin-ga.git#master']
+                }
+            })
+            .then(function(book) {
+                return book.prepareConfig()
+                .then(function() {
+                    var plugins = new PluginsManager(book);
+                    return plugins.install();
+                });
+            })
+            .should.be.fulfilledWith(1);
+        });
     });
 
     describe('Loading', function() {


### PR DESCRIPTION
URLs of plugins from a git repo that are fetched via ssh contain an `@` Example plugin config: `ga@git@github.com:GitbookIO/plugin-ga.git#master`. 

This fails to load because the plugin name is split from the "version" on `@` without a delimiter. 