### PR TITLE
Parse cache tags returned from the API set them in response

### DIFF
--- a/src/lib/cache/http.ts
+++ b/src/lib/cache/http.ts
@@ -26,9 +26,12 @@ export function parseCacheResponse(response: Response): {
     const cacheControlHeader = response.headers.get('cache-control');
     const cacheControl = cacheControlHeader ? parseCacheControl(cacheControlHeader) : null;
 
+    const cacheTagHeader = response.headers.get('x-gitbook-cache-tag');
+    const tags = !cacheTagHeader ? [] : cacheTagHeader.split(',');
+
     const entry = {
         ttl: 60 * 60 * 24,
-        tags: [],
+        tags,
     };
 
     if (cacheControl && cacheControl['max-age']) {


### PR DESCRIPTION
This will allow the response from GitBook Open to set the `cache-tag` and `x-gitbook-cache-tag` headers, allowing Cloudflare to actually use them and to purge them.