### PR TITLE
Use a singleton to store the memory cache in an internal WeakMap for the current request

### DIFF
--- a/src/lib/cache/memory.ts
+++ b/src/lib/cache/memory.ts
@@ -1,6 +1,7 @@
 import { CacheBackend, CacheEntry } from './types';
 import { NON_IMMUTABLE_LOCAL_CACHE_MAX_AGE_SECONDS, isCacheEntryImmutable } from './utils';
 import { getGlobalContext } from '../waitUntil';
+import { singleton } from '../async';
 
 export const memoryCache: CacheBackend = {
     name: 'memory',
@@ -67,12 +68,4 @@ export const memoryCache: CacheBackend = {
  * With next-on-pages, the code seems to be isolated between the middleware and the handler.
  * To share the cache between the two, we use a global variable.
  */
-async function getMemoryCache(): Promise<Map<string, CacheEntry>> {
-    let globalThisForMemoryCache: any = await getGlobalContext();
-
-    if (!globalThisForMemoryCache.gitbookMemoryCache) {
-        globalThisForMemoryCache.gitbookMemoryCache = new Map();
-    }
-
-    return globalThisForMemoryCache.gitbookMemoryCache;
-}
+const getMemoryCache = singleton(async () => new Map());

--- a/src/lib/cache/memory.ts
+++ b/src/lib/cache/memory.ts
@@ -66,5 +66,7 @@ export const memoryCache: CacheBackend = {
 /**
  * With next-on-pages, the code seems to be isolated between the middleware and the handler.
  * To share the cache between the two, we use a global variable.
+ * By using a singleton, we ensure that the cache is only created once and stored in the
+ * current request context.
  */
 const getMemoryCache = singleton(async () => new Map());

--- a/src/lib/cache/memory.ts
+++ b/src/lib/cache/memory.ts
@@ -1,6 +1,5 @@
-import { CacheBackend, CacheEntry } from './types';
+import { CacheBackend } from './types';
 import { NON_IMMUTABLE_LOCAL_CACHE_MAX_AGE_SECONDS, isCacheEntryImmutable } from './utils';
-import { getGlobalContext } from '../waitUntil';
 import { singleton } from '../async';
 
 export const memoryCache: CacheBackend = {

--- a/src/lib/waitUntil.ts
+++ b/src/lib/waitUntil.ts
@@ -12,7 +12,7 @@ export async function getGlobalContext(): Promise<object> {
 
     // We lazy-load the next-on-pages package to avoid errors when running tests because of 'server-only'.
     const { getOptionalRequestContext } = await import('@cloudflare/next-on-pages');
-    return getOptionalRequestContext()?.ctx ?? globalThis;
+    return getOptionalRequestContext()?.cf ?? globalThis;
 }
 
 /**


### PR DESCRIPTION
I made the switch from using the `ctx` property instead of the `cf` one from the `getRequestContext` in the `getGlobalContext` helper while [making the memory cache from the middleware accessible to the next request handler](#2347).

However, since this change was deployed, we have an increased number of these errors:
`Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler.`

This PR reverts this change, but also switches to use the `singleton` helper to create the memory cache, that will store the memory cache and makes it accessible in a `WeakMap` for the current request context.