### PR TITLE
Refactor lib/cli/serve.js and lib/cli/watch.js to fix some major performance issues in development

### DIFF
--- a/lib/cli/serve.js
+++ b/lib/cli/serve.js
@@ -15,20 +15,19 @@ var getOutputFolder = require('./getOutputFolder');
 var Server = require('./server');
 var watch = require('./watch');
 
-var server, lrServer, lrPath;
+var server, lrServer, lrFilepaths = [];
 
 function waitForCtrlC() {
     var d = Promise.defer();
 
-    process.on('SIGINT', function() {
+    process.on('SIGINT', function () {
         d.resolve();
     });
 
     return d.promise;
 }
 
-
-function generateBook(args, kwargs) {
+function startServer(args, kwargs) {
     var port = kwargs.port;
     var outputFolder = getOutputFolder(args);
     var book = getBook(args, kwargs);
@@ -38,59 +37,78 @@ function generateBook(args, kwargs) {
     var hasWatch = kwargs['watch'];
     var hasLiveReloading = kwargs['live'];
     var hasOpen = kwargs['open'];
+    var regenerationInProgress = false;
+    var needsRegeneration = false;
 
-    // Stop server if running
-    if (server.isRunning()) console.log('Stopping server');
-
-    return server.stop()
-    .then(function() {
+    function generateBook() {
         return Parse.parseBook(book)
-        .then(function(resultBook) {
+            .then(function (resultBook) {
+                if (hasLiveReloading) {
+                    // Enable livereload plugin
+                    var config = resultBook.getConfig();
+                    config = ConfigModifier.addPlugin(config, 'livereload');
+                    resultBook = resultBook.set('config', config);
+                }
+                return Output.generate(Generator, resultBook, {
+                    root: outputFolder
+                });
+            });
+    }
+
+    // Also triggers livereload update
+    function regenerateBook() {
+        regenerationInProgress = true;
+        return generateBook(args, kwargs).then(function () {
             if (hasLiveReloading) {
-                // Enable livereload plugin
-                var config = resultBook.getConfig();
-                config = ConfigModifier.addPlugin(config, 'livereload');
-                resultBook = resultBook.set('config', config);
+                // trigger livereload
+                console.log('Triggering livereload for', lrFilepaths);
+                lrServer.changed({
+                    body: {
+                        files: [lrFilepaths]
+                    }
+                });
             }
 
-            return Output.generate(Generator, resultBook, {
-                root: outputFolder
-            });
+            if (needsRegeneration) {
+                needsRegeneration = false;
+                return regenerateBook();
+            }
+            regenerationInProgress = false;
+            lrFilepaths = [];
         });
-    })
-    .then(function() {
-        console.log();
-        console.log('Starting server ...');
-        return server.start(outputFolder, port);
-    })
-    .then(function() {
-        console.log('Serving book on http://localhost:'+port);
+    }
 
-        if (lrPath && hasLiveReloading) {
-            // trigger livereload
-            lrServer.changed({
-                body: {
-                    files: [lrPath]
+    console.log('Generating book ...');
+    return generateBook(args, kwargs).then(function () {
+        console.log('Starting server ...');
+        return server.start(outputFolder, port).then(function () {
+            console.log('Serving book on http://localhost:' + port);
+
+            if (hasOpen) {
+                open('http://localhost:' + port, browser);
+            }
+
+            if (!hasWatch) {
+                return waitForCtrlC();
+            }
+
+            watch(book.getRoot(), function (err, filepath) {
+                if (err) {
+                    console.log(err);
+                    return;
+                }
+                if (!lrFilepaths.includes(filepath)) {
+                    lrFilepaths.push(filepath);
+                }
+                if (regenerationInProgress) {
+                    console.log('Queuing another regeneration after change in', filepath);
+                    needsRegeneration = true;
+                } else {
+                    console.log('Regenerating book after change in', filepath);
+                    regenerateBook();
                 }
             });
-        }
-
-        if (hasOpen) {
-            open('http://localhost:'+port, browser);
-        }
-    })
-    .then(function() {
-        if (!hasWatch) {
             return waitForCtrlC();
-        }
-
-        return watch(book.getRoot())
-        .then(function(filepath) {
-            // set livereload path
-            lrPath = filepath;
-            console.log('Restart after change in file', filepath);
-            console.log('');
-            return generateBook(args, kwargs);
         });
     });
 }
@@ -132,28 +150,27 @@ module.exports = {
         options.log,
         options.format
     ],
-    exec: function(args, kwargs) {
+    exec: function (args, kwargs) {
         server = new Server();
         var hasWatch = kwargs['watch'];
         var hasLiveReloading = kwargs['live'];
 
         return Promise()
-        .then(function() {
-            if (!hasWatch || !hasLiveReloading) {
-                return;
-            }
+            .then(function () {
+                if (!hasWatch || !hasLiveReloading) {
+                    return;
+                }
 
-            lrServer = tinylr({});
-            return Promise.nfcall(lrServer.listen.bind(lrServer), kwargs.lrport)
-            .then(function() {
-                console.log('Live reload server started on port:', kwargs.lrport);
-                console.log('Press CTRL+C to quit ...');
-                console.log('');
-
+                lrServer = tinylr({});
+                return Promise.nfcall(lrServer.listen.bind(lrServer), kwargs.lrport)
+                    .then(function () {
+                        console.log('Live reload server started on port:', kwargs.lrport);
+                        console.log('Press CTRL+C to quit ...');
+                        console.log('');
+                    });
+            })
+            .then(function () {
+                return startServer(args, kwargs);
             });
-        })
-        .then(function() {
-            return generateBook(args, kwargs);
-        });
     }
 };

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -10,8 +10,7 @@ var parsers = require('../parsers');
     @param {String} dir
     @return {Promise}
 */
-function watch(dir) {
-    var d = Promise.defer();
+function watch(dir, callback) {
     dir = path.resolve(dir);
 
     var toWatch = [
@@ -20,7 +19,7 @@ function watch(dir) {
 
     // Watch all parsable files
     parsers.extensions.forEach(function(ext) {
-        toWatch.push('**/*'+ext);
+        toWatch.push('**/*' + ext);
     });
 
     var watcher = chokidar.watch(toWatch, {
@@ -29,18 +28,12 @@ function watch(dir) {
         ignoreInitial: true
     });
 
-    watcher.once('all', function(e, filepath) {
-        watcher.close();
-
-        d.resolve(filepath);
+    watcher.on('all', function(e, filepath) {
+        callback(null, filepath);
     });
-    watcher.once('error', function(err) {
-        watcher.close();
-
-        d.reject(err);
+    watcher.on('error', function(err) {
+        callback(err);
     });
-
-    return d.promise;
 }
 
 module.exports = watch;

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -24,7 +24,7 @@ function watch(dir, callback) {
 
     var watcher = chokidar.watch(toWatch, {
         cwd: dir,
-        ignored: '_book/**',
+        ignored: ['_book/**', 'node_modules/**'],
         ignoreInitial: true
     });
 


### PR DESCRIPTION
Fixes https://github.com/GitbookIO/gitbook/issues/1829

The main thing is that there's no need to stop and start the server. This step was really slow on my computer, and would sometimes take > 45 seconds after the first few changes.

The other thing is that I'm no longer returning a promise from `watch.js`. There's no need to run `chokidar.watch` every time a file changes, we can just set it up once. I pass in a callback that is called every time, so it doesn't need to do any teardown or setup. 

When a file changes, I'm now calling the `regenerateBook` function to regenerate the files. This function also triggers livereload when it's done, and it checks to see if any files have been changed while it was busy. If there any files change during the generation, then it will keep re-running `regenerateBook` until there are no more changes. (Before, it would miss some changes if you save a file, and then save again before the generation had finished.)

The console output now looks like this:


```
$ gitbook serve
Live reload server started on port: 35729
Press CTRL+C to quit ...

Generating book ...
info: 9 plugins are installed
info: 8 explicitly listed
info: loading plugin "ga"... OK
info: loading plugin "livereload"... OK
info: loading plugin "highlight"... OK
info: loading plugin "search"... OK
info: loading plugin "lunr"... OK
info: loading plugin "fontsettings"... OK
info: loading plugin "theme-api"... OK
info: loading plugin "theme-default"... OK
info: found 18 pages
info: found 58 asset files
warn: "this.generator" property is deprecated, use "this.output.name" instead
warn: "navigation" property is deprecated
warn: "book" property is deprecated, use "this" directly instead
warn: "options" property is deprecated, use config.get(key) instead
info: >> generation finished with success in 3.9s !
Starting server ...
Serving book on http://localhost:4000
Regenerating book after change in SUMMARY.md
Queuing another regeneration after change in foo.md
Queuing another regeneration after change in foo.md
Queuing another regeneration after change in SUMMARY.md
info: 9 plugins are installed
info: 8 explicitly listed
info: loading plugin "ga"... OK
info: loading plugin "livereload"... OK
info: loading plugin "highlight"... OK
info: loading plugin "search"... OK
info: loading plugin "lunr"... OK
info: loading plugin "fontsettings"... OK
info: loading plugin "theme-api"... OK
info: loading plugin "theme-default"... OK
info: found 18 pages
info: found 58 asset files
info: >> generation finished with success in 11.5s !
Triggering livereload for [ 'SUMMARY.md', 'foo.md' ]
info: 9 plugins are installed
info: 8 explicitly listed
info: loading plugin "ga"... OK
info: loading plugin "livereload"... OK
info: loading plugin "highlight"... OK
info: loading plugin "search"... OK
info: loading plugin "lunr"... OK
info: loading plugin "fontsettings"... OK
info: loading plugin "theme-api"... OK
info: loading plugin "theme-default"... OK
info: found 17 pages
info: found 59 asset files
info: >> generation finished with success in 2.9s !
Triggering livereload for [ 'SUMMARY.md', 'foo.md' ]
```