### PR TITLE
Update ALIASES.js

### DIFF
--- a/packages/gitbook-plugin-highlight/src/ALIASES.js
+++ b/packages/gitbook-plugin-highlight/src/ALIASES.js
@@ -2,7 +2,6 @@
 const ALIASES = {
     'py': 'python',
     'js': 'javascript',
-    'json': 'javascript',
     'rb': 'ruby',
     'csharp': 'cs'
 };


### PR DESCRIPTION
Remove `json` alias.

Leaving `json` alias in the file causes json to not print correctly since the "key" is in quotes the `js` parser displays the "key" and "value" as javascript keys.