### PR TITLE
add open and browser args to serve command

### DIFF
--- a/lib/cli/serve.js
+++ b/lib/cli/serve.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 var tinylr = require('tiny-lr');
+var open = require('open');
 
 var Parse = require('../parse');
 var Output = require('../output');
@@ -32,9 +33,11 @@ function generateBook(args, kwargs) {
     var outputFolder = getOutputFolder(args);
     var book = getBook(args, kwargs);
     var Generator = Output.getGenerator(kwargs.format);
+    var browser = kwargs['browser'];
 
     var hasWatch = kwargs['watch'];
     var hasLiveReloading = kwargs['live'];
+    var hasOpen = kwargs['open'];
 
     // Stop server if running
     if (server.isRunning()) console.log('Stopping server');
@@ -70,6 +73,10 @@ function generateBook(args, kwargs) {
                     files: [lrPath]
                 }
             });
+        }
+
+        if (hasOpen) {
+            open('http://localhost:'+port, browser);
         }
     })
     .then(function() {
@@ -111,6 +118,16 @@ module.exports = {
             name: 'live',
             description: 'Enable live reloading',
             defaults: true
+        },
+        {
+            name: 'open',
+            description: 'Enable opening book in browser',
+            defaults: true
+        },
+        {
+            name: 'browser',
+            description: 'Specify browser for opening book',
+            defaults: ''
         },
         options.log,
         options.format

--- a/lib/cli/serve.js
+++ b/lib/cli/serve.js
@@ -122,7 +122,7 @@ module.exports = {
         {
             name: 'open',
             description: 'Enable opening book in browser',
-            defaults: true
+            defaults: false
         },
         {
             name: 'browser',

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "nunjucks-do": "1.0.0",
     "object-path": "^0.9.2",
     "omit-keys": "^0.1.0",
+    "open": "0.0.5",
     "q": "1.4.1",
     "read-installed": "^4.0.3",
     "request": "2.72.0",


### PR DESCRIPTION
@i5ting asked for an open option in https://github.com/GitbookIO/gitbook-cli/issues/37

I have added an ```open``` and ```browser``` option. ```open``` is true by default and by using ```browser``` you can specify the browser for opening the book.

Example:
```$ gitbook serve --browser firefox```