### PR TITLE
Readme fix: gitbook fetch beta -> gitbook fetch pre

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -54,7 +54,7 @@ $ gitbook build
 `gitbook-cli` makes it easy to download and install other versions of GitBook to test with your book:
 
 ```
-$ gitbook fetch beta
+$ gitbook fetch pre
 ```
 
 Use `gitbook ls-remote` to list remote versions available for install.


### PR DESCRIPTION
`gitbook fetch beta` results in error: `Error: Invalid version or tag "beta", see available using "gitbook ls-remote"`.
Seems like the correct command is `gitbook fetch pre`