### PR TITLE
Add HSTS and other security headers

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -178,6 +178,7 @@ export async function middleware(request: NextRequest) {
     headers.set('content-security-policy', csp);
     // Basic security headers
     headers.set('strict-transport-security', 'max-age=31536000');
+    headers.set('referrer-policy', 'no-referrer-when-downgrade');
     // Pass a x-forwarded-host and origin to ensure Next doesn't block server actions when proxied
     headers.set('x-forwarded-host', inputURL.host);
     headers.set('origin', inputURL.origin);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -176,6 +176,8 @@ export async function middleware(request: NextRequest) {
     // https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy
     headers.set('x-nonce', nonce);
     headers.set('content-security-policy', csp);
+    // Basic security headers
+    headers.set('strict-transport-security', 'max-age=31536000');
     // Pass a x-forwarded-host and origin to ensure Next doesn't block server actions when proxied
     headers.set('x-forwarded-host', inputURL.host);
     headers.set('origin', inputURL.origin);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -179,6 +179,7 @@ export async function middleware(request: NextRequest) {
     // Basic security headers
     headers.set('strict-transport-security', 'max-age=31536000');
     headers.set('referrer-policy', 'no-referrer-when-downgrade');
+    headers.set('x-content-type-options', 'nosniff');
     // Pass a x-forwarded-host and origin to ensure Next doesn't block server actions when proxied
     headers.set('x-forwarded-host', inputURL.host);
     headers.set('origin', inputURL.origin);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -176,10 +176,6 @@ export async function middleware(request: NextRequest) {
     // https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy
     headers.set('x-nonce', nonce);
     headers.set('content-security-policy', csp);
-    // Basic security headers
-    headers.set('strict-transport-security', 'max-age=31536000');
-    headers.set('referrer-policy', 'no-referrer-when-downgrade');
-    headers.set('x-content-type-options', 'nosniff');
     // Pass a x-forwarded-host and origin to ensure Next doesn't block server actions when proxied
     headers.set('x-forwarded-host', inputURL.host);
     headers.set('origin', inputURL.origin);
@@ -225,6 +221,10 @@ export async function middleware(request: NextRequest) {
 
     // Add Content Security Policy header
     response.headers.set('content-security-policy', csp);
+    // Basic security headers
+    response.headers.set('strict-transport-security', 'max-age=31536000');
+    response.headers.set('referrer-policy', 'no-referrer-when-downgrade');
+    response.headers.set('x-content-type-options', 'nosniff');
 
     const isPrefetch = request.headers.has('x-middleware-prefetch');
 


### PR DESCRIPTION
This PR adds a few easy and missing HTTP response headers for increased security on generated content:
- `Strict-Transport-Security: max-age=31536000` (1 year, the maximum value)
- `Referrer-Policy: no-referrer-when-downgrade` 
- `X-Content-Type-Options: nosniff`