### PR TITLE
Revert crossOrigin="anonymous" for images

### DIFF
--- a/src/components/utils/Image.tsx
+++ b/src/components/utils/Image.tsx
@@ -280,7 +280,6 @@ async function ImagePicture(
         style,
         loading,
         fetchPriority,
-        crossOrigin: 'anonymous',
         ...rest,
         ...attrs,
     };


### PR DESCRIPTION
This PR reverts the introduction of `crossOrigin="anonymous"` as it prevents loading any external images that is not served with `Access-Control-Allow-Origin`.