### PR TITLE
Use Node LTS in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
   - linux
   - osx
 node_js:
-  - "stable"
-  - "4.1"
+  - "lts/*"
 before_install:
   - npm install svgexport -g
 before_script:


### PR DESCRIPTION
Node.js 6.x is now the "active" LTS: https://github.com/nodejs/LTS#lts-schedule

Plus Travis seems to have trouble building the project with Node 4.1