### PR TITLE
Fix passing revalidateBefore option when calling cacheResponse to ensure these go through background revalidation

### DIFF
--- a/src/lib/cache/cache.ts
+++ b/src/lib/cache/cache.ts
@@ -202,7 +202,7 @@ export function cache<Args extends any[], Result>(
 
             if (savedEntry.meta.revalidatesAt && savedEntry.meta.revalidatesAt < Date.now()) {
                 // Revalidate in the background
-                waitUntil(revalidate(key, undefined, ...args));
+                await waitUntil(revalidate(key, undefined, ...args));
             }
 
             return savedEntry.data;

--- a/src/lib/cache/http.ts
+++ b/src/lib/cache/http.ts
@@ -50,6 +50,7 @@ export function cacheResponse<Result, DefaultData = Result>(
     return {
         ttl: defaultEntry.ttl ?? parsed.ttl,
         tags: [...(defaultEntry.tags ?? []), ...parsed.tags],
+        revalidateBefore: defaultEntry.revalidateBefore,
         // @ts-ignore
         data: defaultEntry.data ?? response.data,
     };


### PR DESCRIPTION
Most of the calls defined in the [api file](https://github.com/GitbookIO/gitbook/blob/main/src/lib/api.ts) uses the `cacheResponse` helper, and also define a `revalidateBefore` period.

However, in its current state, `cacheResponse` ignores passing this additional `revalidateBefore` property to its result, so these are currently ignored and all API calls using `cacheResponse` aren't revalidated in the background when they should.