### PR TITLE
Fix multi-id mode and va e2e tests when ran locally

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -466,7 +466,10 @@ async function lookupSpaceInMultiIdMode(request: NextRequest, url: URL): Promise
                 httpOnly: true,
                 maxAge: 60 * 30,
                 secure: process.env.NODE_ENV === 'production',
-                sameSite: 'none',
+                // When using multi-id mode in local env (localhost) we need to use sameSite = 'lax'
+                // otherwise cookies can't be set.
+                // Use sameSite = none in any other environment.
+                sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
             },
         },
     };
@@ -682,7 +685,10 @@ function getLookupResultForVisitorAuth(
                 value: getVisitorAuthCookieValue(basePath, visitorAuthToken),
                 options: {
                     httpOnly: true,
-                    sameSite: 'none',
+                    // When running E2E tests locally against local env we need to use sameSite = 'lax'
+                    // otherwise cookies can't be set and VA tests fails.
+                    // Use sameSite = none in any other environment.
+                    sameSite: process.env.NODE_ENV !== 'development' ? 'none' : 'lax',
                     secure: process.env.NODE_ENV === 'production',
                     maxAge: 7 * 24 * 60 * 60,
                 },


### PR DESCRIPTION
This PR aims to prevent the e2e va test to fail when ran against local env (localhost).

VA E2E tests are currently failing because we use a cookie to store the va token on initial request but use `sameSite = none`.  But in localhost env the cookie will not be properly set/retrieved because of that policy.

As a result, the test fails with a `Authentication missing to access this content` error.

The same issue happens when testing multi-id mode (preview) locally as we store the content token passed in the preview URL into a cookie with the same policy.

| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2024-04-19 at 16 48 42](https://github.com/GitbookIO/gitbook/assets/1927278/ffa3024e-440f-4618-b71b-0ff17ad10d78)  | ![Screenshot 2024-04-19 at 16 52 02](https://github.com/GitbookIO/gitbook/assets/1927278/deb3d702-efca-4754-9c83-a3999a12d0a6)  |

