### PR TITLE
Fix passing the correct nonce for iframely script and preload it

### DIFF
--- a/src/components/DocumentView/Embed.tsx
+++ b/src/components/DocumentView/Embed.tsx
@@ -1,4 +1,5 @@
 import * as gitbookAPI from '@gitbook/api';
+import { headers } from 'next/headers';
 import Script from 'next/script';
 import ReactDOM from 'react-dom';
 
@@ -12,6 +13,7 @@ import { IntegrationBlock } from './Integration';
 
 export async function Embed(props: BlockProps<gitbookAPI.DocumentBlockEmbed>) {
     const { block, context, ...otherProps } = props;
+    const nonce = headers().get('x-nonce') || undefined;
     
     ReactDOM.preconnect('https://cdn.iframe.ly');
 
@@ -29,7 +31,7 @@ export async function Embed(props: BlockProps<gitbookAPI.DocumentBlockEmbed>) {
                         }}
                     />
                     {/* We load the iframely script to resize the embed iframes dynamically */}
-                    <Script src="https://cdn.iframe.ly/embed.js" defer async />
+                    <Script src="https://cdn.iframe.ly/embed.js" nonce={nonce} defer async />
                 </>
             ) : embed.type === 'integration' ? (
                 <IntegrationBlock

--- a/src/components/DocumentView/Embed.tsx
+++ b/src/components/DocumentView/Embed.tsx
@@ -30,8 +30,7 @@ export async function Embed(props: BlockProps<gitbookAPI.DocumentBlockEmbed>) {
                             __html: embed.html,
                         }}
                     />
-                    {/* We load the iframely script to resize the embed iframes dynamically */}
-                    <Script src="https://cdn.iframe.ly/embed.js" nonce={nonce} defer async />
+                    <Script src="https://cdn.iframe.ly/embed.js" nonce={nonce} />
                 </>
             ) : embed.type === 'integration' ? (
                 <IntegrationBlock

--- a/src/components/DocumentView/Embed.tsx
+++ b/src/components/DocumentView/Embed.tsx
@@ -15,7 +15,7 @@ export async function Embed(props: BlockProps<gitbookAPI.DocumentBlockEmbed>) {
     const { block, context, ...otherProps } = props;
     const nonce = headers().get('x-nonce') || undefined;
     
-    ReactDOM.preconnect('https://cdn.iframe.ly');
+    ReactDOM.preload('https://cdn.iframe.ly/embed.js', { as: 'script', nonce });
 
     const { data: embed } = await (context.content
         ? api().spaces.getEmbedByUrlInSpace(context.content.spaceId, { url: block.data.url })


### PR DESCRIPTION
Should supersede #2293  
We also preload the script directly because it's always needed when there are embeds on the page and it can be fetched in parallel of other resources in this case.

Script loaded without errors:
<img width="1552" alt="image" src="https://github.com/GitbookIO/gitbook/assets/7927876/04f99385-3fdb-4f05-93d8-052cda1bfd62">
