### PR TITLE
Set preconnect links to main domains on render

### DIFF
--- a/src/app/(space)/(content)/layout.tsx
+++ b/src/app/(space)/(content)/layout.tsx
@@ -8,6 +8,7 @@ import { AdminToolbar } from '@/components/AdminToolbar';
 import { CookiesToast } from '@/components/Cookies';
 import { LoadIntegrations } from '@/components/Integrations';
 import { SpaceLayout } from '@/components/SpaceLayout';
+import { api } from '@/lib/api';
 import { buildVersion } from '@/lib/build';
 import { getContentSecurityPolicyNonce } from '@/lib/csp';
 import { absoluteHref, baseUrl } from '@/lib/links';
@@ -39,6 +40,7 @@ export default async function ContentLayout(props: { children: React.ReactNode }
         scripts,
     } = await fetchSpaceData();
 
+    ReactDOM.preconnect(api().endpoint);
     scripts.forEach(({ script }) => {
         ReactDOM.preload(script, {
             as: 'script',

--- a/src/app/(space)/(content)/layout.tsx
+++ b/src/app/(space)/(content)/layout.tsx
@@ -9,6 +9,7 @@ import { CookiesToast } from '@/components/Cookies';
 import { LoadIntegrations } from '@/components/Integrations';
 import { SpaceLayout } from '@/components/SpaceLayout';
 import { api } from '@/lib/api';
+import { assetsDomain } from '@/lib/assets';
 import { buildVersion } from '@/lib/build';
 import { getContentSecurityPolicyNonce } from '@/lib/csp';
 import { absoluteHref, baseUrl } from '@/lib/links';
@@ -41,6 +42,10 @@ export default async function ContentLayout(props: { children: React.ReactNode }
     } = await fetchSpaceData();
 
     ReactDOM.preconnect(api().endpoint);
+    if (assetsDomain) {
+        ReactDOM.preconnect(assetsDomain);
+    }
+
     scripts.forEach(({ script }) => {
         ReactDOM.preload(script, {
             as: 'script',

--- a/src/components/DocumentView/Embed.tsx
+++ b/src/components/DocumentView/Embed.tsx
@@ -1,5 +1,6 @@
 import * as gitbookAPI from '@gitbook/api';
 import Script from 'next/script';
+import ReactDOM from 'react-dom';
 
 import { Card } from '@/components/primitives';
 import { api } from '@/lib/api';
@@ -11,6 +12,8 @@ import { IntegrationBlock } from './Integration';
 
 export async function Embed(props: BlockProps<gitbookAPI.DocumentBlockEmbed>) {
     const { block, context, ...otherProps } = props;
+    
+    ReactDOM.preconnect('https://cdn.iframe.ly');
 
     const { data: embed } = await (context.content
         ? api().spaces.getEmbedByUrlInSpace(context.content.spaceId, { url: block.data.url })


### PR DESCRIPTION
Preconnect to the main external domains used (API, iframely for embeds, ...) during rendering to send hints to the browser.