### PR TITLE
Fixed two issues for handling git URLs for plugins

### DIFF
--- a/lib/models/__tests__/pluginDependency.js
+++ b/lib/models/__tests__/pluginDependency.js
@@ -42,21 +42,39 @@ describe('PluginDependency', function() {
                 expect(plugin.getVersion()).toBe('git+ssh://samy@github.com/GitbookIO/plugin-ga.git');
             });
         });
-    });
 
-    describe('listToArray', function() {
-        var list = PluginDependency.listToArray(Immutable.List([
-            PluginDependency.createFromString('hello@1.0.0'),
-            PluginDependency.createFromString('noversion'),
-            PluginDependency.createFromString('-disabled')
-        ]));
+        describe('listToArray', function() {
+            it('must create an array from a list of plugin dependencies', function() {
+                var list = PluginDependency.listToArray(Immutable.List([
+                    PluginDependency.createFromString('hello@1.0.0'),
+                    PluginDependency.createFromString('noversion'),
+                    PluginDependency.createFromString('-disabled')
+                ]));
 
-        expect(list).toEqual([
-            'hello@1.0.0',
-            'noversion',
-            '-disabled'
-        ]);
+                expect(list).toEqual([
+                    'hello@1.0.0',
+                    'noversion',
+                    '-disabled'
+                ]);
+            });
+        });
+
+        describe('listFromArray', function() {
+            it('must create an array from a list of plugin dependencies', function() {
+                var arr = Immutable.fromJS([
+                    'hello@1.0.0',
+                    {
+                        'name': 'plugin-ga',
+                        'version': 'git+ssh://samy@github.com/GitbookIO/plugin-ga.git'
+                    }
+                ]);
+                var list = PluginDependency.listFromArray(arr);
+
+                expect(list.first().getName()).toBe('hello');
+                expect(list.first().getVersion()).toBe('1.0.0');
+                expect(list.last().getName()).toBe('plugin-ga');
+                expect(list.last().getVersion()).toBe('git+ssh://samy@github.com/GitbookIO/plugin-ga.git');
+            });
+        });
     });
 });
-
-

--- a/lib/models/pluginDependency.js
+++ b/lib/models/pluginDependency.js
@@ -95,8 +95,8 @@ PluginDependency.listFromArray = function(arr) {
                 return PluginDependency.createFromString(entry);
             } else {
                 return PluginDependency({
-                    name: entry.name,
-                    version: entry.version
+                    name: entry.get('name'),
+                    version: entry.get('version')
                 });
             }
         })

--- a/lib/plugins/__tests__/resolveVersion.js
+++ b/lib/plugins/__tests__/resolveVersion.js
@@ -1,0 +1,14 @@
+var PluginDependency = require('../../models/pluginDependency');
+var resolveVersion = require('../resolveVersion');
+
+describe('resolveVersion', function() {
+    it('must skip resolving and return non-semver versions', function(done) {
+        var plugin = PluginDependency.createFromString('plugin-ga@git+ssh://samy@github.com/GitbookIO/plugin-ga.git');
+
+        resolveVersion(plugin)
+        .then(function(version) {
+            expect(version).toBe('git+ssh://samy@github.com/GitbookIO/plugin-ga.git');
+            done();
+        });
+    });
+});

--- a/lib/plugins/installPlugins.js
+++ b/lib/plugins/installPlugins.js
@@ -1,75 +1,10 @@
-var npm = require('npm');
 var npmi = require('npmi');
-var semver = require('semver');
-var Immutable = require('immutable');
 
 var pkg = require('../../package.json');
 var DEFAULT_PLUGINS = require('../constants/defaultPlugins');
 var Promise = require('../utils/promise');
-var Plugin = require('../models/plugin');
-var gitbook = require('../gitbook');
 var listForBook = require('./listForBook');
