### PR TITLE
Simpler summary export

### DIFF
--- a/packages/gitbook/src/modifiers/summary/__tests__/editArticleTitle.js
+++ b/packages/gitbook/src/modifiers/summary/__tests__/editArticleTitle.js
@@ -1,0 +1,36 @@
+const Summary = require('../../../models/summary');
+
+describe('editArticleTitle', () => {
+    const editArticleTitle = require('../editArticleTitle');
+    const summary = Summary.createFromParts([
+        {
+            articles: [
+                {
+                    title: 'My First Article',
+                    path: 'README.md'
+                },
+                {
+                    title: 'My Second Article',
+                    path: 'article.md'
+                }
+            ]
+        },
+        {
+            title: 'Test'
+        }
+    ]);
+
+    it('should correctly set title of first article', () => {
+        const newSummary = editArticleTitle(summary, '1.1', 'Hello World');
+        const article = newSummary.getByLevel('1.1');
+
+        expect(article.getTitle()).toBe('Hello World');
+    });
+
+    it('should correctly set title of second article', () => {
+        const newSummary = editArticleTitle(summary, '1.2', 'Hello World');
+        const article = newSummary.getByLevel('1.2');
+
+        expect(article.getTitle()).toBe('Hello World');
+    });
+});

--- a/packages/gitbook/src/modifiers/summary/__tests__/fixtures/article-no-link.yaml
+++ b/packages/gitbook/src/modifiers/summary/__tests__/fixtures/article-no-link.yaml
@@ -13,13 +13,24 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: Hello
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: Hello
       - kind: block
         type: list_item
         nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: World
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: World
+

--- a/packages/gitbook/src/modifiers/summary/__tests__/fixtures/article-with-link.yaml
+++ b/packages/gitbook/src/modifiers/summary/__tests__/fixtures/article-with-link.yaml
@@ -16,15 +16,20 @@ nodes:
               - kind: inline
                 type: link
                 data:
-                  href: hello.md
+                  href: 'hello.md'
                 nodes:
                   - kind: text
-                    text: Hello
+                    text: 'Hello'
       - kind: block
         type: list_item
         nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: World
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: 'World'

--- a/packages/gitbook/src/modifiers/summary/__tests__/fixtures/deep.yaml
+++ b/packages/gitbook/src/modifiers/summary/__tests__/fixtures/deep.yaml
@@ -20,8 +20,13 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: '1.1'
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: '1.1'
           - kind: block
             type: unordered_list
             nodes:
@@ -31,24 +36,39 @@ nodes:
                   - kind: block
                     type: unstyled
                     nodes:
-                      - kind: text
-                        text: '1.1.1'
+                      - kind: inline
+                        type: link
+                        data:
+                          href: ''
+                        nodes:
+                          - kind: text
+                            text: '1.1.1'
               - kind: block
                 type: list_item
                 nodes:
                   - kind: block
                     type: unstyled
                     nodes:
-                      - kind: text
-                        text: '1.1.2'
+                      - kind: inline
+                        type: link
+                        data:
+                          href: ''
+                        nodes:
+                          - kind: text
+                            text: '1.1.2'
       - kind: block
         type: list_item
         nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: '1.2'
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: '1.2'
           - kind: block
             type: unordered_list
             nodes:
@@ -58,16 +78,26 @@ nodes:
                   - kind: block
                     type: unstyled
                     nodes:
-                      - kind: text
-                        text: '1.2.1'
+                      - kind: inline
+                        type: link
+                        data:
+                          href: ''
+                        nodes:
+                          - kind: text
+                            text: '1.2.1'
               - kind: block
                 type: list_item
                 nodes:
                   - kind: block
                     type: unstyled
                     nodes:
-                      - kind: text
-                        text: '1.2.2'
+                      - kind: inline
+                        type: link
+                        data:
+                          href: ''
+                        nodes:
+                          - kind: text
+                            text: '1.2.2'
 
   - kind: block
     type: header_two
@@ -84,8 +114,13 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: '2.1'
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: '2.1'
           - kind: block
             type: unordered_list
             nodes:
@@ -95,8 +130,13 @@ nodes:
                   - kind: block
                     type: unstyled
                     nodes:
-                      - kind: text
-                        text: '2.1.1'
+                      - kind: inline
+                        type: link
+                        data:
+                          href: ''
+                        nodes:
+                          - kind: text
+                            text: '2.1.1'
                   - kind: block
                     type: unordered_list
                     nodes:
