### PR TITLE
Avoid crashing Cloudflare Worker when syntax highlighting too many lines of code.

### DIFF
--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -42,7 +42,7 @@ async function waitForCookiesDialog(page: Page) {
 const testCases: TestsCase[] = [
     {
         name: 'GitBook Site',
-        baseUrl: 'https://gitbook.gitbook.io/gitbook-site/',
+        baseUrl: 'https://gitbook-sites.gitbook.io/gitbook-site/',
         tests: [
             {
                 name: 'Home',

--- a/src/app/(space)/(core)/~gitbook/pdf/page.tsx
+++ b/src/app/(space)/(core)/~gitbook/pdf/page.tsx
@@ -11,7 +11,7 @@ import { notFound } from 'next/navigation';
 import * as React from 'react';
 
 import { getContentPointer } from '@/app/(space)/fetch';
-import { DocumentView } from '@/components/DocumentView';
+import { DocumentView, createHighlightingContext } from '@/components/DocumentView';
 import { TrademarkLink } from '@/components/TableOfContents/Trademark';
 import { PolymorphicComponentProp } from '@/components/utils/types';
 import { getSpaceLanguage } from '@/intl/server';
@@ -216,6 +216,7 @@ async function PDFPageDocument(props: {
     const { space, page, refContext } = props;
 
     const document = page.documentId ? await getDocument(space.id, page.documentId) : null;
+    const shouldHighlightCode = createHighlightingContext();
 
     return (
         <PrintPage id={pagePDFContainerId(page)}>
@@ -238,6 +239,7 @@ async function PDFPageDocument(props: {
                         contentRefContext: refContext,
                         resolveContentRef: (ref) => resolveContentRef(ref, refContext),
                         getId: (id) => pagePDFContainerId(page, id),
+                        shouldHighlightCode,
                     }}
                 />
             ) : null}

--- a/src/components/Cookies/CookiesToast.tsx
+++ b/src/components/Cookies/CookiesToast.tsx
@@ -76,6 +76,7 @@ export function CookiesToast(props: { privacyPolicy?: string }) {
             </p>
             <button
                 onClick={() => setShow(false)}
+                aria-label={tString(language, 'cookies_close')}
                 className={tcls(
                     'absolute',
                     'top-3',
@@ -97,6 +98,7 @@ export function CookiesToast(props: { privacyPolicy?: string }) {
                 <Button
                     variant="primary"
                     size="small"
+                    aria-label={tString(language, 'cookies_accept')}
                     onClick={() => {
                         onUpdateState(true);
                     }}
@@ -106,6 +108,7 @@ export function CookiesToast(props: { privacyPolicy?: string }) {
                 <Button
                     variant="secondary"
                     size="small"
+                    aria-label={tString(language, 'cookies_reject')}
                     onClick={() => {
                         onUpdateState(false);
                     }}

--- a/src/components/DocumentView/CodeBlock/CodeBlock.tsx
+++ b/src/components/DocumentView/CodeBlock/CodeBlock.tsx
@@ -3,7 +3,7 @@ import { DocumentBlockCode, JSONDocument } from '@gitbook/api';
 import { tcls } from '@/lib/tailwind';
 
 import { CopyCodeButton } from './CopyCodeButton';
-import { highlight, HighlightLine, HighlightToken } from './highlight';
+import { highlight, HighlightLine, HighlightToken, plainHighlighting } from './highlight';
 import { BlockProps } from '../Block';
 import { DocumentContext } from '../DocumentView';
 import { Inline } from '../Inline';
@@ -15,7 +15,8 @@ import './theme.css';
  */
 export async function CodeBlock(props: BlockProps<DocumentBlockCode>) {
     const { block, document, style, context } = props;
-    const lines = await highlight(block);
+    const withHighlighting = context.shouldHighlightCode();
+    const lines = withHighlighting ? await highlight(block) : plainHighlighting(block);
 
     const id = block.key!;
 

--- a/src/components/DocumentView/CodeBlock/PlainCodeBlock.tsx
+++ b/src/components/DocumentView/CodeBlock/PlainCodeBlock.tsx
@@ -50,6 +50,7 @@ export function PlainCodeBlock(props: { code: string; syntax: string }) {
                 mode: 'default',
                 contentRefContext: null,
                 resolveContentRef: async () => null,
+                shouldHighlightCode: () => true,
             }}
             block={block}
             ancestorBlocks={[]}

--- a/src/components/DocumentView/CodeBlock/createHighlightingContext.ts
+++ b/src/components/DocumentView/CodeBlock/createHighlightingContext.ts
@@ -1,0 +1,16 @@
+const CODE_HIGHLIGHT_BLOCK_LIMIT = 50;
+
+/**
+ * Protect against memory issues when highlighting a large number of code blocks.
+ * This context only allows 50 code blocks per render to be highlighted.
+ * Once highlighting can scale up to a large number of code blocks, it can be removed.
+ *
+ * https://linear.app/gitbook-x/issue/RND-3588/gitbook-open-code-syntax-highlighting-runs-out-of-memory-after-a
+ */
+export function createHighlightingContext() {
+    let count = 0;
+    return () => {
+        count += 1;
+        return count < CODE_HIGHLIGHT_BLOCK_LIMIT;
+    };
+}

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -47,8 +47,8 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     }
 
     const overLimit = await renderer.runBlocking(async () => {
-            lineCount += block.nodes.length;
-            blockCount++;
+        lineCount += block.nodes.length;
+        blockCount++;
         return lineCount > LINE_LIMIT;
     })
 
@@ -72,7 +72,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     });
 
     console.log(
-        `${JSON.stringify({ blockCount, lineCount })} block has ${
+        `${block.key} ${JSON.stringify({ blockCount, lineCount })} block has ${
             block.nodes.length
         } lines, ${code.length} characters ${inlines.length} inlines`,
     );

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -70,15 +70,17 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         const highlighter = await loadHighlighter();
         await loadHighlighterLanguage(highlighter, langName);
 
+        const start = Date.now();
         const lines = highlighter.codeToTokensBase(code, {
             lang: langName,
             tokenizeMaxLineLength: 120,
         });
+        const end = Date.now() - start;
 
         let currentIndex = 0;
 
         console.log(
-            `${block.key} code len: ${code.length} lineCountBefore: ${lineCountBefore} tokenCount: ${tokenCount}`,
+            `${block.key} ${end - start}ms code len: ${code.length} lineCountBefore: ${lineCountBefore} tokenCount: ${tokenCount}`,
         );
         return lines.map((tokens, index) => {
             tokenCount += tokens.length;

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -66,23 +66,19 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
             return a.start - b.start;
         });
 
-        const lineCountBefore = lineCount;
         const highlighter = await loadHighlighter();
         await loadHighlighterLanguage(highlighter, langName);
+        lineCount += block.nodes.length;
 
         const start = Date.now();
         const lines = highlighter.codeToTokensBase(code, {
             lang: langName,
             tokenizeMaxLineLength: 120,
         });
-        const end = Date.now() - start;
+        const duration = Date.now() - start;
 
         let currentIndex = 0;
-
-        console.log(
-            `${block.key} ${end - start}ms code len: ${code.length} lineCountBefore: ${lineCountBefore} tokenCount: ${tokenCount}`,
-        );
-        return lines.map((tokens, index) => {
+        const result = lines.map((tokens, index) => {
             tokenCount += tokens.length;
             const lineBlock = block.nodes[index];
             const result: HighlightToken[] = [];
@@ -98,6 +94,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
             };
 
             while (tokens.length > 0) {
+                console.log(`tokens.length: ${tokens.length}`)
                 result.push(...matchTokenAndInlines(eatToken, inlines));
             }
 
@@ -108,6 +105,12 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
                 tokens: result,
             };
         });
+
+        console.log(
+            `${block.key} ${duration}ms code len: ${code.length} lineCountBefore: ${lineCount} tokenCount: ${tokenCount} created lines: ${result.length}`,
+        );
+
+        return result;
     });
 }
 

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -36,12 +36,10 @@ type PositionedToken = ThemedToken & { start: number; end: number };
  */
 export async function highlight(block: DocumentBlockCode): Promise<HighlightLine[]> {
     const langName = block.data.syntax ? getLanguageForSyntax(block.data.syntax) : null;
-
     if (!langName) {
         // Language not found, fallback to plain highlighting
         return plainHighlighting(block);
     }
-    debugger;
 
     const inlines: InlineIndexed[] = [];
     const code = getPlainCodeBlock(block, inlines);

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -79,32 +79,33 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         const duration = Date.now() - start;
 
         let currentIndex = 0;
-        const result = lines.map((tokens, index) => {
-            tokenCount += tokens.length;
-            const lineBlock = block.nodes[index];
-            const result: HighlightToken[] = [];
+        const result = plainHighlighting(block);
+        // const result = lines.map((tokens, index) => {
+        //     tokenCount += tokens.length;
+        //     const lineBlock = block.nodes[index];
+        //     const result: HighlightToken[] = [];
 
-            const eatToken = (): PositionedToken | null => {
-                const token = tokens.shift();
-                if (token) {
-                    currentIndex += token.content.length;
-                }
-                return token
-                    ? { ...token, start: currentIndex - token.content.length, end: currentIndex }
-                    : null;
-            };
+        //     const eatToken = (): PositionedToken | null => {
+        //         const token = tokens.shift();
+        //         if (token) {
+        //             currentIndex += token.content.length;
+        //         }
+        //         return token
+        //             ? { ...token, start: currentIndex - token.content.length, end: currentIndex }
+        //             : null;
+        //     };
 
-            while (tokens.length > 0) {
-                result.push(...matchTokenAndInlines(eatToken, inlines));
-            }
+        //     while (tokens.length > 0) {
+        //         result.push(...matchTokenAndInlines(eatToken, inlines));
+        //     }
 
-            currentIndex += 1; // for the \n
+        //     currentIndex += 1; // for the \n
 
-            return {
-                highlighted: !!lineBlock.data.highlighted,
-                tokens: result,
-            };
-        });
+        //     return {
+        //         highlighted: !!lineBlock.data.highlighted,
+        //         tokens: result,
+        //     };
+        // });
 
         
         console.log(

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -325,7 +325,6 @@ const loadHighlighter = singleton(async () => {
             // loads it on its own.
             //
             // Otherwise for Vercel/Cloudflare, we need to load it ourselves.
-            console.log('load the wasm');
             await loadWasm((obj) => WebAssembly.instantiate(onigWasm, obj));
         }
         const highlighter = await getHighlighter({

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -30,6 +30,7 @@ type InlineIndexed = { inline: any; start: number; end: number };
 type PositionedToken = ThemedToken & { start: number; end: number };
 
 const tokenMutex = asyncMutexFunction();
+let running = 0;
 
 /**
  * Highlight a code block while preserving inline elements.
@@ -53,13 +54,17 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     await loadHighlighterLanguage(highlighter, langName);
 
     const lines = await tokenMutex.runBlocking(async () => {
-        return highlighter.codeToTokensBase(code, {
+        console.log(`running... ${running}`)
+        running ++;
+        const lines = highlighter.codeToTokensBase(code, {
             lang: langName,
             tokenizeMaxLineLength: 120,
         });
+        running--;
+        return lines;
     })
     
-    console.log(`block has ${block.nodes.length} lines, ${code.length} characters ${inlines.length} inlines ${JSON.stringify(process.memoryUsage())}`);
+    console.log(`${running} block has ${block.nodes.length} lines, ${code.length} characters ${inlines.length} inlines`);
     let currentIndex = 0;
 
     return lines.map((tokens, index) => {

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -15,6 +15,8 @@ import { asyncMutexFunction, singleton } from '@/lib/async';
 import { getNodeText } from '@/lib/document';
 import { trace } from '@/lib/tracing';
 
+import { DocumentContext } from '../DocumentView';
+
 export type HighlightLine = {
     highlighted: boolean;
     tokens: HighlightToken[];
@@ -30,14 +32,6 @@ type InlineIndexed = { inline: any; start: number; end: number };
 type PositionedToken = ThemedToken & { start: number; end: number };
 
 /**
- * Due to a combination of memory limitations of Cloudflare workers and the memory
- * cost of shiki, we need to set a limit on the number of blocks we can highlight
- * in a single page.
- */
-let blockCount = 0;
-const BLOCK_LIMIT = 50;
-
-/**
  * Highlight a code block while preserving inline elements.
  */
 export async function highlight(block: DocumentBlockCode): Promise<HighlightLine[]> {
@@ -47,12 +41,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         // Language not found, fallback to plain highlighting
         return plainHighlighting(block);
     }
-
-    blockCount++;
-    if (blockCount > BLOCK_LIMIT) {
-        // Too many blocks and we risk crashing the worker, fallback to plain highlighting
-        return plainHighlighting(block);
-    }
+    debugger;
 
     const inlines: InlineIndexed[] = [];
     const code = getPlainCodeBlock(block, inlines);

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -52,13 +52,14 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         return plainHighlighting(block);
     }
 
-    lineCount += block.nodes.length;
-    if (lineCount > LINE_LIMIT) {
-        // Too many lines and we risk crashing the worker, fallback to plain highlighting
-        return plainHighlighting(block);
-    }
+    // lineCount += block.nodes.length;
+    // if (lineCount > LINE_LIMIT) {
+    //     // Too many lines and we risk crashing the worker, fallback to plain highlighting
+    //     return plainHighlighting(block);
+    // }
 
     return runner.runBlocking(async () => {
+        console.log(`start ${block.key}`)
         const inlines: InlineIndexed[] = [];
         const code = getPlainCodeBlock(block, inlines);
 
@@ -94,7 +95,6 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
             };
 
             while (tokens.length > 0) {
-                console.log(`tokens.length: ${tokens.length}`)
                 result.push(...matchTokenAndInlines(eatToken, inlines));
             }
 
@@ -106,10 +106,10 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
             };
         });
 
+        
         console.log(
-            `${block.key} ${duration}ms code len: ${code.length} lineCountBefore: ${lineCount} tokenCount: ${tokenCount} created lines: ${result.length}`,
+            `end ${block.key} ${duration}ms code len: ${code.length} lineCountBefore: ${lineCount} tokenCount: ${tokenCount} created lines: ${result.length}`,
         );
-
         return result;
     });
 }

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -35,7 +35,7 @@ type PositionedToken = ThemedToken & { start: number; end: number };
  * in a single page.
  */
 let blockCount = 0;
-const BLOCK_LIMIT = 60;
+const BLOCK_LIMIT = 50;
 
 const runner = asyncMutexFunction();
 

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -37,8 +37,10 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         return plainHighlighting(block);
     }
 
+    
     const inlines: InlineIndexed[] = [];
     const code = getPlainCodeBlock(block, inlines);
+    console.log(`block has ${block.nodes.length} lines, ${code.length} characters ${inlines.length} inlines`);
 
     inlines.sort((a, b) => {
         return a.start - b.start;
@@ -49,7 +51,6 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     const lines = highlighter.codeToTokensBase(code, {
         lang: langName,
         tokenizeMaxLineLength: 120,
-        includeExplanation: false
     });
     let currentIndex = 0;
 

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -31,12 +31,11 @@ type PositionedToken = ThemedToken & { start: number; end: number };
 
 /**
  * Due to a combination of memory limitations of Cloudflare workers and the memory
- * cost of shiki, we need to set a limit on the number of lines we can highlight.
- *
- * This is done per invocation of the Cloudflare worker, so we can store it in-memory.
+ * cost of shiki, we need to set a limit on the number of blocks we can highlight
+ * in a single page.
  */
 let blockCount = 0;
-const BLOCK_LIMIT = 50;
+const BLOCK_LIMIT = 60;
 
 const runner = asyncMutexFunction();
 
@@ -53,7 +52,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
 
     blockCount++;
     if (blockCount > BLOCK_LIMIT) {
-        // Too many lines and we risk crashing the worker, fallback to plain highlighting
+        // Too many blocks and we risk crashing the worker, fallback to plain highlighting
         return plainHighlighting(block);
     }
 

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -73,7 +73,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         lineCount += block.nodes.length;
 
         
-        const lines = highlighter.codeToTokensBase(code.replace('\\', ''), {
+        const lines = highlighter.codeToTokensBase(code.replace('\\', '').replaceAll(/[^\x00-\x7F]+/gi, ''), {
             lang: langName,
             tokenizeMaxLineLength: 120,
         });

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -52,10 +52,6 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         return plainHighlighting(block);
     }
 
-    if (block.key === 'dc6e6efdb1ed4981b71d5d3b02087996') {
-        return plainHighlighting(block);
-    }
-
     // lineCount += block.nodes.length;
     // if (lineCount > LINE_LIMIT) {
     //     // Too many lines and we risk crashing the worker, fallback to plain highlighting
@@ -71,7 +67,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
             return a.start - b.start;
         });
 
-        const highlighter = await loadHighlighter();
+        const highlighter = await loadHighlighter(tokenCount > 4000);
         await loadHighlighterLanguage(highlighter, langName);
         lineCount += block.nodes.length;
 

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -312,7 +312,7 @@ function cleanupLine(line: string): string {
     return line.replace(/\r/g, '');
 }
 
-let memoryHighlighter = undefined;
+let memoryHighlighter: HighlighterGeneric<any, any> | undefined = undefined;
 
 const loadHighlighterSingleton = singleton(async () => {
     return await trace('highlighting.loadHighlighter', async () => {

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -29,11 +29,9 @@ type InlineIndexed = { inline: any; start: number; end: number };
 
 type PositionedToken = ThemedToken & { start: number; end: number };
 
-let counts = {
-    blocks: 0,
-    lines: 0,
-    characters: 0,
-}
+let blockCount = 0;
+let lineCount = 0;
+let charCount = 0;
 
 /**
  * Highlight a code block while preserving inline elements.
@@ -53,9 +51,9 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         return a.start - b.start;
     });
 
-    counts.blocks += 1;
-    counts.lines += block.nodes.length;
-    counts.characters += code.length;
+    blockCount += 1;
+    lineCount += block.nodes.length;
+    charCount += code.length;
     
     const highlighter = await loadHighlighter();
     await loadHighlighterLanguage(highlighter, langName);
@@ -66,7 +64,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
             tokenizeMaxLineLength: 120,
         });
     
-    console.log(`${JSON.stringify(counts)} block has ${block.nodes.length} lines, ${code.length} characters ${inlines.length} inlines`);
+    console.log(`${JSON.stringify({ blockCount, lineCount, charCount })} block has ${block.nodes.length} lines, ${code.length} characters ${inlines.length} inlines`);
     let currentIndex = 0;
 
     return lines.map((tokens, index) => {

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -37,8 +37,6 @@ type PositionedToken = ThemedToken & { start: number; end: number };
 let blockCount = 0;
 const BLOCK_LIMIT = 50;
 
-const runner = asyncMutexFunction();
-
 /**
  * Highlight a code block while preserving inline elements.
  */

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -74,7 +74,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         lineCount += block.nodes.length;
         blockCount += 1;
 
-        if (blockCount >= 100) {
+        if (blockCount >= 50) {
             return plainHighlighting(block);
         }
         

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -30,7 +30,7 @@ type InlineIndexed = { inline: any; start: number; end: number };
 type PositionedToken = ThemedToken & { start: number; end: number };
 
 const tokenMutex = asyncMutexFunction();
-let running = 0;
+let count = 0;
 
 /**
  * Highlight a code block while preserving inline elements.
@@ -54,17 +54,15 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     await loadHighlighterLanguage(highlighter, langName);
 
     const lines = await tokenMutex.runBlocking(async () => {
-        console.log(`running... ${running}`)
-        running ++;
+        count++;
         const lines = highlighter.codeToTokensBase(code, {
             lang: langName,
             tokenizeMaxLineLength: 120,
         });
-        running--;
         return lines;
     })
     
-    console.log(`${running} block has ${block.nodes.length} lines, ${code.length} characters ${inlines.length} inlines`);
+    console.log(`${count} block has ${block.nodes.length} lines, ${code.length} characters ${inlines.length} inlines`);
     let currentIndex = 0;
 
     return lines.map((tokens, index) => {

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -34,13 +34,20 @@ let blockCount = 0;
 let lineCount = 0;
 let charCount = 0;
 
+const LINE_LIMIT = 1000;
+
 /**
  * Highlight a code block while preserving inline elements.
  */
 export async function highlight(block: DocumentBlockCode): Promise<HighlightLine[]> {
     const langName = block.data.syntax ? getLanguageForSyntax(block.data.syntax) : null;
+    
     if (!langName) {
         // Language not found, fallback to plain highlighting
+        return plainHighlighting(block);
+    }
+
+    if (lineCount + block.nodes.length > LINE_LIMIT) {
         return plainHighlighting(block);
     }
 

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -30,7 +30,7 @@ type InlineIndexed = { inline: any; start: number; end: number };
 type PositionedToken = ThemedToken & { start: number; end: number };
 
 let lineCount = 0;
-const LINE_LIMIT = 1000;
+const LINE_LIMIT = 750;
 const renderer = asyncMutexFunction();
 
 /**
@@ -60,10 +60,10 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     const highlighter = await loadHighlighter();
     await loadHighlighterLanguage(highlighter, langName);
 
-    const lines = await renderer.runBlocking(async () => highlighter.codeToTokensBase(code, {
+    const lines = highlighter.codeToTokensBase(code, {
         lang: langName,
         tokenizeMaxLineLength: 120,
-    }));
+    });
 
     console.log(
         `${block.key} lines:${lineCount} block has ${

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -73,7 +73,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         lineCount += block.nodes.length;
 
         
-        const lines = highlighter.codeToTokensBase(code, {
+        const lines = highlighter.codeToTokensBase(code.replace('\\', ''), {
             lang: langName,
             tokenizeMaxLineLength: 120,
         });

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -31,51 +31,7 @@ type PositionedToken = ThemedToken & { start: number; end: number };
  * Highlight a code block while preserving inline elements.
  */
 export async function highlight(block: DocumentBlockCode): Promise<HighlightLine[]> {
-    const langName = block.data.syntax ? getLanguageForSyntax(block.data.syntax) : null;
-    if (!langName) {
-        // Language not found, fallback to plain highlighting
-        return plainHighlighting(block);
-    }
-
-    const inlines: InlineIndexed[] = [];
-    const code = getPlainCodeBlock(block, inlines);
-
-    inlines.sort((a, b) => {
-        return a.start - b.start;
-    });
-
-    const highlighter = await loadHighlighter();
-    await loadHighlighterLanguage(langName);
-    const lines = highlighter.codeToTokensBase(code, {
-        lang: langName,
-    });
-    let currentIndex = 0;
-
-    return lines.map((tokens, index) => {
-        const lineBlock = block.nodes[index];
-        const result: HighlightToken[] = [];
-
-        const eatToken = (): PositionedToken | null => {
-            const token = tokens.shift();
-            if (token) {
-                currentIndex += token.content.length;
-            }
-            return token
-                ? { ...token, start: currentIndex - token.content.length, end: currentIndex }
-                : null;
-        };
-
-        while (tokens.length > 0) {
-            result.push(...matchTokenAndInlines(eatToken, inlines));
-        }
-
-        currentIndex += 1; // for the \n
-
-        return {
-            highlighted: !!lineBlock.data.highlighted,
-            tokens: result,
-        };
-    });
+    return plainHighlighting(block);
 }
 
 /**

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -318,6 +318,11 @@ const loadLanguagesMutex = asyncMutexFunction();
 async function loadHighlighterLanguage(lang: keyof typeof bundledLanguages) {
     await loadLanguagesMutex.runBlocking(async () => {
         const highlighter = await loadHighlighter();
+
+        if (highlighter.getLoadedLanguages().includes(lang)) {
+            return;
+        }
+
         await trace(
             `highlighting.loadLanguage(${lang})`,
             async () => await highlighter.loadLanguage(lang),

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -49,6 +49,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     const lines = highlighter.codeToTokensBase(code, {
         lang: langName,
         tokenizeMaxLineLength: 120,
+        includeExplanation: false
     });
     let currentIndex = 0;
 

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -54,7 +54,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     const highlighter = await loadHighlighter();
     await loadHighlighterLanguage(highlighter, langName);
 
-    renderer.runBlocking(async () => {
+    const lines = await renderer.runBlocking(async () => {
         blockCount += 1;
         lineCount += block.nodes.length;
         charCount += code.length;

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -52,6 +52,10 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         return plainHighlighting(block);
     }
 
+    if (block.key === 'dc6e6efdb1ed4981b71d5d3b02087996') {
+        return plainHighlighting(block);
+    }
+
     // lineCount += block.nodes.length;
     // if (lineCount > LINE_LIMIT) {
     //     // Too many lines and we risk crashing the worker, fallback to plain highlighting

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -31,7 +31,7 @@ type PositionedToken = ThemedToken & { start: number; end: number };
 
 let lineCount = 0;
 
-const LINE_LIMIT = 1000;
+const LINE_LIMIT = 500;
 
 /**
  * Highlight a code block while preserving inline elements.
@@ -45,7 +45,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     }
 
     lineCount += block.nodes.length;
-    console.log(`highlight, lineCount ${lineCount}`);
+    console.log(`highlight, lineCount ${lineCount}, ${lineCount > LINE_LIMIT ? 'simple' : 'complex'}`);
     if (lineCount > LINE_LIMIT) {
         return plainHighlighting(block);
     }

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -30,8 +30,8 @@ type InlineIndexed = { inline: any; start: number; end: number };
 type PositionedToken = ThemedToken & { start: number; end: number };
 
 let lineCount = 0;
-
-const LINE_LIMIT = 500;
+const LINE_LIMIT = 1000;
+const renderer = asyncMutexFunction();
 
 /**
  * Highlight a code block while preserving inline elements.
@@ -60,10 +60,10 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     const highlighter = await loadHighlighter();
     await loadHighlighterLanguage(highlighter, langName);
 
-    const lines = highlighter.codeToTokensBase(code, {
+    const lines = await renderer.runBlocking(async () => highlighter.codeToTokensBase(code, {
         lang: langName,
         tokenizeMaxLineLength: 120,
-    });
+    }));
 
     console.log(
         `${block.key} lines:${lineCount} block has ${

--- a/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/src/components/DocumentView/CodeBlock/highlight.ts
@@ -29,8 +29,6 @@ type InlineIndexed = { inline: any; start: number; end: number };
 
 type PositionedToken = ThemedToken & { start: number; end: number };
 
-const renderer = asyncMutexFunction();
-let blockCount = 0;
 let lineCount = 0;
 
 const LINE_LIMIT = 1000;
@@ -46,13 +44,9 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
         return plainHighlighting(block);
     }
 
-    const overLimit = await renderer.runBlocking(async () => {
-        lineCount += block.nodes.length;
-        blockCount++;
-        return lineCount > LINE_LIMIT;
-    })
-
-    if (overLimit) {
+    lineCount += block.nodes.length;
+    console.log(`highlight, lineCount ${lineCount}`);
+    if (lineCount > LINE_LIMIT) {
         return plainHighlighting(block);
     }
 
@@ -72,7 +66,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
     });
 
     console.log(
-        `${block.key} ${JSON.stringify({ blockCount, lineCount })} block has ${
+        `${block.key} lines:${lineCount} block has ${
             block.nodes.length
         } lines, ${code.length} characters ${inlines.length} inlines`,
     );

--- a/src/components/DocumentView/CodeBlock/index.ts
+++ b/src/components/DocumentView/CodeBlock/index.ts
@@ -1,2 +1,3 @@
 export * from './CodeBlock';
 export * from './PlainCodeBlock';
+export * from './createHighlightingContext';

--- a/src/components/DocumentView/DocumentView.tsx
+++ b/src/components/DocumentView/DocumentView.tsx
@@ -36,6 +36,16 @@ export interface DocumentContext {
      * Transform an ID to be added to the DOM.
      */
     getId?: (id: string) => string;
+
+    /**
+     * Returns true if the given code block should be highlighted.
+     * This function was added to protect against memory issues when highlighting
+     * a large number of code blocks.
+     * Once highlighting can scale up to a large number of code blocks, it can be removed.
+     *
+     * https://linear.app/gitbook-x/issue/RND-3588/gitbook-open-code-syntax-highlighting-runs-out-of-memory-after-a
+     */
+    shouldHighlightCode: () => boolean;
 }
 
 export interface DocumentContextProps {

--- a/src/components/DocumentView/index.ts
+++ b/src/components/DocumentView/index.ts
@@ -1,1 +1,2 @@
 export * from './DocumentView';
+export { createHighlightingContext } from './CodeBlock';

--- a/src/components/PageBody/PageBody.tsx
+++ b/src/components/PageBody/PageBody.tsx
@@ -17,13 +17,6 @@ import { DocumentView, createHighlightingContext } from '../DocumentView';
 import { PageFeedbackForm } from '../PageFeedback';
 import { DateRelative } from '../primitives';
 
-/**
- * Due to a combination of memory limitations of Cloudflare workers and the memory
- * cost of shiki, we need to set a limit on the number of blocks we can highlight
- * in a single page.
- */
-const CODE_HIGHLIGHT_BLOCK_LIMIT = 50;
-
 export function PageBody(props: {
     space: Space;
     contentTarget: ContentTarget;

--- a/src/components/PageBody/PageBody.tsx
+++ b/src/components/PageBody/PageBody.tsx
@@ -13,9 +13,16 @@ import { PageCover } from './PageCover';
 import { PageFooterNavigation } from './PageFooterNavigation';
 import { PageHeader } from './PageHeader';
 import { TrackPageView } from './TrackPageView';
-import { DocumentView } from '../DocumentView';
+import { DocumentView, createHighlightingContext } from '../DocumentView';
 import { PageFeedbackForm } from '../PageFeedback';
 import { DateRelative } from '../primitives';
+
+/**
+ * Due to a combination of memory limitations of Cloudflare workers and the memory
+ * cost of shiki, we need to set a limit on the number of blocks we can highlight
+ * in a single page.
+ */
+const CODE_HIGHLIGHT_BLOCK_LIMIT = 50;
 
 export function PageBody(props: {
     space: Space;
@@ -32,6 +39,7 @@ export function PageBody(props: {
     const asFullWidth = document ? hasFullWidthBlock(document) : false;
     const language = getSpaceLanguage(customization);
     const updatedAt = page.updatedAt ?? page.createdAt;
+    const shouldHighlightCode = createHighlightingContext();
 
     return (
         <>
@@ -73,6 +81,7 @@ export function PageBody(props: {
                             contentRefContext: context,
                             resolveContentRef: (ref, options) =>
                                 resolveContentRef(ref, context, options),
+                            shouldHighlightCode,
                         }}
                     />
                 ) : (

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -161,6 +161,7 @@ function transformAnswer(
                     mode: 'default',
                     contentRefContext: null,
                     resolveContentRef: async () => null,
+                    shouldHighlightCode: () => false,
                 }}
                 style={['space-y-5']}
             />

--- a/src/lib/async.ts
+++ b/src/lib/async.ts
@@ -233,7 +233,6 @@ export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
 
     return async () => {
         if (cachedResult !== UndefinedSymbol) {
-            console.log(`singleton: return early`);
             // Result is actually shared between requests
             return cachedResult;
         }
@@ -242,7 +241,6 @@ export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
         const ctx = await getGlobalContext();
         const current = states.get(ctx);
         if (current) {
-            console.log(`singleton: return from state`);
             return current;
         }
 

--- a/src/lib/async.ts
+++ b/src/lib/async.ts
@@ -228,27 +228,30 @@ const UndefinedSymbol = Symbol('Undefined');
  * where I/O cannot be performed on behalf of a different request.
  */
 export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
-    let cachedResult: R | typeof UndefinedSymbol = UndefinedSymbol;
+    let cachedResult: Promise<R> | typeof UndefinedSymbol = UndefinedSymbol;
     const states = new WeakMap<object, Promise<R>>();
 
     return async () => {
+        console.log('cachedResult', cachedResult === UndefinedSymbol);
         if (cachedResult !== UndefinedSymbol) {
             // Result is actually shared between requests
             return cachedResult;
         }
 
         // Promises are not shared between requests in Cloudflare Workers
-        const ctx = await getGlobalContext();
-        const current = states.get(ctx);
-        if (current) {
-            return current;
-        }
+        // const ctx = await getGlobalContext();
+        // const current = states.get(ctx);
+        // if (current) {
+        //     console.log(`states.get`)
+        //     return current;
+        // }
 
         const promise = execute();
-        states.set(ctx, promise);
+        console.log(`states miss, set cachedResult`);
+        cachedResult = promise;
+        // states.set(ctx, promise);
 
         const result = await promise;
-        cachedResult = result;
         return result;
     };
 }

--- a/src/lib/async.ts
+++ b/src/lib/async.ts
@@ -227,13 +227,13 @@ const UndefinedSymbol = Symbol('Undefined');
  * Wrap a singleton operation in a safe way for Cloudflare worker
  * where I/O cannot be performed on behalf of a different request.
  */
-export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
+export function singleton<R>(execute: () => Promise<R>): (force?: boolean) => Promise<R> {
     let cachedResult: Promise<R> | typeof UndefinedSymbol = UndefinedSymbol;
     const states = new WeakMap<object, Promise<R>>();
 
-    return async () => {
+    return async (force) => {
         // console.log('cachedResult', cachedResult === UndefinedSymbol);
-        if (cachedResult !== UndefinedSymbol) {
+        if (!force && cachedResult !== UndefinedSymbol) {
             // Result is actually shared between requests
             return cachedResult;
         }

--- a/src/lib/async.ts
+++ b/src/lib/async.ts
@@ -233,6 +233,7 @@ export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
 
     return async () => {
         if (cachedResult !== UndefinedSymbol) {
+            console.log(`singleton: return early`);
             // Result is actually shared between requests
             return cachedResult;
         }
@@ -241,10 +242,12 @@ export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
         const ctx = await getGlobalContext();
         const current = states.get(ctx);
         if (current) {
+            console.log(`singleton: return from state`);
             return current;
         }
 
         const promise = execute();
+        console.log(`set state`);
         states.set(ctx, promise);
 
         const result = await promise;

--- a/src/lib/async.ts
+++ b/src/lib/async.ts
@@ -245,7 +245,6 @@ export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
         }
 
         const promise = execute();
-        console.log(`set state`);
         states.set(ctx, promise);
 
         const result = await promise;

--- a/src/lib/async.ts
+++ b/src/lib/async.ts
@@ -232,7 +232,7 @@ export function singleton<R>(execute: () => Promise<R>): () => Promise<R> {
     const states = new WeakMap<object, Promise<R>>();
 
     return async () => {
-        console.log('cachedResult', cachedResult === UndefinedSymbol);
+        // console.log('cachedResult', cachedResult === UndefinedSymbol);
         if (cachedResult !== UndefinedSymbol) {
             // Result is actually shared between requests
             return cachedResult;


### PR DESCRIPTION
For pages with 100s of lines of code, the Cloudflare worker crashes.  After a lot of investigation, it seems that Shiki uses more memory as the rendering goes on.

Code blocks are rendered in parallel thanks to Next, so it's possible to have multiple Shiki tokenizations happening at once. But even after having code blocks render sequentially (no more than one tokenization operation at a time), a page with 100+ blocks will still crash from memory.

I've shipped a hotfix that stops code highlighting after 50 blocks just so that the pages don't crash anymore. Otherwise longer term fixes would be:
- A more powerful Worker :pray:
- Doing syntax highlighting client-side (no support yet in Shiki as the onigasm library is not supported in browsers yet)
- More investigation into the memory leak, it's possible that only certain lines of code cause a memory explosion

Future work tracked here: https://linear.app/gitbook-x/issue/RND-3588/gitbook-open-code-syntax-highlighting-runs-out-of-memory-after-a