### PR TITLE
Override site's spaces published URLs

### DIFF
--- a/src/app/(space)/fetch.ts
+++ b/src/app/(space)/fetch.ts
@@ -177,7 +177,13 @@ async function fetchParentSite(organizationId: string, siteId: string) {
 
     const spaces: Record<string, Space> = {};
     siteSpaces.forEach((siteSpace) => {
-        spaces[siteSpace.space.id] = siteSpace.space;
+        spaces[siteSpace.space.id] = {
+            ...siteSpace.space,
+            urls: {
+                ...siteSpace.space.urls,
+                published: siteSpace.urls.published,
+            },
+        };
     });
 
     return { parent: site, spaces: Object.values(spaces) };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -616,10 +616,9 @@ export const getSiteSpaceCustomizationFromAPI = cache(
             revalidateBefore: 60 * 60,
             tags: [
                 getAPICacheTag({
-                    tag: 'site-space',
+                    tag: 'site',
                     organization: organizationId,
                     site: siteId,
-                    siteSpace: siteSpaceId,
                 }),
             ],
         });
@@ -997,12 +996,6 @@ export function getAPICacheTag(
               tag: 'site';
               site: string;
               organization: string;
-          }
-        | {
-              tag: 'site-space';
-              site: string;
-              siteSpace: string;
-              organization: string;
           },
 ): string {
     switch (spec.tag) {
@@ -1016,8 +1009,6 @@ export function getAPICacheTag(
             return `synced-block:${spec.syncedBlock}`;
         case 'site':
             return `site:${spec.organization}:${spec.site}`;
-        case 'site-space':
-            return `site-space:${spec.organization}:${spec.site}:${spec.siteSpace}`;
         default:
             assertNever(spec);
     }


### PR DESCRIPTION
Temporary fix for now until site's are GA and we don't use `space.published` in the UI anymore