### PR TITLE
Remove cache client-side

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -261,7 +261,7 @@ export async function middleware(request: NextRequest) {
         );
     } else {
         if (resolved.cacheMaxAge) {
-            const cacheControl = `public, max-age=0, s-maxage=${resolved.cacheMaxAge}, stale-while-revalidate=60, stale-if-error=0`;
+            const cacheControl = `public, max-age=0, s-maxage=${resolved.cacheMaxAge}, stale-if-error=0`;
 
             if (
                 process.env.GITBOOK_OUTPUT_CACHE === 'true' &&

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -261,7 +261,7 @@ export async function middleware(request: NextRequest) {
         );
     } else {
         if (resolved.cacheMaxAge) {
-            const cacheControl = `public, max-age=60, s-maxage=${resolved.cacheMaxAge}, stale-while-revalidate=60, stale-if-error=0`;
+            const cacheControl = `public, max-age=0, s-maxage=${resolved.cacheMaxAge}, stale-while-revalidate=60, stale-if-error=0`;
 
             if (
                 process.env.GITBOOK_OUTPUT_CACHE === 'true' &&


### PR DESCRIPTION
Since we have to invalidate the content, it's not OK to have a cache client-side because we can't invalidate this one.