### PR TITLE
Fix display of parameter's description in OpenAPI block

### DIFF
--- a/packages/react-openapi/src/OpenAPISpec.tsx
+++ b/packages/react-openapi/src/OpenAPISpec.tsx
@@ -44,7 +44,12 @@ export function OpenAPISpec(props: { rawData: any; context: OpenAPIClientContext
                     <OpenAPISchemaProperties
                         properties={group.parameters.map((parameter) => ({
                             propertyName: parameter.name,
-                            schema: noReference(parameter.schema) ?? {},
+                            schema: ({
+                                // Description of the parameter is defined at the parameter level
+                                // we use display it if the schema doesn't override it
+                                description: parameter.description,
+                                ...(noReference(parameter.schema) ?? {}),
+                            }),
                             required: parameter.required,
                         }))}
                         context={context}

--- a/packages/react-openapi/src/OpenAPISpec.tsx
+++ b/packages/react-openapi/src/OpenAPISpec.tsx
@@ -44,12 +44,12 @@ export function OpenAPISpec(props: { rawData: any; context: OpenAPIClientContext
                     <OpenAPISchemaProperties
                         properties={group.parameters.map((parameter) => ({
                             propertyName: parameter.name,
-                            schema: ({
+                            schema: {
                                 // Description of the parameter is defined at the parameter level
                                 // we use display it if the schema doesn't override it
                                 description: parameter.description,
                                 ...(noReference(parameter.schema) ?? {}),
-                            }),
+                            },
                             required: parameter.required,
                         }))}
                         context={context}


### PR DESCRIPTION
The previous logic was ignoring the fact that OpenAPI parameters can have their own `description`.