### PR TITLE
Bump caches for documents.

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -558,7 +558,7 @@ export const getRevisionFile = batch<[string, string, string], RevisionFile | nu
  * Get a document by its ID.
  */
 export const getDocument = cache(
-    'api.getDocument',
+    'api.getDocument.v2',
     async (spaceId: string, documentId: string, options: CacheFunctionOptions) => {
         const response = await api().spaces.getDocumentById(
             spaceId,


### PR DESCRIPTION
In order to fix an issue where our caches were holding potentially stale or invalid data, we're bumping the document caches to force a refresh. This is coupled with internal changes on the GitBook side to fix the cause of the invalid data.