### PR TITLE
Fix typo breaking monospacing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This document aims to be a comprehensive guide to the GitBook command line tool,
 
 ### What is `gitbook`?
 
-`gitbook` is a command line tool (and Node.js library) for building beautiful books using GitHub/Git and Markdown (or AsciiDoc). This documentation has been generated using `gitbook.
+`gitbook` is a command line tool (and Node.js library) for building beautiful books using GitHub/Git and Markdown (or AsciiDoc). This documentation has been generated using `gitbook`.
 
 `gitbook` can output your content as a website ([customizable](themes/README.md) and [extensibles](plugins/README.md)) or as an ebook (PDF, ePub or Mobi).
 


### PR DESCRIPTION
`gitbook --> `gitbook`