### PR TITLE
Set tracking prompt cookie age to 365days instead of a session cookie

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -69,7 +69,9 @@ async function fetchVisitorID(): Promise<string> {
  * Accept or reject cookies.
  */
 export function setCookiesTracking(enabled: boolean) {
-    cookies.set(GRANTED_COOKIE, enabled ? 'yes' : 'no');
+    cookies.set(GRANTED_COOKIE, enabled ? 'yes' : 'no', {
+        expires: 365,
+    });
 }
 
 /**


### PR DESCRIPTION
Closes RND-3184