### PR TITLE
Forward content resolution API response tags to local caches

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -243,6 +243,7 @@ export const getPublishedContentByUrl = cache(
             };
             return {
                 tags: [
+                    ...parsed.tags,
                     getAPICacheTag({
                         tag: 'url',
                         hostname: parsedURL.hostname,


### PR DESCRIPTION
This will also ensure that content cache be refreshed on demand in "local" (meaning this application's) caches (memory, Cloudflare cache, KV, ...).