### PR TITLE
bump bash-color to version that has a license

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "browser": "./lib/browser.js",
   "dependencies": {
-    "bash-color": "0.0.3",
+    "bash-color": "0.0.4",
     "cheerio": "0.20.0",
     "chokidar": "1.4.3",
     "cp": "0.2.0",


### PR DESCRIPTION
Version currently being used does not have a license making it difficult for companies to use.