### PR TITLE
Pass a nonce to the script for cdn.iframe.ly/embed.js

### DIFF
--- a/src/components/DocumentView/Embed.tsx
+++ b/src/components/DocumentView/Embed.tsx
@@ -3,6 +3,7 @@ import Script from 'next/script';
 
 import { Card } from '@/components/primitives';
 import { api } from '@/lib/api';
+import { getContentSecurityPolicyNonce } from '@/lib/csp';
 import { tcls } from '@/lib/tailwind';
 
 import { BlockProps } from './Block';
@@ -23,7 +24,12 @@ export async function Embed(props: BlockProps<DocumentBlockEmbed>) {
                         }}
                     />
                     {/* We load the iframely script to resize the embed iframes dynamically */}
-                    <Script src="https://cdn.iframe.ly/embed.js" defer async />
+                    <Script
+                        src="https://cdn.iframe.ly/embed.js"
+                        defer
+                        async
+                        nonce={getContentSecurityPolicyNonce()}
+                    />
                 </>
             ) : (
                 <Card


### PR DESCRIPTION
To fix:

<img width="1287" alt="Screenshot 2024-04-18 at 08 25 25" src="https://github.com/GitbookIO/gitbook/assets/845425/0fd6c0f2-9f36-4ad4-be88-8390ed223b66">

It looks like host based allowlist is disabled.