### PR TITLE
Update validatePlugin messages and tests

### DIFF
--- a/lib/plugins/__tests__/validatePlugin.js
+++ b/lib/plugins/__tests__/validatePlugin.js
@@ -1,16 +1,80 @@
+var Immutable = require('immutable');
 var Promise = require('../../utils/promise');
 var Plugin = require('../../models/plugin');
 var validatePlugin = require('../validatePlugin');
 
 describe('validatePlugin', function() {
+
+    var validPlugin = Plugin.createFromString('test')
+        .set('package', Immutable.Map({
+            // plugins are considered loaded if package.size > 0
+            size: 1,
+            name: 'name',
+            engines: Immutable.Map({
+                gitbook: '>=3.0.0'
+            })
+        }));
+
     it('must not validate a not loaded plugin', function() {
         var plugin = Plugin.createFromString('test');
 
         return validatePlugin(plugin)
         .then(function() {
-            throw new Error('Should not be validate');
+            throw new Error('Should not be validated');
         }, function(err) {
             return Promise();
+        });
+    });
+
+    it('must not validate a plugin without a package name', function() {
+        var plugin = validPlugin;
+        var package = plugin.get('package');
+
+        plugin = plugin.set('package', package.merge({ name: undefined }));
+
+        return validatePlugin(plugin)
+        .then(function() {
+            throw new Error('Should not be validated');
+        }, function(err) {
+            return  Promise();
+        });
+    });
+
+    it('must not validate a plugin without defined "engines"', function() {
+        var plugin = validPlugin;
+        var package = plugin.get('package');
+
+        plugin = plugin.set('package', package.merge({ engines: undefined }));
+
+        return validatePlugin(plugin)
+        .then(function() {
+            throw new Error('Should not be validated');
+        }, function(err) {
+            return  Promise();
+        });
+    });
+
+    it('must not validate a plugin without "gitbook" defined in "engines" field', function() {
+        var plugin = validPlugin;
+        var package = plugin.get('package');
+
+        plugin = plugin.set('package', package.merge({ engines: { node: '>=3.0.0' } }));
+
+        return validatePlugin(plugin)
+        .then(function() {
+            throw new Error('Should not be validated');
+        }, function(err) {
+            return  Promise();
+        });
+    });
+
+    it('must validate valid plugins', function() {
+        var plugin = validPlugin;
+        return validatePlugin(plugin)
+        .then(function() {
+            return Promise();
+        }, function(err) {
+            throw new Error('Should be validated');
         });
     });
 });

--- a/lib/plugins/validatePlugin.js
+++ b/lib/plugins/validatePlugin.js
@@ -11,21 +11,43 @@ var Promise = require('../utils/promise');
 function validatePlugin(plugin) {
     var packageInfos = plugin.getPackage();
 
-    var isValid = (
-        plugin.isLoaded() &&
-        packageInfos &&
-        packageInfos.get('name') &&
-        packageInfos.get('engines') &&
-        packageInfos.get('engines').get('gitbook')
-    );
-
-    if (!isValid) {
-        return Promise.reject(new Error('Error loading plugin "' + plugin.getName() + '" at "' + plugin.getPath() + '"'));
+    if (!packageInfos) {
+        return Promise.reject(
+            new Error('Error getting plugin package information at "' + plugin.getPath() + '"')
+        );
     }
 
-    var engine = packageInfos.get('engines').get('gitbook');
+    var isLoaded = plugin.isLoaded();
+    var name = packageInfos.get('name');
+    var engines = packageInfos.get('engines');
+
+    var isValid = isLoaded && name && engines && engines.get('gitbook');
+
+    if (!isValid) {
+        var error = 'Error validating plugin' + (name ? '"' + name + '"' : '');
+
+        if (!isLoaded){
+            error += '\n  plugin could not be loaded';
+        }
+        if (!name) {
+            error += '\n  "name" must be defined in plugin\'s package.json';
+        }
+        if (!engines) {
+            error += '\n  "engines" must be defined in plugin\'s package.json';
+        }
+        if (engines && !engines.get('gitbook')) {
+            error += '\n  "gitbook" must be defined in plugin\'s package.json "engines" field';
+        }
+        error += '\n    at "' + plugin.getPath() + '"';
+
+        return Promise.reject(new Error(error));
+    }
+
+    var engine = engines.get('gitbook');
     if (!gitbook.satisfies(engine)) {
-        return Promise.reject(new Error('GitBook doesn\'t satisfy the requirements of this plugin: ' + engine));
+        return Promise.reject(
+            new Error('GitBook doesn\'t satisfy the requirements of this plugin: ' + engine)
+        );
     }
 
     return Promise(plugin);


### PR DESCRIPTION
These commits add detailed error messages for plugin validation and expand on the plugin validation tests. This change was motivated by the infamous `Error: Error loading plugin ...` error message generated in `validatePlugin()`.

While developing a new theme, we forgot to include `gitbook` in the `engines` field in the plugin's `package.json` file. Unfortunately, it took a little while to track down the issue because of the previous generic error message, even with the use of `--debug --log=debug`.

This should hopefully help others avoid making the same mistake .