### PR TITLE
Fixed target attribute for external links

### DIFF
--- a/lib/output/modifiers/__tests__/resolveLinks.js
+++ b/lib/output/modifiers/__tests__/resolveLinks.js
@@ -87,6 +87,18 @@ describe('resolveLinks', function() {
         });
     });
 
+    describe('External link', function() {
+        var TEST = '<p>This is a <a href="http://www.github.com">external link</a></p>';
+
+        it('should have target="_blank" attribute', function() {
+            var $ = cheerio.load(TEST);
+
+            return resolveLinks('hello.md', resolveFileBasic, $)
+            .then(function() {
+                var link = $('a');
+                expect(link.attr('target')).toBe('_blank');
+            });
+        });
+    });
+
 });
-
-

--- a/lib/output/modifiers/resolveLinks.js
+++ b/lib/output/modifiers/resolveLinks.js
@@ -24,7 +24,7 @@ function resolveLinks(currentFile, resolveFile, $) {
         }
 
         if (LocationUtils.isExternal(href)) {
-            $a.attr('_target', 'blank');
+            $a.attr('target', '_blank');
             return;
         }
 


### PR DESCRIPTION
The attribute key/value for links that should be opened into a new window is ```target="_blank"``` but Gitbook generated ```_target="blank"``` (the underscore should be before attribute value, not name)

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target