@@ -106,8 +146,13 @@ nodes:
                           - kind: block
                             type: unstyled
                             nodes:
-                              - kind: text
-                                text: '2.1.1.1'
+                              - kind: inline
+                                type: link
+                                data:
+                                  href: ''
+                                nodes:
+                                  - kind: text
+                                    text: '2.1.1.1'
                           - kind: block
                             type: unordered_list
                             nodes:
@@ -117,5 +162,10 @@ nodes:
                                   - kind: block
                                     type: unstyled
                                     nodes:
-                                      - kind: text
-                                        text: '2.1.1.1.1'
+                                      - kind: inline
+                                        type: link
+                                        data:
+                                          href: ''
+                                        nodes:
+                                          - kind: text
+                                            text: '2.1.1.1.1'

--- a/packages/gitbook/src/modifiers/summary/__tests__/fixtures/empty-items.yaml
+++ b/packages/gitbook/src/modifiers/summary/__tests__/fixtures/empty-items.yaml
@@ -13,13 +13,23 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: ''
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: ''
       - kind: block
         type: list_item
         nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: ''
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: ''

--- a/packages/gitbook/src/modifiers/summary/__tests__/fixtures/empty-part.yaml
+++ b/packages/gitbook/src/modifiers/summary/__tests__/fixtures/empty-part.yaml
@@ -19,8 +19,13 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: 'Article 1'
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: 'Article 1'
 
   - kind: block
     type: header_two
@@ -48,8 +53,13 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: 'Article 2'
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: 'Article 2'
 
   - kind: block
     type: header_two

--- a/packages/gitbook/src/modifiers/summary/__tests__/fixtures/parts-ul.yaml
+++ b/packages/gitbook/src/modifiers/summary/__tests__/fixtures/parts-ul.yaml
@@ -13,8 +13,13 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: Hello
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: Hello
 
   - kind: block
     type: header_two
@@ -30,8 +35,13 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: World
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: World
 
   - kind: block
     type: hr
@@ -47,5 +57,10 @@ nodes:
           - kind: block
             type: unstyled
             nodes:
-              - kind: text
-                text: Yeah
+              - kind: inline
+                type: link
+                data:
+                  href: ''
+                nodes:
+                  - kind: text
+                    text: Yeah

--- a/packages/gitbook/src/modifiers/summary/__tests__/toDocument.js
+++ b/packages/gitbook/src/modifiers/summary/__tests__/toDocument.js
@@ -21,7 +21,7 @@ function expectDocument(documentPath, parts) {
 
 describe('summaryToDocument', () => {
     it('should convert unlinked articles', () => {
-        expectDocument('ul.yaml', [
+        expectDocument('article-no-link.yaml', [
             {
                 title: '',
                 articles: [
@@ -39,7 +39,7 @@ describe('summaryToDocument', () => {
     });
 
     it('should convert articles with links', () => {
-        expectDocument('ul-with-link.yaml', [
+        expectDocument('article-with-link.yaml', [
             {
                 title: '',
                 articles: [

--- a/packages/gitbook/src/modifiers/summary/toDocument.js
+++ b/packages/gitbook/src/modifiers/summary/toDocument.js
@@ -8,24 +8,20 @@ const { BLOCKS, INLINES } = require('markup-it');
  */
 function articleToBlock(article) {
     const { title, ref, articles } = article;
-    const text = Text.createFromString(title);
-
-    // Text or link ?
-    const innerNode = ref ? Inline.create({
-        type: INLINES.LINK,
-        nodes: [
-            text
-        ],
-        data: {
-            href: ref
-        }
-    }) : text;
 
     const nodes = [
         Block.create({
             type: BLOCKS.TEXT,
             nodes: [
-                innerNode
+                Inline.create({
+                    type: INLINES.LINK,
+                    nodes: [
+                        Text.createFromString(title)
+                    ],
+                    data: {
+                        href: ref || ''
+                    }
+                })
             ]
         })
     ];


### PR DESCRIPTION
This always default to a link export for articles.
This helps having a more reliable markdown syntax for the summary, and allows writing numbered articles:

```
# Summary

* [Introduction](README.md)
* [Empty]()
* [1. Numbered]()
```

Which is otherwised parsed as a numbered sublist

Related to this editor bug: https://gitbook.zendesk.com/agent/tickets/5478