### PR TITLE
Update for new macOS versions.

### DIFF
--- a/docs/ebook.md
+++ b/docs/ebook.md
@@ -25,6 +25,13 @@ Download the [Calibre application](https://calibre-ebook.com/download). After mo
 $ sudo ln -s ~/Applications/calibre.app/Contents/MacOS/ebook-convert /usr/bin
 ```
 
+After El Capitan you have to create `/usr/local/bin` if it doesn't exists, and create the symlink there:
+
+```
+$ mkdir -p /usr/local/bin 
+$ sudo ln -s /Applications/calibre.app/Contents/MacOS/ebook-convert /usr/local/bin
+```
+
 You can replace `/usr/bin` with any directory that is in your $PATH.
 
 ### Cover


### PR DESCRIPTION
On my machine the software was installed under `/Applications` and not `~/Applications`, also, the OS denied to create any symlinks in `/usr/bin` because of security reasons.