### PR TITLE
Ignore symlink

### DIFF
--- a/lib/fs/node.js
+++ b/lib/fs/node.js
@@ -14,6 +14,8 @@ function fsReadDir(folder) {
             .map(function(file) {
                 if (file == '.' || file == '..') return;
 
+                if (fs.lstatSync(path.join(folder, file)).isSymbolicLink()) return;
+
                 var stat = fs.statSync(path.join(folder, file));
                 if (stat.isDirectory()) file = file + path.sep;
                 return file;

--- a/lib/utils/fs.js
+++ b/lib/utils/fs.js
@@ -155,6 +155,7 @@ module.exports = {
     pickFile: pickFile,
     stat: Promise.nfbind(fs.stat),
     statSync: fs.statSync,
+    lstatSync: fs.lstatSync,
     readdir: Promise.nfbind(fs.readdir),
     writeStream: writeStream,
     readStream: fs.createReadStream,


### PR DESCRIPTION
Refer #1500 and #1722 

gitbook crashes when gitbook serves symbolic files (e.g. `Error: ENOENT: no such file or directory, stat '/path/to/symlink_file'`.

I will ignore symlink files.