### PR TITLE
Resolves #1015, enable the include directive (using server safe mode)

### DIFF
--- a/packages/gitbook/src/parsers/__tests__/asciidoc.js
+++ b/packages/gitbook/src/parsers/__tests__/asciidoc.js
@@ -1,0 +1,9 @@
+const AsciidocParser = require('../asciidoc');
+
+describe('AsciidocParser', () => {
+
+    it('should convert to HTML and include file', () => {
+        const result = AsciidocParser.toHTML('= GitBook User Manual\n\n== Usage\n\ninclude::src/parsers/__tests__/usage.adoc[]');
+        expect(result).toMatch(/To use GitBook/);
+    });
+});

--- a/packages/gitbook/src/parsers/__tests__/usage.adoc
+++ b/packages/gitbook/src/parsers/__tests__/usage.adoc
@@ -1,0 +1,1 @@
+To use GitBook, just type `gitbook init`

--- a/packages/gitbook/src/parsers/asciidoc.js
+++ b/packages/gitbook/src/parsers/asciidoc.js
@@ -36,6 +36,7 @@ function toDocument(text) {
  */
 function toHTML(text) {
     return asciidocjs.convert(text, {
+        safe: 'server',
         attributes: 'showtitle'
     });
 }


### PR DESCRIPTION
Read more about include directive: http://asciidoctor.org/docs/user-manual/#include-directive

NOTE: The path is resolved relatively to where the command where run. We could define the `base_dir` on each page to resolve relatively to the page.

In other words, given:
```
chapter-1/
  index.adoc
  include.adoc
```
The following **will** work:

```
include::chapter-1/include.adoc[]
```

The following **will not** work:

```
include::include.adoc[]
```



Resolves #1015