### PR TITLE
Fix gitbook-cli help info for `gitbook pbf` and `gitbook mobi`

### DIFF
--- a/lib/cli/buildEbook.js
+++ b/lib/cli/buildEbook.js
@@ -11,9 +11,13 @@ var getBook = require('./getBook');
 
 
 module.exports = function(format) {
+    let description = ({
+        pdf: 'build a book into a pdf file',
+        mobi: 'build a book into a kindle reader file',
+    })[format] || 'build a book into an ebook file';
     return {
         name: (format + ' [book] [output]'),
-        description: 'build a book into an ebook file',
+        description: description,
         options: [
             options.log
         ],


### PR DESCRIPTION
This fixes the help text for `gitbook pdf` and `gitbook mobi` as seen below:

```sh
$ ./node_modules/.bin/gitbook help | tail -10

    pdf [book] [output]         build a book into an ebook file
        --log                   Minimum log level to display (Default is info; Values are debug, info, warn, error, disabled)

    epub [book] [output]        build a book into an ebook file
        --log                   Minimum log level to display (Default is info; Values are debug, info, warn, error, disabled)

    mobi [book] [output]        build a book into an ebook file
        --log                   Minimum log level to display (Default is info; Values are debug, info, warn, error, disabled)
```