### PR TITLE
Update asciidoc extensions

### DIFF
--- a/lib/constants/extsAsciidoc.js
+++ b/lib/constants/extsAsciidoc.js
@@ -1,4 +1,6 @@
 module.exports = [
+    '.ad',
     '.adoc',
+    '.asc',
     '.asciidoc'
 ];


### PR DESCRIPTION
Upstream asciidoctor (Common implementation) uses [this list of extensions](https://github.com/asciidoctor/asciidoctor/blob/v1.5.4/lib/asciidoctor.rb#L250-L258).
