### PR TITLE
disabling `cpr`s "confirm" option for fs.copyDir

### DIFF
--- a/lib/output/website/copyPluginAssets.js
+++ b/lib/output/website/copyPluginAssets.js
@@ -64,7 +64,7 @@ function copyAssets(output, plugin) {
         {
             deleteFirst: false,
             overwrite: true,
-            confirm: true
+            confirm: false // fixes Issue #1309, don't use graceful-fs.stat
         }
     );
 }


### PR DESCRIPTION
Seems as if the release branch for 3.2.2 is gone, this should probably be a PR onto that and then artifact 3.2.3 would go to npm?

This fixes: https://github.com/GitbookIO/gitbook/issues/1309