### PR TITLE
Decode page content for non-English characters

### DIFF
--- a/lib/output/website/onPage.js
+++ b/lib/output/website/onPage.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var omit = require('omit-keys');
+var he = require('he');
 
 var Templating = require('../../templating');
 var Plugins = require('../../plugins');
@@ -62,6 +63,9 @@ function onPage(output, page) {
 
         // We should probabbly move it to "template" or a "site" namespace
         context.basePath = basePath;
+
+        // Decode page content for non-English characters
+        context.page.content = he.decode(context.page.content);
 
         // Render the theme
         return Templating.renderFile(engine, prefix + '/page.html', context)

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gitbook-plugin-theme-default": "1.0.7",
     "github-slugid": "1.0.1",
     "graceful-fs": "4.1.4",
+    "he": "^1.1.1",
     "i18n-t": "1.0.1",
     "ignore": "3.1.2",
     "immutable": "^3.8.1",


### PR DESCRIPTION
It can prevent randomized decimal and hex entity-encoding which is appled for non-English characters.

When a website is generated, non-English characters in page content decode wrong. For example, `안녕하세요` is decoded to `&#xC548;&#xB155;&#xD558;&#xC138;&#xC694;`. I fixed it with node package, "he" and it works nicely. 

According to my tests, this issue might be also related with #687, #702 and #1419.