### PR TITLE
Remove mask on page cover

### DIFF
--- a/src/components/PageBody/PageCover.tsx
+++ b/src/components/PageBody/PageCover.tsx
@@ -69,14 +69,7 @@ export async function PageCover(props: {
                     // Maximum size of the cover
                     { width: 1248 },
                 ]}
-                className={tcls(
-                    'w-full',
-                    'object-cover',
-                    'object-center',
-                    as === 'full'
-                        ? ['[mask-image:linear-gradient(rgba(0,0,0,1),_rgba(0,0,0,0.5))]']
-                        : null,
-                )}
+                className={tcls('w-full', 'object-cover', 'object-center')}
                 inlineStyle={{ aspectRatio: `${PAGE_COVER_SIZE.width}/${PAGE_COVER_SIZE.height}` }}
             />
         </div>


### PR DESCRIPTION
This PR removes the mask on page cover that is impacting content such as https://docs.tuum.com/api-cookbooks.
The mask is a difference with the GitBook editor that doesn't seem justified.