### PR TITLE
Remove Page/Space label from BlockContentRef

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,10 @@
         ["style \\=([^;]*);", "\"([^\"]*)\""],
         ["style \\=([^;]*);", "\\`([^\\`]*)\\`"]
     ],
-    "tailwindCSS.classAttributes": ["class", "className", "style", ".*Style"]
+    "tailwindCSS.classAttributes": [
+        "class",
+        "className",
+        "style",
+        ".*Style"
+    ]
 }

--- a/src/components/DocumentView/BlockContentRef.tsx
+++ b/src/components/DocumentView/BlockContentRef.tsx
@@ -1,12 +1,11 @@
-import { CustomizationThemedURL, DocumentBlockContentRef } from '@gitbook/api';
+import { DocumentBlockContentRef } from '@gitbook/api';
 
+import { LogoIcon } from '@/components/icons';
 import { Card, Emoji } from '@/components/primitives';
 import { getSpaceCustomization, ignoreAPIError } from '@/lib/api';
 import { ResolvedContentRef } from '@/lib/references';
 
 import { BlockProps } from './Block';
-import { Image } from '../utils';
-
 
 export async function BlockContentRef(props: BlockProps<DocumentBlockContentRef>) {
     const { block, context, style } = props;
@@ -42,36 +41,15 @@ async function SpaceRefCard(props: { resolved: ResolvedContentRef } & BlockProps
 
     const spaceCustomization = await ignoreAPIError(getSpaceCustomization(spaceId));
     const customFavicon = spaceCustomization?.favicon;
-    const customEmoji = customFavicon && 'emoji' in customFavicon ? customFavicon.emoji : null;
-    const customIcon = customFavicon && 'icon' in customFavicon ? customFavicon.icon : null;
+    const customEmoji = customFavicon && 'emoji' in customFavicon ? customFavicon.emoji : undefined;
+    const customIcon = customFavicon && 'icon' in customFavicon ? customFavicon.icon : undefined;
 
     return (
         <Card
-            leadingIcon={customIcon ? <BlockContentRefIcon icon={customIcon} /> : customEmoji ? <Emoji code={customEmoji} style="text-xl" /> : null}
+            leadingIcon={<LogoIcon icon={customIcon} emoji={customEmoji} alt='' sizes={[{ width: 24 }]} style={['object-contain', 'size-6']} />}
             href={resolved.href}
             title={resolved.text}
             style={style}
         />
     );
-}
-
-function BlockContentRefIcon(props: { icon: CustomizationThemedURL }) {
-    const { icon } = props;
-            
-    return icon ? <Image 
-        priority='lazy' 
-        alt=""
-        sources={{
-            light: {
-                src: typeof icon ==='string' ? icon : icon.light,
-                size: { width: 256, height: 256 },
-            },
-            dark: {
-                src:  typeof icon ==='string' ? icon : icon.dark,
-                size: { width: 256, height: 256 },
-            },
-        }}
-        sizes={[{ width: 24 }]}
-        className="size-6 flex-1 object-contain"
-    /> : null;
 }

--- a/src/components/DocumentView/BlockContentRef.tsx
+++ b/src/components/DocumentView/BlockContentRef.tsx
@@ -1,27 +1,41 @@
 import { DocumentBlockContentRef } from '@gitbook/api';
 
 import { Card, Emoji } from '@/components/primitives';
+import { type ResolvedContentRef } from '@/lib/references';
 
 import { BlockProps } from './Block';
+import { Image } from '../utils';
+
+
 
 export async function BlockContentRef(props: BlockProps<DocumentBlockContentRef>) {
     const { block, context, style } = props;
-    const kind = block?.data?.ref?.kind;
 
     const resolved = await context.resolveContentRef(block.data.ref, {
         resolveAnchorText: true,
     });
+
     if (!resolved) {
         return null;
     }
 
     return (
         <Card
-            leadingIcon={resolved.emoji ? <Emoji code={resolved.emoji} /> : null}
+            leadingIcon={resolved.icon ? <BlockContentRefIcon resolved={resolved}  /> : resolved.emoji ? <Emoji code={resolved.emoji} style="text-xl" /> : null}
             href={resolved.href}
-            preTitle={kind}
             title={resolved.text}
             style={style}
         />
     );
+}
+
+function BlockContentRefIcon(props: { resolved: ResolvedContentRef }) {
+    const { resolved,  } = props;
+    return resolved.icon ? <Image 
+        priority='lazy' 
+        alt=""
+        sources={{ light: { src: resolved.icon, size: { width: 24, height: 24 } }, dark: {src: resolved.icon }}}
+        sizes={[ { width: 24 }]}
+        className="size-6 flex-1 object-contain"
+    /> : null;
 }

--- a/src/components/DocumentView/BlockContentRef.tsx
+++ b/src/components/DocumentView/BlockContentRef.tsx
@@ -1,7 +1,6 @@
-import { DocumentBlockContentRef } from '@gitbook/api';
+import { CustomizationThemedURL, DocumentBlockContentRef } from '@gitbook/api';
 
 import { Card, Emoji } from '@/components/primitives';
-import { type ResolvedContentRef } from '@/lib/references';
 
 import { BlockProps } from './Block';
 import { Image } from '../utils';
@@ -18,10 +17,10 @@ export async function BlockContentRef(props: BlockProps<DocumentBlockContentRef>
     if (!resolved) {
         return null;
     }
-
+    
     return (
         <Card
-            leadingIcon={resolved.icon ? <BlockContentRefIcon resolved={resolved}  /> : resolved.emoji ? <Emoji code={resolved.emoji} style="text-xl" /> : null}
+            leadingIcon={resolved.icon ? <BlockContentRefIcon icon={resolved.icon} /> : resolved.emoji ? <Emoji code={resolved.emoji} style="text-xl" /> : null}
             href={resolved.href}
             title={resolved.text}
             style={style}
@@ -29,13 +28,23 @@ export async function BlockContentRef(props: BlockProps<DocumentBlockContentRef>
     );
 }
 
-function BlockContentRefIcon(props: { resolved: ResolvedContentRef }) {
-    const { resolved,  } = props;
-    return resolved.icon ? <Image 
+function BlockContentRefIcon(props: { icon: string | CustomizationThemedURL }) {
+    const { icon } = props;
+            
+    return icon ? <Image 
         priority='lazy' 
         alt=""
-        sources={{ light: { src: resolved.icon, size: { width: 24, height: 24 } }, dark: {src: resolved.icon }}}
-        sizes={[ { width: 24 }]}
+        sources={{
+            light: {
+                src: typeof icon ==='string' ? icon : icon.light,
+                size: { width: 256, height: 256 },
+            },
+            dark: {
+                src:  typeof icon ==='string' ? icon : icon.dark,
+                size: { width: 256, height: 256 },
+            },
+        }}
+        sizes={[{ width: 24 }]}
         className="size-6 flex-1 object-contain"
     /> : null;
 }

--- a/src/components/Header/HeaderLogo.tsx
+++ b/src/components/Header/HeaderLogo.tsx
@@ -8,6 +8,7 @@ import {
 } from '@gitbook/api';
 
 import { HeaderMobileMenu } from '@/components/Header/HeaderMobileMenu';
+import { LogoIcon } from '@/components/icons';
 import { Image } from '@/components/utils';
 import { absoluteHref } from '@/lib/links';
 import { tcls } from '@/lib/tailwind';
@@ -95,40 +96,11 @@ export function HeaderLogo(props: HeaderLogoProps) {
 
 function LogoFallback(props: HeaderLogoProps) {
     const { parent, space, customization } = props;
-    const customIcon = 'icon' in customization.favicon ? customization.favicon.icon : null;
-
+    const customIcon = 'icon' in customization.favicon ? customization.favicon.icon : undefined;
+    const customEmoji = 'emoji' in customization.favicon ? customization.favicon.emoji : undefined;
     return (
         <>
-            <Image
-                alt="Logo"
-                sources={
-                    customIcon
-                        ? {
-                              light: { src: customIcon.light, aspectRatio: '1' },
-                              dark: customIcon.dark
-                                  ? { src: customIcon.dark, aspectRatio: '1' }
-                                  : null,
-                          }
-                        : {
-                              light: {
-                                  src: absoluteHref('~gitbook/icon?size=medium&theme=light', true),
-                                  size: { width: 256, height: 256 },
-                              },
-                              dark: {
-                                  src: absoluteHref('~gitbook/icon?size=medium&theme=dark', true),
-                                  size: { width: 256, height: 256 },
-                              },
-                          }
-                }
-                sizes={[
-                    {
-                        width: 32,
-                    },
-                ]}
-                fetchPriority="high"
-                style={['w-8', 'h-8', 'object-contain']}
-            />
-
+            <LogoIcon icon={customIcon} emoji={customEmoji} alt='' sizes={[{ width: 32 }]} style={['object-contain', 'size-8']} fetchPriority='high'/> 
             <h1
                 className={tcls(
                     'text-pretty',

--- a/src/components/icons/LogoIcon.tsx
+++ b/src/components/icons/LogoIcon.tsx
@@ -1,0 +1,39 @@
+import { CustomizationThemedURL } from "@gitbook/api";
+
+import { Image } from '@/components/utils';
+import { absoluteHref } from "@/lib/links";
+
+import { Emoji } from "../primitives";
+
+
+export function LogoIcon(props: { icon?: CustomizationThemedURL; emoji?: string } & Omit<React.ComponentProps<typeof Image>, 'sources'>) {
+    const { icon, emoji, alt, ...imageProps } = props;
+
+    if (emoji && !icon) {
+        return <Emoji code={emoji} style="text-xl" />;
+    }
+
+    return <Image 
+        alt={alt ?? ''}
+        sources={icon ? {
+            light: {
+                src: icon.light,
+                aspectRatio: '1',
+            },
+            dark: {
+                src: icon.dark,
+                aspectRatio: '1',
+            },
+        } : {
+            light: {
+                src: absoluteHref('~gitbook/icon?size=medium&theme=light', true),
+                size: { width: 256, height: 256 },
+            },
+            dark: {
+                src: absoluteHref('~gitbook/icon?size=medium&theme=dark', true),
+                size: { width: 256, height: 256 },
+            },
+        }}
+        {...imageProps}
+    />;
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './LogoIcon';

--- a/src/lib/references.ts
+++ b/src/lib/references.ts
@@ -20,6 +20,8 @@ export interface ResolvedContentRef {
     text: string;
     /** Emoji associated with the reference */
     emoji?: string;
+    /** Icon associated with the reference */
+    icon?: string;
     /** URL to open for the content ref */
     href: string;
     /** True if the content ref is active */
@@ -176,6 +178,8 @@ export async function resolveContentRef(
                 href: targetSpace.urls.published ?? targetSpace.urls.app,
                 text: targetSpace.title,
                 active: true,
+                emoji:  targetSpace.emoji,
+                icon: targetSpace.urls.icon
             };
         }
 

--- a/src/lib/references.ts
+++ b/src/lib/references.ts
@@ -177,8 +177,7 @@ export async function resolveContentRef(
             return {
                 href: targetSpace.urls.published ?? targetSpace.urls.app,
                 text: targetSpace.title,
-                active: true,
-                emoji: targetSpace.emoji,
+                active: true
             };
         }
 

--- a/src/lib/references.ts
+++ b/src/lib/references.ts
@@ -1,4 +1,4 @@
-import { ContentRef, CustomizationThemedURL, Revision, RevisionFile, RevisionPageDocument, Space } from '@gitbook/api';
+import { ContentRef, Revision, RevisionFile, RevisionPageDocument, Space } from '@gitbook/api';
 import assertNever from 'assert-never';
 
 import {
@@ -8,7 +8,6 @@ import {
     getRevisionFile,
     getSpace,
     getSpaceContentData,
-    getSpaceCustomization,
     getUserById,
     ignoreAPIError,
 } from './api';
@@ -22,8 +21,6 @@ export interface ResolvedContentRef {
     text: string;
     /** Emoji associated with the reference */
     emoji?: string;
-    /** Icon associated with the reference */
-    icon?: CustomizationThemedURL | string;
     /** URL to open for the content ref */
     href: string;
     /** True if the content ref is active */
@@ -177,17 +174,11 @@ export async function resolveContentRef(
                 };
             }
 
-            const spaceCustomization = await ignoreAPIError(getSpaceCustomization(targetSpace.id));
-            const customFavicon = spaceCustomization?.favicon;
-            const customEmoji = customFavicon && 'emoji' in customFavicon ? customFavicon.emoji : null;
-            const customIcon = customFavicon && 'icon' in customFavicon ? customFavicon.icon : null;
-
             return {
                 href: targetSpace.urls.published ?? targetSpace.urls.app,
                 text: targetSpace.title,
                 active: true,
-                emoji: customEmoji ?? targetSpace.emoji,
-                icon: customIcon ?? targetSpace.urls.icon
+                emoji: targetSpace.emoji,
             };
         }
 


### PR DESCRIPTION
In this change, we:

- adds emoji to Space content ref
- remove the kind (Page/Space) pre title
- increases size of the leading emoji in the block

### Preview

![Screenshot 2024-07-11 at 10 53 48](https://github.com/GitbookIO/gitbook/assets/56626/8eb2bb92-0cde-4033-a1eb-19fd818b5183)
