### PR TITLE
Fix render of one of when alternatives are primitives

### DIFF
--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -182,6 +182,8 @@ export function OpenAPIRootSchema(props: {
 
 /**
  * Render a tab for an alternative schema.
+ * It renders directly the properties if relevant;
+ * for primitives, it renders the schema itself.
  */
 function OpenAPISchemaAlternative(props: {
     schema: OpenAPIV3.SchemaObject;
@@ -190,12 +192,13 @@ function OpenAPISchemaAlternative(props: {
 }) {
     const { schema, circularRefs, context } = props;
     const id = useId();
+    const subProperties = getSchemaProperties(schema);
 
     return (
         <OpenAPISchemaProperties
             id={id}
-            properties={getSchemaProperties(schema) ?? []}
-            circularRefs={new Map(circularRefs).set(schema, id)}
+            properties={subProperties ?? [{ schema }]}
+            circularRefs={subProperties ? new Map(circularRefs).set(schema, id) : circularRefs}
             context={context}
         />
     );


### PR DESCRIPTION
## Before:
<img width="1063" alt="Screenshot 2024-07-14 at 20 51 03" src="https://github.com/user-attachments/assets/7c725e3a-043c-47e8-b913-be62d351f495">


## After:

<img width="1062" alt="Screenshot 2024-07-14 at 20 51 16" src="https://github.com/user-attachments/assets/48480afd-12c3-471a-929b-9dea9ce176a2">