### PR TITLE
improve support for linking SUMMARY.md to sources outside root dir

### DIFF
--- a/lib/cli/buildEbook.js
+++ b/lib/cli/buildEbook.js
@@ -25,6 +25,7 @@ module.exports = function(format) {
 
             // Create temporary directory
             var outputFolder = tmp.dirSync().name;
+            options.outputFolder = outputFolder;
 
             var book = getBook(args, kwargs);
             var logger = book.getLogger();
@@ -71,6 +72,7 @@ module.exports = function(format) {
                 logger.info.ok(count + ' file(s) generated');
 
                 logger.debug('cleaning up... ');
+                delete options.outputFolder;
                 return logger.debug.promise(fs.rmDir(outputFolder));
             });
         }

--- a/lib/output/website/createTemplateEngine.js
+++ b/lib/output/website/createTemplateEngine.js
@@ -91,6 +91,23 @@ function createTemplateEngine(output, currentFile) {
         return JSONUtils.encodePage(page, summary);
     }
 
+    function resolveFileNotWithinRoot(filePath) {
+        if (currentFile.substr(0,2) === '..') {
+            let regex = {
+                "path_sep":    /[\\\/]/,
+                "currentFile": /^((?:\.\.\/)+)([^\.].*)$/
+            }
+
+            let up_count = currentFile.replace(regex.currentFile, '$1').split('/').length - 1
+            let dn_count = currentFile.replace(regex.currentFile, '$2').split('/').length - 1
+            let base_path = ('../').repeat(up_count - 2 + dn_count) + outputFolder.split(regex.path_sep).slice(-up_count).join('/')
+
+            filePath = base_path + '/gitbook/' + filePath
+            return filePath
+        }
+        return false
+    }
+
     return TemplateEngine.create({
         loader: loader,
 
@@ -116,11 +133,17 @@ function createTemplateEngine(output, currentFile) {
              * it also resolve pages
              */
             resolveFile: function(filePath) {
+                let resolvedPath = resolveFileNotWithinRoot(filePath)
+                if (resolvedPath) return resolvedPath
+
                 filePath = resolveFileToURL(output, filePath);
                 return LocationUtils.relativeForFile(currentFile, filePath);
             },
 
             resolveAsset: function(filePath) {
+                let resolvedPath = resolveFileNotWithinRoot(filePath)
+                if (resolvedPath) return resolvedPath
+
                 filePath = LocationUtils.toAbsolute(filePath, '', '');
                 filePath = path.join('gitbook', filePath);
                 filePath = LocationUtils.relativeForFile(currentFile, filePath);

--- a/lib/output/website/createTemplateEngine.js
+++ b/lib/output/website/createTemplateEngine.js
@@ -100,7 +100,7 @@ function createTemplateEngine(output, currentFile) {
 
             var up_count = currentFile.replace(regex.currentFile, '$1').split('/').length - 1;
             var dn_count = currentFile.replace(regex.currentFile, '$2').split('/').length - 1;
-            var base_path = ('../').repeat(up_count - 2 + dn_count) + outputFolder.split(regex.path_sep).slice(-up_count).join('/');
+            var base_path = ('../').repeat(dn_count) + outputFolder.split(regex.path_sep).slice(-up_count).join('/');
 
             filePath = base_path + '/gitbook/' + filePath;
             return filePath;

--- a/lib/output/website/createTemplateEngine.js
+++ b/lib/output/website/createTemplateEngine.js
@@ -93,19 +93,19 @@ function createTemplateEngine(output, currentFile) {
 
     function resolveFileNotWithinRoot(filePath) {
         if (currentFile.substr(0,2) === '..') {
-            let regex = {
+            var regex = {
                 "path_sep":    /[\\\/]/,
                 "currentFile": /^((?:\.\.\/)+)([^\.].*)$/
-            }
+            };
 
-            let up_count = currentFile.replace(regex.currentFile, '$1').split('/').length - 1
-            let dn_count = currentFile.replace(regex.currentFile, '$2').split('/').length - 1
-            let base_path = ('../').repeat(up_count - 2 + dn_count) + outputFolder.split(regex.path_sep).slice(-up_count).join('/')
+            var up_count = currentFile.replace(regex.currentFile, '$1').split('/').length - 1;
+            var dn_count = currentFile.replace(regex.currentFile, '$2').split('/').length - 1;
+            var base_path = ('../').repeat(up_count - 2 + dn_count) + outputFolder.split(regex.path_sep).slice(-up_count).join('/');
 
-            filePath = base_path + '/gitbook/' + filePath
-            return filePath
+            filePath = base_path + '/gitbook/' + filePath;
+            return filePath;
         }
-        return false
+        return false;
     }
 
     return TemplateEngine.create({
@@ -133,16 +133,16 @@ function createTemplateEngine(output, currentFile) {
              * it also resolve pages
              */
             resolveFile: function(filePath) {
-                let resolvedPath = resolveFileNotWithinRoot(filePath)
-                if (resolvedPath) return resolvedPath
+                var resolvedPath = resolveFileNotWithinRoot(filePath);
+                if (resolvedPath) return resolvedPath;
 
                 filePath = resolveFileToURL(output, filePath);
                 return LocationUtils.relativeForFile(currentFile, filePath);
             },
 
             resolveAsset: function(filePath) {
-                let resolvedPath = resolveFileNotWithinRoot(filePath)
-                if (resolvedPath) return resolvedPath
+                var resolvedPath = resolveFileNotWithinRoot(filePath);
+                if (resolvedPath) return resolvedPath;
 
                 filePath = LocationUtils.toAbsolute(filePath, '', '');
                 filePath = path.join('gitbook', filePath);

--- a/lib/output/website/createTemplateEngine.js
+++ b/lib/output/website/createTemplateEngine.js
@@ -91,23 +91,6 @@ function createTemplateEngine(output, currentFile) {
         return JSONUtils.encodePage(page, summary);
     }
 
-    function resolveFileNotWithinRoot(filePath) {
-        if (currentFile.substr(0,2) === '..') {
-            var regex = {
-                "path_sep":    /[\\\/]/,
-                "currentFile": /^((?:\.\.\/)+)([^\.].*)$/
-            };
-
-            var up_count = currentFile.replace(regex.currentFile, '$1').split('/').length - 1;
-            var dn_count = currentFile.replace(regex.currentFile, '$2').split('/').length - 1;
-            var base_path = ('../').repeat(dn_count) + outputFolder.split(regex.path_sep).slice(-up_count).join('/');
-
-            filePath = base_path + '/gitbook/' + filePath;
-            return filePath;
-        }
-        return false;
-    }
-
     return TemplateEngine.create({
         loader: loader,
 
@@ -133,17 +116,11 @@ function createTemplateEngine(output, currentFile) {
              * it also resolve pages
              */
             resolveFile: function(filePath) {
-                var resolvedPath = resolveFileNotWithinRoot(filePath);
-                if (resolvedPath) return resolvedPath;
-
                 filePath = resolveFileToURL(output, filePath);
                 return LocationUtils.relativeForFile(currentFile, filePath);
             },
 
             resolveAsset: function(filePath) {
-                var resolvedPath = resolveFileNotWithinRoot(filePath);
-                if (resolvedPath) return resolvedPath;
-
                 filePath = LocationUtils.toAbsolute(filePath, '', '');
                 filePath = path.join('gitbook', filePath);
                 filePath = LocationUtils.relativeForFile(currentFile, filePath);

--- a/lib/utils/location.js
+++ b/lib/utils/location.js
@@ -97,8 +97,26 @@ function toAbsolute(_href, dir, outdir) {
  * @return {String}
  */
 function relative(dir, file) {
-    var isDirectory = file.slice(-1) === '/';
-    return normalize(path.relative(dir, file)) + (isDirectory? '/': '');
+    if (dir.substr(0,2) === '..') {
+        var outputFolder = require('../cli/options').outputFolder;
+        var currentFile = dir + '/';
+
+        var regex = {
+            "path_sep":    /[\\\/]/,
+            "currentFile": /^((?:\.\.\/)+)([^\.].*)$/
+        };
+
+        var up_count = currentFile.replace(regex.currentFile, '$1').split('/').length - 1;
+        var dn_count = currentFile.replace(regex.currentFile, '$2').split('/').length - 1;
+        var base_path = ('../').repeat(dn_count) + outputFolder.split(regex.path_sep).slice(-up_count).join('/');
+
+        var filePath = base_path + '/' + file;
+        return filePath;
+    }
+    else {
+        var isDirectory = file.slice(-1) === '/';
+        return normalize(path.relative(dir, file)) + (isDirectory? '/': '');
+    }
 }
 
 /**


### PR DESCRIPTION
* this does NOT fix the fact that HTML files are saved outside of the $TEMP directory
  * root directory is mapped to: `$TEMP/tmp-12345`
  * relative paths can escape this directory:
    * `../foo.md` => `$TEMP/foo.html`
    * `../../bar.md` => `$TEMP/../bar.html`
    * `../../../baz.md` => `$TEMP/../../baz.html`
    * `../../foo/bar/baz.md` => `$TEMP/../foo/bar/baz.html`
      * directory structure is created
      * `foo` directory becomes a sibling to `$TEMP`

* this DOES fix the relative paths linking these HTML files to CSS stylesheets that ARE stored inside of $TEMP