### PR TITLE
Remove Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GitBook is a command line tool (and Node.js library) for building beautiful book
 
 You can publish and host books easily online using [gitbook.com](https://legacy.gitbook.com). A desktop editor is [also available](https://legacy.gitbook.com/editor).
 
-Check out the [GitBook Community Slack Channel](https://slack.gitbook.com), Stay updated by following [@GitBookIO](https://twitter.com/GitBookIO) on Twitter or [GitBook](https://www.facebook.com/gitbookcom) on Facebook.
+Stay updated by following [@GitBookIO](https://twitter.com/GitBookIO) on Twitter or [GitBook](https://www.facebook.com/gitbookcom) on Facebook.
 
 Complete documentation is available at [toolchain.gitbook.com](http://toolchain.gitbook.com/).
 


### PR DESCRIPTION
We are going to close the Slack community, in an effort to consolidate our supports channel to improve the quality of the help we provide for our users. This removes the link to the Slack community.