### PR TITLE
small changes in the documentation "Installing ebook-convert"

### DIFF
--- a/docs/ebook.md
+++ b/docs/ebook.md
@@ -15,11 +15,13 @@ $ gitbook mobi ./ ./mybook.mobi
 
 ### Installing ebook-convert
 
-`ebook-convert` is required to generate ebooks (epub, mobi, pdf).
+The cli tools `ebook-convert` is required to generate ebooks (epub, mobi, pdf).
+
+Download the [Calibre application](https://calibre-ebook.com/download). Then verify that the `ebook-convert` are accessible via your path.
 
 ##### OS X
 
-Download the [Calibre application](https://calibre-ebook.com/download). After moving the `calibre.app` to your Applications folder create a symbolic link to the ebook-convert tool:
+After moving the `calibre.app` to your Applications folder create a symbolic link to the ebook-convert tool:
 
 ```
 $ sudo ln -s ~/Applications/calibre.app/Contents/MacOS/ebook-convert /usr/bin


### PR DESCRIPTION
Personally, I find this part of the documentation a bit confusing. When I first see that I jumped on a `npm install` command line. But the true answer (or URL link) is actually in the OS X section.

Related issues :
[GitbookIO/gitbook-cli/issues/26](https://github.com/GitbookIO/gitbook-cli/issues/26)
