### PR TITLE
Investigate an issue where images with 127.0.0.1 in the URL are not correctly resolved.

### DIFF
--- a/src/app/(global)/~gitbook/image/route.ts
+++ b/src/app/(global)/~gitbook/image/route.ts
@@ -12,7 +12,7 @@ export const runtime = 'edge';
 export async function GET(request: NextRequest) {
     console.log(`received GET: url=${request.url.toString()} nextUrl=${request.nextUrl.toString()}`)
     console.log(`received GET: url.searchParams=${new URL(request.url).searchParams.get('url')} nextUrl.searchParams=${request.nextUrl.searchParams.get('url')}`)
-    const url = request.nextUrl.searchParams.get('url');
+    const url = request.nextUrl.searchParams.get('url')?.replace('$GITBOOK_LOCALHOST$', '127.0.0.1');
     const signature = request.nextUrl.searchParams.get('sign');
     if (!url || !signature) {
         return new Response('Missing url/sign parameters', { status: 400 });

--- a/src/app/(global)/~gitbook/image/route.ts
+++ b/src/app/(global)/~gitbook/image/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 
 import { verifyImageSignature, resizeImage, CloudflareImageOptions } from '@/lib/images';
+import { parseImageAPIURL } from '@/lib/urls';
 
 export const runtime = 'edge';
 
@@ -10,13 +11,13 @@ export const runtime = 'edge';
  * Fetch and resize an image.
  */
 export async function GET(request: NextRequest) {
-    console.log(`received GET: url=${request.url.toString()} nextUrl=${request.nextUrl.toString()}`)
-    console.log(`received GET: url.searchParams=${new URL(request.url).searchParams.get('url')} nextUrl.searchParams=${request.nextUrl.searchParams.get('url')}`)
-    const url = request.nextUrl.searchParams.get('url')?.replace('$GITBOOK_LOCALHOST$', '127.0.0.1');
+    let urlParam = request.nextUrl.searchParams.get('url');
     const signature = request.nextUrl.searchParams.get('sign');
-    if (!url || !signature) {
+    if (!urlParam || !signature) {
         return new Response('Missing url/sign parameters', { status: 400 });
     }
+
+    const url = parseImageAPIURL(urlParam);
 
     // Prevent infinite loops
     if (url.includes('/~gitbook/image')) {

--- a/src/app/(global)/~gitbook/image/route.ts
+++ b/src/app/(global)/~gitbook/image/route.ts
@@ -10,6 +10,8 @@ export const runtime = 'edge';
  * Fetch and resize an image.
  */
 export async function GET(request: NextRequest) {
+    console.log(`received GET: url=${request.url.toString()} nextUrl=${request.nextUrl.toString()}`)
+    console.log(`received GET: url.searchParams=${new URL(request.url).searchParams.get('url')} nextUrl.searchParams=${request.nextUrl.searchParams.get('url')}`)
     const url = request.nextUrl.searchParams.get('url');
     const signature = request.nextUrl.searchParams.get('sign');
     if (!url || !signature) {

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -93,6 +93,7 @@ export async function getResizedImageURL(
 
         url.searchParams.set('sign', signature);
 
+        console.log(`getResizedImageURL`, input, 'to', url.toString());
         return url.toString();
     };
 }

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -76,7 +76,7 @@ export async function getResizedImageURL(
 
     return (options) => {
         const url = new URL('/~gitbook/image', rootUrl());
-        url.searchParams.set('url', input);
+        url.searchParams.set('url', input.replace('127.0.0.1', '$GITBOOK_LOCALHOST$'));
 
         if (options.width) {
             url.searchParams.set('width', options.width.toString());

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { noCacheFetchOptions } from '@/lib/cache/http';
 
 import { rootUrl } from './links';
+import { getImageAPIUrl } from './urls';
 
 export interface CloudflareImageJsonFormat {
     width: number;
@@ -76,7 +77,7 @@ export async function getResizedImageURL(
 
     return (options) => {
         const url = new URL('/~gitbook/image', rootUrl());
-        url.searchParams.set('url', input.replace('127.0.0.1', '$GITBOOK_LOCALHOST$'));
+        url.searchParams.set('url', getImageAPIUrl(input));
 
         if (options.width) {
             url.searchParams.set('width', options.width.toString());

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -94,7 +94,6 @@ export async function getResizedImageURL(
 
         url.searchParams.set('sign', signature);
 
-        console.log(`getResizedImageURL`, input, 'to', url.toString());
         return url.toString();
     };
 }

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -65,3 +65,21 @@ export function getPDFUrlSearchParams(
 
     return searchParams;
 }
+
+/**
+ * Because of a bug in Cloudflare, 127.0.0.1 is replaced by localhost.
+ * We protect against it by converting to a special token, and then parsing
+ * the token in the image API.
+ */
+const GITBOOK_LOCALHOST_TOKEN = '$GITBOOK_LOCALHOST$';
+
+/**
+ * Prepare a URL for the GitBook Open Image API.
+ */
+export function getImageAPIUrl(url: string): string {
+    return url.replace('127.0.0.1', GITBOOK_LOCALHOST_TOKEN);
+}
+
+export function parseImageAPIURL(url: string): string {
+    return url.replace(GITBOOK_LOCALHOST_TOKEN, '127.0.0.1');
+}

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -77,9 +77,9 @@ const GITBOOK_LOCALHOST_TOKEN = '$GITBOOK_LOCALHOST$';
  * Prepare a URL for the GitBook Open Image API.
  */
 export function getImageAPIUrl(url: string): string {
-    return url.replace('127.0.0.1', GITBOOK_LOCALHOST_TOKEN);
+    return url.replaceAll('127.0.0.1', GITBOOK_LOCALHOST_TOKEN);
 }
 
 export function parseImageAPIURL(url: string): string {
-    return url.replace(GITBOOK_LOCALHOST_TOKEN, '127.0.0.1');
+    return url.replaceAll(GITBOOK_LOCALHOST_TOKEN, '127.0.0.1');
 }


### PR DESCRIPTION
Due to a bug in somewhere in the Cloudflare/Nextjs/next-on-pages stack, `127.0.0.1` is converted to `localhost` in URLs. We haven't been able to find the root cause, this PR fixes it temporarily.