### PR TITLE
Tree shake unused code for Sentry

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,7 @@ module.exports = withSentryConfig(
                 config.plugins.push(
                     new webpack.DefinePlugin({
                         __SENTRY_DEBUG__: false,
+                        // We always init Sentry with enableTracing: false for now, so this is useless
                         __SENTRY_TRACING__: false,
                         __RRWEB_EXCLUDE_IFRAME__: true,
                         __RRWEB_EXCLUDE_SHADOW_DOM__: true,

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ module.exports = withSentryConfig(
             GITBOOK_ASSETS_PREFIX: process.env.GITBOOK_ASSETS_PREFIX,
         },
 
-        webpack(config) {
+        webpack(config, { dev }) {
             config.resolve.fallback = {
                 ...config.resolve.fallback,
 
@@ -18,6 +18,20 @@ module.exports = withSentryConfig(
                 path: false,
                 http: false,
             };
+
+            // Tree shake debug code for Sentry
+            // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/#tree-shaking-with-nextjs
+            if (!dev) {
+                config.plugins.push(
+                    new webpack.DefinePlugin({
+                        __SENTRY_DEBUG__: false,
+                        __SENTRY_TRACING__: false,
+                        __RRWEB_EXCLUDE_IFRAME__: true,
+                        __RRWEB_EXCLUDE_SHADOW_DOM__: true,
+                        __SENTRY_EXCLUDE_REPLAY_WORKER__: true,
+                    }),
+                );
+            }
 
             return config;
         },
@@ -45,9 +59,9 @@ module.exports = withSentryConfig(
                 {
                     protocol: 'https',
                     hostname: '*.gitbook.io',
-                }
-            ]
-        }
+                },
+            ],
+        },
     },
     {
         silent: true,

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ module.exports = withSentryConfig(
             GITBOOK_ASSETS_PREFIX: process.env.GITBOOK_ASSETS_PREFIX,
         },
 
-        webpack(config, { dev }) {
+        webpack(config, { dev, webpack }) {
             config.resolve.fallback = {
                 ...config.resolve.fallback,
 

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,8 +1,15 @@
-import * as Sentry from '@sentry/nextjs';
+import {
+    BrowserClient,
+    makeFetchTransport,
+    defaultStackParser,
+    getCurrentScope,
+} from '@sentry/nextjs';
 
 const dsn = process.env.SENTRY_DSN;
 if (dsn) {
-    Sentry.init({
+    // To tree shake default integrations that we don't use
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/#tree-shaking-default-integrations
+    const client = new BrowserClient({
         debug: false,
         dsn,
         integrations: [],
@@ -11,5 +18,10 @@ if (dsn) {
         beforeSendTransaction: () => {
             return null;
         },
+        transport: makeFetchTransport,
+        stackParser: defaultStackParser,
     });
+
+    getCurrentScope().setClient(client);
+    client.init();
 }

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,8 +1,8 @@
-import * as Sentry from '@sentry/nextjs';
+import { init } from '@sentry/nextjs';
 
 const dsn = process.env.SENTRY_DSN;
 if (dsn) {
-    Sentry.init({
+    init({
         debug: false,
         dsn,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,8 @@
-import * as Sentry from '@sentry/nextjs';
+import { init } from '@sentry/nextjs';
 
 const dsn = process.env.SENTRY_DSN;
 if (dsn) {
-    Sentry.init({
+    init({
         debug: false,
         dsn,
 

--- a/src/app/(space)/error.tsx
+++ b/src/app/(space)/error.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as Sentry from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 import React from 'react';
 
 import { Button } from '@/components/primitives/Button';
@@ -15,7 +15,7 @@ export default function ErrorPage(props: {
     const language = useLanguage();
 
     React.useEffect(() => {
-        Sentry.captureException(error);
+        captureException(error);
     }, [error]);
 
     return (

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import * as Sentry from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 import Error from 'next/error';
 import { useEffect } from 'react';
 
 export default function GlobalError({ error }: { error: Error }) {
     useEffect(() => {
-        Sentry.captureException(error);
+        captureException(error);
     }, [error]);
 
     return (

--- a/src/lib/tracing.ts
+++ b/src/lib/tracing.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/nextjs';
+import { startSpan } from '@sentry/nextjs';
 
 export interface TraceSpan {
     setAttribute: (label: string, value: boolean | string | number) => void;
@@ -22,7 +22,7 @@ export async function trace<T>(
         typeof name === 'string' ? { operation: name, name: undefined } : name;
     const completeName = executionName ? `${operation}(${executionName})` : operation;
 
-    return await Sentry.startSpan(
+    return await startSpan(
         {
             name: completeName,
             op: operation,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { GitBookAPI } from '@gitbook/api';
-import * as Sentry from '@sentry/nextjs';
+import { setTag, setContext } from '@sentry/nextjs';
 import assertNever from 'assert-never';
 import jwt from 'jsonwebtoken';
 import type { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
@@ -94,8 +94,8 @@ interface ContentAPITokenPayload {
 export async function middleware(request: NextRequest) {
     const { url, mode } = getInputURL(request);
 
-    Sentry.setTag('url', url.toString());
-    Sentry.setContext('request', {
+    setTag('url', url.toString());
+    setContext('request', {
         method: request.method,
         url: url.toString(),
         rawRequestURL: request.url,
@@ -145,8 +145,8 @@ export async function middleware(request: NextRequest) {
         return writeCookies(NextResponse.redirect(normalizedVA.toString()), resolved.cookies);
     }
 
-    Sentry.setTag('space', resolved.space);
-    Sentry.setContext('content', {
+    setTag('space', resolved.space);
+    setContext('content', {
         space: resolved.space,
         changeRequest: resolved.changeRequest,
         revision: resolved.revision,


### PR DESCRIPTION
Noticed that one of the JS chunks for the app was quite big, and it included a whole lot of code dedicated to Sentry only, which we don't use to a lot of extent client-side (no integrations).

Searched and found [this GitHub issue](https://github.com/getsentry/sentry-javascript/issues/7680), talking about [this tree shaking guide](https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/).

Applying the suggestions led to removing ~40KB of gzipped code, or ~136KB of uncompressed JS, which is ~10% of the first load JS code size.

### Before (main)
<img width="1552" alt="image" src="https://github.com/GitbookIO/gitbook/assets/7927876/3efe0804-fccd-4093-ab0a-c1bf5219be9c">

### After
<img width="1552" alt="image" src="https://github.com/GitbookIO/gitbook/assets/7927876/065207a6-e08c-4256-a4b8-8e241843d8ec">
