### PR TITLE
Updated book.js link

### DIFF
--- a/docs/plugins/api.md
+++ b/docs/plugins/api.md
@@ -4,7 +4,7 @@ GitBooks provides different APIs and contexts to plugins. These APIs can vary ac
 
 #### Book instance
 
-The `Book` class is the central point of GitBook, it centralize all access read methods. This class is defined in [book.js](https://github.com/GitbookIO/gitbook/blob/master/lib/book.js).
+The `Book` class is the central point of GitBook, it centralize all access read methods. This class is defined in [book.js](https://github.com/GitbookIO/gitbook/blob/master/book.js).
 
 ```js
 // Read configuration from book.json


### PR DESCRIPTION
The book.js link was pointing to a 404 page. This commit updates the link.