### PR TITLE
Ignore empty articles, and be more flexible in parsing articles

### DIFF
--- a/packages/gitbook/package.json
+++ b/packages/gitbook/package.json
@@ -43,7 +43,7 @@
     "json-schema-defaults": "0.1.1",
     "jsonschema": "1.1.0",
     "juice": "2.0.0",
-    "markup-it": "^3.2.2",
+    "markup-it": "^3.4.0",
     "mkdirp": "0.5.1",
     "moment": "2.13.0",
     "npm": "3.10.9",

--- a/packages/gitbook/src/parse/__tests__/fixtures/summary/empty-items.yaml
+++ b/packages/gitbook/src/parse/__tests__/fixtures/summary/empty-items.yaml
@@ -21,5 +21,11 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: ''
+              - kind: inline
+                type: link
+                data:
+                  href: 'art1.md'
+                nodes:
+                  - kind: text
+                    text: '' # No title so ignored
+

--- a/packages/gitbook/src/parse/__tests__/fixtures/summary/flexible.yaml
+++ b/packages/gitbook/src/parse/__tests__/fixtures/summary/flexible.yaml
@@ -1,0 +1,115 @@
+nodes:
+  - kind: block
+    type: header_one
+    nodes:
+      - kind: text
+        text: Summary
+  - kind: block
+    type: unordered_list
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: unstyled
+            nodes:
+              - kind: text
+                text: 'ignored text'
+              - kind: inline
+                type: link
+                data:
+                  href: 'art1.md'
+                nodes:
+                  - kind: text
+                    text: 'Article 1'
+              - kind: text
+                text: ''
+
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'Article 2'
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'Ignored'
+
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'First paragraph. There is a link further, so should be ignored'
+
+          # Sublist, that is not after a link. Should be ignored
+          - kind: block
+            type: unordered_list
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: unstyled
+                    nodes:
+                      - kind: inline
+                        type: link
+                        data:
+                          href: 'ignored.md'
+                        nodes:
+                          - kind: text
+                            text: 'Ignored'
+
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: inline
+                type: link
+                data:
+                  href: 'art3.md'
+                nodes:
+                  - kind: text
+                    text: 'Article 3'
+
+          # First sublist that is after the link. Parsed as subarticles
+          - kind: block
+            type: unordered_list
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: unstyled
+                    nodes:
+                      - kind: inline
+                        type: link
+                        data:
+                          href: 'art2.1.md'
+                        nodes:
+                          - kind: text
+                            text: 'Article 2.1'
+
+          # Ignored because we already parsed the previous list
+          - kind: block
+            type: unordered_list
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: unstyled
+                    nodes:
+                      - kind: inline
+                        type: link
+                        data:
+                          href: 'ignored'
+                        nodes:
+                          - kind: text
+                            text: 'ignored'
+

--- a/packages/gitbook/src/parse/__tests__/summaryFromDocument.js
+++ b/packages/gitbook/src/parse/__tests__/summaryFromDocument.js
@@ -92,22 +92,13 @@ describe('summaryFromDocument', () => {
         ]);
     });
 
-    it('should parse empty items', () => {
+    it('should ignore empty items', () => {
         const summary = readSummary('summary/empty-items.yaml');
 
         expectParts(summary, [
             {
                 title: '',
-                articles: [
-                    {
-                        title: '',
-                        ref: ''
-                    },
-                    {
-                        title: '',
-                        ref: ''
-                    }
-                ]
+                articles: []
             }
         ]);
     });
@@ -210,4 +201,36 @@ describe('summaryFromDocument', () => {
         expectParts(summary, [
         ]);
     });
+
+    it('should be flexible', () => {
+        const summary = readSummary('summary/flexible.yaml');
+
+        expectParts(summary, [
+            {
+                title: '',
+                articles: [
+                    {
+                        title: 'Article 1',
+                        ref: 'art1.md'
+                    },
+                    {
+                        title: 'Article 2',
+                        articles: []
+                    },
+                    {
+                        title: 'Article 3',
+                        ref: 'art3.md',
+                        articles: [
+                            {
+                                title: 'Article 2.1',
+                                ref: 'art2.1.md',
+                                articles: []
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]);
+    });
+
 });


### PR DESCRIPTION
Once integrated in the Editor, this would 

- Fix https://github.com/GitbookIO/feedback/issues/372 and fix https://github.com/GitbookIO/feedback/issues/411

  The reason is links in the parsed Slate.Document are surrounded by empty texts in Asciidoc, so considered as empty articles. And empty articles were not ignored.

- Fix https://github.com/GitbookIO/editor/issues/571