### PR TITLE
Add destRoot config option

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -17,12 +17,12 @@ module.exports = {
     ],
     exec: function(args, kwargs) {
         var book = getBook(args, kwargs);
-        var outputFolder = getOutputFolder(args);
-
         var Generator = Output.getGenerator(kwargs.format);
 
         return Parse.parseBook(book)
         .then(function(resultBook) {
+            var outputFolder = getOutputFolder(resultBook, args);
+
             return Output.generate(Generator, resultBook, {
                 root: outputFolder
             });

--- a/lib/cli/getOutputFolder.js
+++ b/lib/cli/getOutputFolder.js
@@ -6,9 +6,10 @@ var path = require('path');
     @param {Array} args
     @return {String}
 */
-function getOutputFolder(args) {
+function getOutputFolder(book, args) {
+    var outputRootFromConfig = book.config.getValue('destRoot')
     var bookRoot = path.resolve(args[0] || process.cwd());
-    var defaultOutputRoot = path.join(bookRoot, '_book');
+    var defaultOutputRoot = outputRootFromConfig ? path.resolve(outputRootFromConfig) : path.join(bookRoot, '_book');
     var outputFolder = args[1]? path.resolve(process.cwd(), args[1]) : defaultOutputRoot;
 
     return outputFolder;

--- a/lib/cli/serve.js
+++ b/lib/cli/serve.js
@@ -30,10 +30,10 @@ function waitForCtrlC() {
 
 function generateBook(args, kwargs) {
     var port = kwargs.port;
-    var outputFolder = getOutputFolder(args);
     var book = getBook(args, kwargs);
     var Generator = Output.getGenerator(kwargs.format);
     var browser = kwargs['browser'];
+    var outputFolder;
 
     var hasWatch = kwargs['watch'];
     var hasLiveReloading = kwargs['live'];
@@ -52,6 +52,8 @@ function generateBook(args, kwargs) {
                 config = ConfigModifier.addPlugin(config, 'livereload');
                 resultBook = resultBook.set('config', config);
             }
+
+            outputFolder = getOutputFolder(resultBook, args);
 
             return Output.generate(Generator, resultBook, {
                 root: outputFolder

--- a/lib/constants/configSchema.js
+++ b/lib/constants/configSchema.js
@@ -8,7 +8,11 @@ module.exports = {
     'properties': {
         'root': {
             'type': 'string',
-            'title': 'Path fro the root folder containing the book\'s content'
+            'title': 'Path for the root folder containing the book\'s content'
+        },
+        'destRoot': {
+            'type': 'string',
+            'title': 'Path to place the generated output for the book'
         },
         'title': {
             'type': 'string',


### PR DESCRIPTION
GitBook currently only supports custom output directories by specifying one as an argument to `gitbook build`. This patch adds a new config option `destRoot`, which can still be overridden by the command line option if one is specified.

This simplifies the workflow and prevents the build process from requiring the argument every time.