### PR TITLE
Update GitBook trademark

### DIFF
--- a/src/components/TableOfContents/TableOfContents.tsx
+++ b/src/components/TableOfContents/TableOfContents.tsx
@@ -75,7 +75,7 @@ export function TableOfContents(props: {
                     'dark:group-hover:[&::-webkit-scrollbar-thumb]:bg-light/3',
                     'navigation-open:flex', // can be auto height animated as such https://stackoverflow.com/a/76944290
                     'lg:-ml-5',
-                    customization.trademark.enabled ? 'lg:pb-16' : 'lg:pb-4',
+                    customization.trademark.enabled ? 'lg:pb-20' : 'lg:pb-4',
                 )}
             >
                 <PagesList

--- a/src/components/TableOfContents/Trademark.tsx
+++ b/src/components/TableOfContents/Trademark.tsx
@@ -95,7 +95,6 @@ export function TrademarkLink(props: {
                 'tracking-[-0.016em]',
                 'dark:hover:bg-light/1',
                 'dark:ring-light/1',
-                'dark:font-semibold',
                 'border',
                 'border-dark/2',
                 'dark:border-light/2',

--- a/src/components/TableOfContents/Trademark.tsx
+++ b/src/components/TableOfContents/Trademark.tsx
@@ -84,6 +84,8 @@ export function TrademarkLink(props: {
                 'flex-row',
                 'items-center',
                 'hover:bg-dark/1',
+                'bg-light',
+                'dark:bg-dark',
                 'px-4',
                 'py-4',
                 'rounded-lg',

--- a/src/components/TableOfContents/Trademark.tsx
+++ b/src/components/TableOfContents/Trademark.tsx
@@ -86,7 +86,7 @@ export function TrademarkLink(props: {
                 'hover:bg-dark/1',
                 'px-4',
                 'py-4',
-                'rounded-md',
+                'rounded-lg',
                 'straight-corners:rounded-none',
                 'hover:backdrop-blur-sm',
                 'lg:ring-0',
@@ -95,6 +95,8 @@ export function TrademarkLink(props: {
                 'dark:ring-light/1',
                 'dark:font-normal',
                 'border',
+                'border-dark/2',
+                'dark:border-light/2',
             )}
         >
             <IconLogo className={tcls('w-5', 'h-5', 'mr-3')} />

--- a/src/components/TableOfContents/Trademark.tsx
+++ b/src/components/TableOfContents/Trademark.tsx
@@ -85,7 +85,7 @@ export function TrademarkLink(props: {
                 'items-center',
                 'hover:bg-dark/1',
                 'px-4',
-                'py-2',
+                'py-4',
                 'rounded-md',
                 'straight-corners:rounded-none',
                 'hover:backdrop-blur-sm',
@@ -94,6 +94,7 @@ export function TrademarkLink(props: {
                 'dark:hover:bg-light/1',
                 'dark:ring-light/1',
                 'dark:font-normal',
+                'border',
             )}
         >
             <IconLogo className={tcls('w-5', 'h-5', 'mr-3')} />

--- a/src/components/TableOfContents/Trademark.tsx
+++ b/src/components/TableOfContents/Trademark.tsx
@@ -95,7 +95,7 @@ export function TrademarkLink(props: {
                 'tracking-[-0.016em]',
                 'dark:hover:bg-light/1',
                 'dark:ring-light/1',
-                'dark:font-normal',
+                'dark:font-semibold',
                 'border',
                 'border-dark/2',
                 'dark:border-light/2',


### PR DESCRIPTION
This makes some small style updates the trademark logo:

Afters (left) befores (right):
<img width="693" alt="Screenshot 2024-05-02 at 11 28 01" src="https://github.com/GitbookIO/gitbook/assets/1750321/da83e0e9-489f-4667-aa9f-00a49e0871d1">
<img width="719" alt="Screenshot 2024-05-02 at 11 39 56" src="https://github.com/GitbookIO/gitbook/assets/1750321/3b16d533-8a9f-48b4-abed-4d41cce1305d">


