### PR TITLE
Fix ToC not re-rendering when linking to a variant from SearchResults

### DIFF
--- a/src/components/Search/SearchModal.tsx
+++ b/src/components/Search/SearchModal.tsx
@@ -232,28 +232,23 @@ function SearchModalBody(
                 </div>
             </div>
             {!state.ask || !withAsk ? (
-                <>
-                    <SearchResults
-                        ref={resultsRef}
-                        spaceId={spaceId}
-                        revisionId={revisionId}
-                        parent={state.global ? parent : null}
-                        query={state.query}
-                        withAsk={withAsk}
-                        onSwitchToAsk={() => {
-                            onChangeQuery({
-                                ask: true,
-                                query: state.query,
-                                global: state.global,
-                            });
-                        }}
-                        onClose={onClose}
-                    >
-                        {parent && state.query ? (
-                            <SearchScopeToggle spaceTitle={spaceTitle} />
-                        ) : null}
-                    </SearchResults>
-                </>
+                <SearchResults
+                    ref={resultsRef}
+                    spaceId={spaceId}
+                    revisionId={revisionId}
+                    parent={state.global ? parent : null}
+                    query={state.query}
+                    withAsk={withAsk}
+                    onSwitchToAsk={() => {
+                        onChangeQuery({
+                            ask: true,
+                            query: state.query,
+                            global: state.global,
+                        });
+                    }}
+                >
+                    {parent && state.query ? <SearchScopeToggle spaceTitle={spaceTitle} /> : null}
+                </SearchResults>
             ) : null}
             {state.query && state.ask && withAsk ? (
                 <SearchAskAnswer spaceId={spaceId} query={state.query} />

--- a/src/components/Search/SearchPageResultItem.tsx
+++ b/src/components/Search/SearchPageResultItem.tsx
@@ -21,10 +21,6 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
         <Link
             ref={ref}
             href={item.href}
-            onClick={(event) => {
-                event.preventDefault();
-                onClick(item.href);
-            }}
             className={tcls(
                 'flex',
                 'flex-row',

--- a/src/components/Search/SearchPageResultItem.tsx
+++ b/src/components/Search/SearchPageResultItem.tsx
@@ -11,11 +11,10 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
         query: string;
         item: ComputedPageResult;
         active: boolean;
-        onClick: (to: string) => void;
     },
     ref: React.Ref<HTMLAnchorElement>,
 ) {
-    const { query, item, active, onClick } = props;
+    const { query, item, active } = props;
 
     return (
         <Link

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -211,7 +211,6 @@ export const SearchResults = React.forwardRef(function SearchResults(
                                         query={query}
                                         item={item}
                                         active={index === cursor}
-                                        onClick={onClose}
                                     />
                                 );
                             }

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -43,11 +43,10 @@ export const SearchResults = React.forwardRef(function SearchResults(
         parent: Site | Collection | null;
         withAsk: boolean;
         onSwitchToAsk: () => void;
-        onClose: (to?: string) => void;
     },
     ref: React.Ref<SearchResultsRef>,
 ) {
-    const { children, query, spaceId, revisionId, parent, withAsk, onSwitchToAsk, onClose } = props;
+    const { children, query, spaceId, revisionId, parent, withAsk, onSwitchToAsk } = props;
 
     const language = useLanguage();
     const debounceTimeout = React.useRef<NodeJS.Timeout | null>(null);
@@ -251,7 +250,6 @@ export const SearchResults = React.forwardRef(function SearchResults(
                                         query={query}
                                         item={item}
                                         active={index === cursor}
-                                        onClick={onClose}
                                     />
                                 );
                             }

--- a/src/components/Search/SearchSectionResultItem.tsx
+++ b/src/components/Search/SearchSectionResultItem.tsx
@@ -11,20 +11,15 @@ export const SearchSectionResultItem = React.forwardRef(function SearchSectionRe
         query: string;
         item: ComputedSectionResult;
         active: boolean;
-        onClick: (to: string) => void;
     },
     ref: React.Ref<HTMLAnchorElement>,
 ) {
-    const { query, item, active, onClick } = props;
+    const { query, item, active } = props;
 
     return (
         <Link
             ref={ref}
             href={item.href}
-            onClick={(event) => {
-                event.preventDefault();
-                onClick(item.href);
-            }}
             className={tcls(
                 'search-section-result-item',
                 '[&:has(+:not(&))]:mb-6',


### PR DESCRIPTION
When navigating between variants/spaces from search results, we load the correct page but the ToC is not re-rendered as it is a SSR component. This PR removes the client side routing from the search results when you are viewing results.