-
-var npmIsReady;
-
-/**
-    Initialize and prepare NPM
-
-    @return {Promise}
-*/
-function initNPM() {
-    if (npmIsReady) return npmIsReady;
-
-    npmIsReady = Promise.nfcall(npm.load, {
-        silent: true,
-        loglevel: 'silent'
-    });
-
-    return npmIsReady;
-}
-
-
-
-/**
-    Resolve a plugin to a version
-
-    @param {Plugin}
-    @return {Promise<String>}
-*/
-function resolveVersion(plugin) {
-    var npmId = Plugin.nameToNpmID(plugin.getName());
-    var requiredVersion = plugin.getVersion();
-
-    return initNPM()
-    .then(function() {
-        return Promise.nfcall(npm.commands.view, [npmId + '@' + requiredVersion, 'engines'], true);
-    })
-    .then(function(versions) {
-        versions = Immutable.Map(versions).entrySeq();
-
-        var result = versions
-            .map(function(entry) {
-                return {
-                    version: entry[0],
-                    gitbook: (entry[1].engines || {}).gitbook
-                };
-            })
-            .filter(function(v) {
-                return v.gitbook && gitbook.satisfies(v.gitbook);
-            })
-            .sort(function(v1, v2) {
-                return semver.lt(v1.version, v2.version)? 1 : -1;
-            })
-            .get(0);
-
-        if (!result) {
-            return undefined;
-        } else {
-            return result.version;
-        }
-    });
-}
-
+var resolveVersion = require('./resolveVersion');
 
 /**
     Install a plugin for a book

--- a/lib/plugins/resolveVersion.js
+++ b/lib/plugins/resolveVersion.js
@@ -1,0 +1,71 @@
+var npm = require('npm');
+var semver = require('semver');
+var Immutable = require('immutable');
+
+var Promise = require('../utils/promise');
+var Plugin = require('../models/plugin');
+var gitbook = require('../gitbook');
+
+var npmIsReady;
+
+/**
+    Initialize and prepare NPM
+
+    @return {Promise}
+*/
+function initNPM() {
+    if (npmIsReady) return npmIsReady;
+
+    npmIsReady = Promise.nfcall(npm.load, {
+        silent: true,
+        loglevel: 'silent'
+    });
+
+    return npmIsReady;
+}
+
+/**
+    Resolve a plugin to a version
+
+    @param {Plugin}
+    @return {Promise<String>}
+*/
+function resolveVersion(plugin) {
+    var npmId = Plugin.nameToNpmID(plugin.getName());
+    var requiredVersion = plugin.getVersion();
+
+    if (!semver.validRange(requiredVersion)) {
+        return Promise.resolve(requiredVersion);
+    }
+
+    return initNPM()
+    .then(function() {
+        return Promise.nfcall(npm.commands.view, [npmId + '@' + requiredVersion, 'engines'], true);
+    })
+    .then(function(versions) {
+        versions = Immutable.Map(versions).entrySeq();
+
+        var result = versions
+            .map(function(entry) {
+                return {
+                    version: entry[0],
+                    gitbook: (entry[1].engines || {}).gitbook
+                };
+            })
+            .filter(function(v) {
+                return v.gitbook && gitbook.satisfies(v.gitbook);
+            })
+            .sort(function(v1, v2) {
+                return semver.lt(v1.version, v2.version)? 1 : -1;
+            })
+            .get(0);
+
+        if (!result) {
+            return undefined;
+        } else {
+            return result.version;
+        }
+    });
+}
+
+module.exports = resolveVersion;


### PR DESCRIPTION
Fixed two issues for handling git URLs for plugins that are published to git repositories rather than on npmjs.org.

Fixed issue in pluginDependency to dereference 'name' and 'version' using Immutable Map.get(...) accessors since config values are now wrapped by Immutable.fromJS(...) in config.js > setValue(...).  Added associated unit test.

Fixed issue in resolveVersion where a plugin may be using a git URL rather than a semver for the version portion of the plugin config definition.  In addition, refactored the resolveVersion function into a new module to allow for unit testing.  Added associated unit test.