### PR TITLE
fix path to Calibre in ebook instructions

### DIFF
--- a/docs/ebook.md
+++ b/docs/ebook.md
@@ -22,7 +22,7 @@ $ gitbook mobi ./ ./mybook.mobi
 Download the [Calibre application](https://calibre-ebook.com/download). After moving the `calibre.app` to your Applications folder create a symbolic link to the ebook-convert tool:
 
 ```
-$ sudo ln -s ~/Applications/calibre.app/Contents/MacOS/ebook-convert /usr/bin
+$ sudo ln -s /Applications/calibre.app/Contents/MacOS/ebook-convert /usr/bin
 ```
 
 You can replace `/usr/bin` with any directory that is in your $PATH.


### PR DESCRIPTION
Calibre has an alias to the root-level Applications folder in their disk image, so that's presumably where most people will install it.
