### PR TITLE
Fix for incorrect splitting the plugin name/version

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -20,9 +20,9 @@ function normalizePluginsList(plugins) {
     plugins = _.map(plugins, function(plugin) {
         if (plugin.name) return plugin;
 
-        var parts = plugin.split('@', 1);
+        var parts = plugin.split('@');
         var name = parts[0];
-        var version = parts[1];
+        var version = parts.slice(1).join('@');
         return {
             'name': name,
             'version': version // optional


### PR DESCRIPTION
In the previous pull request I had misinterpreted the second argument of String.prototype.split. The remainder of the splitted string must be joined instead of delimiting the number of splits.
The tests were all passing because the plugin in the test is also available in npmjs. 
My apologies for the extra work.