### PR TITLE
Use published URL for site when displaying results for a Site space

### DIFF
--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -94,6 +94,8 @@ export async function searchParentContent(
             siteSpaces.reduce(
                 (acc, siteSpace) => {
                     acc[siteSpace.space.id] = siteSpace.space;
+                    // replace the published url for the "space" with the site's published url
+                    acc[siteSpace.space.id].urls.published = siteSpace.urls.published;
                     return acc;
                 },
                 {} as Record<string, Space>,


### PR DESCRIPTION
Published URLs for spaces are used in search results but these are not relevant when searching within Sites. This causes a bug on Sites currently where the search result for a different variant takes you to a non-existent page (as it is missing the /v/ portion of the space's published URL).
We need to, instead, use the SiteSpace published URL. This fixes the issue for the moment by adding the published URL for the SiteSpace into the Space result.
