### PR TITLE
Fix an issue where attackers could use the Nextjs image endpoint to redirect to any URL.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,6 +39,15 @@ module.exports = withSentryConfig(
 
         assetPrefix: process.env.GITBOOK_ASSETS_PREFIX,
         poweredByHeader: false,
+
+        images: {
+            remotePatterns: [
+                {
+                    protocol: 'https',
+                    hostname: '*.gitbook.io',
+                }
+            ]
+        }
     },
     {
         silent: true,


### PR DESCRIPTION
Due to a vulnerability in Nextjs, attackers could use the internal Next image API to present any content under the URL of a published GitBook space.

This should prevent it, by only allowing GitBook URLs through the image endpoint.