### PR TITLE
Fix extra dot of filePath

### DIFF
--- a/lib/output/helper/fileToURL.js
+++ b/lib/output/helper/fileToURL.js
@@ -21,8 +21,15 @@ function fileToURL(output, filePath) {
 
     filePath = fileToOutput(output, filePath);
 
-    if (directoryIndex && path.basename(filePath) == 'index.html') {
+    switch (true) {
+    case !directoryIndex:
+        break;
+    case filePath === 'index.html':
+        filePath = '/';
+        break;
+    case path.basename(filePath) === 'index.html':
         filePath = path.dirname(filePath) + '/';
+        break;
     }
 
     return LocationUtils.normalize(filePath);


### PR DESCRIPTION
`filePath` of "README.md" in root directory should return "/" rather than "./".