### PR TITLE
Prevent SVG images to be resized and rendered on the /~gitbook/image endpoint

### DIFF
--- a/src/app/(global)/~gitbook/image/route.ts
+++ b/src/app/(global)/~gitbook/image/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 
-import { verifyImageSignature, resizeImage, CloudflareImageOptions } from '@/lib/images';
+import { verifyImageSignature, resizeImage, CloudflareImageOptions, checkIsSizableImageURL } from '@/lib/images';
 import { parseImageAPIURL } from '@/lib/urls';
 
 export const runtime = 'edge';
@@ -24,6 +24,12 @@ export async function GET(request: NextRequest) {
 
     // Prevent infinite loops
     if (url.includes('/~gitbook/image')) {
+        return new Response('Invalid url parameter', { status: 400 });
+    }
+
+    // Check again if the image can be sized, even though we checked when rendering the Image component
+    // Otherwise, it's possible to pass just any link to this endpoint and trigger HTML injection on the domain
+    if (!checkIsSizableImageURL(url)) {
         return new Response('Invalid url parameter', { status: 400 });
     }
 

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -41,7 +41,7 @@ export function isImageResizingEnabled(): boolean {
 /**
  * Check if a URL is an HTTP URL.
  */
-export function checkIsHttpURL(input: string): boolean {
+export function checkIsHttpURL(input: string | URL): boolean {
     if (!URL.canParse(input)) {
         return false;
     }
@@ -54,11 +54,16 @@ export function checkIsHttpURL(input: string): boolean {
  * Skip it for non-http(s) URLs (data, etc).
  * Skip it for SVGs.
  */
-function checkIsSizableImageURL(input: string): boolean {
-    if (input.endsWith('.svg')) {
+export function checkIsSizableImageURL(input: string): boolean {
+    if (!URL.canParse(input)) {
         return false;
     }
-    return checkIsHttpURL(input);
+
+    const parsed = new URL(input);
+    if (parsed.pathname.endsWith('.svg')) {
+        return false;
+    }
+    return checkIsHttpURL(parsed);
 }
 
 /**


### PR DESCRIPTION
The `Image` component endpoint prevents generating resize URLs for SVG files already.

However, the `/~gitbook/image` resize endpoint doesn't recheck if the URL can (and should) be resized, which includes SVG files.

This PR improves the `checkIsSizableImageURL` helper to ensure that the URL can be parsed, and that the targeted filename, via the pathname, ends in `.svg`, instead of checking the URL that could have a query string parameter.
It also uses this helper in the image resizing endpoint to prevent resizing and thus rendering SVGs on the domain used to serve the docs.