### PR TITLE
Update Site search endpoint

### DIFF
--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -36,7 +36,6 @@ type ResultType =
  */
 export const SearchResults = React.forwardRef(function SearchResults(
     props: {
-        organizationId?: string;
         children?: React.ReactNode;
         query: string;
         spaceId: string;

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -36,6 +36,7 @@ type ResultType =
  */
 export const SearchResults = React.forwardRef(function SearchResults(
     props: {
+        organizationId?: string;
         children?: React.ReactNode;
         query: string;
         spaceId: string;
@@ -96,6 +97,7 @@ export const SearchResults = React.forwardRef(function SearchResults(
                 const fetchedResults = await (parent
                     ? searchParentContent(parent, query)
                     : searchSpaceContent(spaceId, revisionId, query));
+
                 setResults(withAsk ? withQuestionResult(fetchedResults, query) : fetchedResults);
             }, 250);
 

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -54,9 +54,9 @@ export interface AskAnswerResult {
 export async function searchSiteContent(args: {
     query: string;
     siteSpaceIds?: string[];
-    cacheKey?: string;
+    cacheBust?: string;
 }): Promise<OrderedComputedResult[]> {
-    const { siteSpaceIds = [], query, cacheKey } = args;
+    const { siteSpaceIds = [], query, cacheBust } = args;
     const pointer = getContentPointer();
 
     if ('siteId' in pointer && 'organizationId' in pointer) {
@@ -65,7 +65,7 @@ export async function searchSiteContent(args: {
             pointer.siteId,
             query,
             siteSpaceIds,
-            cacheKey,
+            cacheBust,
         );
 
         // resolve all SiteSpaces so we can match up with the spaceId
@@ -124,7 +124,7 @@ export async function searchSpaceContent(
 
         // This is a site so use a different function which we can eventually call directly
         // We also want to break cache for this specific space if the revisionId is different so use it as a cache busting key
-        return await searchSiteContent({ siteSpaceIds, query, cacheKey: revisionId });
+        return await searchSiteContent({ siteSpaceIds, query, cacheBust: revisionId });
     }
 
     const data = await api.searchSpaceContent(spaceId, revisionId, query);

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -55,6 +55,7 @@ export interface AskAnswerResult {
 export async function searchSiteContent(
     siteSpaceIds: string[],
     query: string,
+    cacheKey: string,
 ): Promise<OrderedComputedResult[]> {
     const pointer = getContentPointer();
 
@@ -65,6 +66,7 @@ export async function searchSiteContent(
             pointer.siteId,
             query,
             siteSpaceIds,
+            cacheKey,
         );
 
         // resolve all SiteSpaces so we can match up with the spaceId
@@ -99,7 +101,8 @@ export async function searchSpaceContent(
         const siteSpaceIds = pointer.siteSpaceId ? [pointer.siteSpaceId] : []; // if we don't have a siteSpaceID search all content
 
         // This is a site so use a different endpoint
-        return await searchSiteContent(siteSpaceIds, query);
+        // We also want to break cache for this specific space if the revisionId is different so use it as a cache key
+        return await searchSiteContent(siteSpaceIds, query, revisionId);
     }
 
     const data = await api.searchSpaceContent(spaceId, revisionId, query);

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -62,14 +62,19 @@ export async function searchSpaceContent(
 ): Promise<OrderedComputedResult[]> {
     const pointer = getContentPointer();
 
-    if ('siteId' in pointer && 'organizationId' in pointer && pointer.siteSpaceId) {
+    if ('siteId' in pointer && 'organizationId' in pointer) {
+        const siteSpaceIds = pointer.siteSpaceId ? [pointer.siteSpaceId] : []; // if we don't have a siteSpaceID search all content
+
+        // This is a site so use a different endpoint
         const searchResults = await api.searchSiteContent(
             pointer.organizationId,
             pointer.siteId,
             query,
-            [pointer.siteSpaceId],
+            siteSpaceIds,
+            revisionId,
         );
 
+        // resolve all SiteSpaces so we can match up with the spaceId
         const allSiteSpaces = await api.getSiteSpaces({
             organizationId: pointer.organizationId,
             siteId: pointer.siteId,

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -74,7 +74,7 @@ export async function searchSiteContent(args: {
                 siteSpaceIds,
                 cacheBust,
             ),
-            api.getSiteSpaces({
+            siteSpaceIds ? null : api.getSiteSpaces({
                 organizationId: pointer.organizationId,
                 siteId: pointer.siteId,
                 siteShareKey: pointer.siteShareKey,

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -96,9 +96,10 @@ export async function searchParentContent(
     query: string,
 ): Promise<OrderedComputedResult[]> {
     const pointer = getContentPointer();
+    const isSite = 'siteId' in pointer;
 
     const [data, collectionSpaces, siteSpaces] = await Promise.all([
-        'siteId' in pointer
+        isSite
             ? api.searchSiteContent(pointer.organizationId, pointer.siteId, query, [])
             : api.searchParentContent(parent.id, query),
         parent.object === 'collection' ? api.getCollectionSpaces(parent.id) : null,

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -271,7 +271,7 @@ function transformSectionsAndPage(args: {
     return [page, sections];
 }
 
-export function transformSitePageResult(item: SearchPageResult, siteSpace?: SiteSpace) {
+function transformSitePageResult(item: SearchPageResult, siteSpace?: SiteSpace) {
     const [page, sections] = transformSectionsAndPage({
         item,
         space: siteSpace?.space,

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -52,26 +52,19 @@ export interface AskAnswerResult {
     hasAnswer: boolean;
 }
 
-/**
- * Server action to search content in a space
- */
-export async function searchSpaceContent(
-    spaceId: string,
-    revisionId: string,
+export async function searchSiteContent(
+    siteSpaceIds: string[],
     query: string,
 ): Promise<OrderedComputedResult[]> {
     const pointer = getContentPointer();
 
     if ('siteId' in pointer && 'organizationId' in pointer) {
-        const siteSpaceIds = pointer.siteSpaceId ? [pointer.siteSpaceId] : []; // if we don't have a siteSpaceID search all content
-
         // This is a site so use a different endpoint
         const searchResults = await api.searchSiteContent(
             pointer.organizationId,
             pointer.siteId,
             query,
             siteSpaceIds,
-            revisionId,
         );
 
         // resolve all SiteSpaces so we can match up with the spaceId
@@ -87,6 +80,26 @@ export async function searchSpaceContent(
                 return spaceItem.pages.map((item) => transformPageResult(item, space?.space));
             })
             .flat(2);
+    }
+
+    return [];
+}
+
+/**
+ * Server action to search content in a space
+ */
+export async function searchSpaceContent(
+    spaceId: string,
+    revisionId: string,
+    query: string,
+): Promise<OrderedComputedResult[]> {
+    const pointer = getContentPointer();
+
+    if ('siteId' in pointer && 'organizationId' in pointer) {
+        const siteSpaceIds = pointer.siteSpaceId ? [pointer.siteSpaceId] : []; // if we don't have a siteSpaceID search all content
+
+        // This is a site so use a different endpoint
+        return await searchSiteContent(siteSpaceIds, query);
     }
 
     const data = await api.searchSpaceContent(spaceId, revisionId, query);

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -60,7 +60,6 @@ export async function searchSiteContent(args: {
     const pointer = getContentPointer();
 
     if ('siteId' in pointer && 'organizationId' in pointer) {
-        // This is a site so use a different endpoint
         const searchResults = await api.searchSiteContent(
             pointer.organizationId,
             pointer.siteId,
@@ -106,6 +105,7 @@ export async function searchSiteContent(args: {
             .flat(2);
     }
 
+    // This should never happen
     return [];
 }
 

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -56,8 +56,13 @@ export async function searchSiteContent(args: {
     siteSpaceIds?: string[];
     cacheBust?: string;
 }): Promise<OrderedComputedResult[]> {
-    const { siteSpaceIds = [], query, cacheBust } = args;
+    const { siteSpaceIds, query, cacheBust } = args;
     const pointer = getContentPointer();
+
+    if (siteSpaceIds?.length === 0) {
+        // if we have no siteSpaces to search in then we won't find anything. skip the call.
+        return [];
+    }
 
     if ('siteId' in pointer && 'organizationId' in pointer) {
         const [searchResults, allSiteSpaces] = await Promise.all([
@@ -75,7 +80,7 @@ export async function searchSiteContent(args: {
             }),
         ]);
 
-        if (siteSpaceIds.length === 0) {
+        if (!siteSpaceIds) {
             // We are searching all of this Site's content
 
             const processedSiteSpaces = allSiteSpaces.map((siteSpace) => {

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -74,18 +74,20 @@ export async function searchSiteContent(args: {
                 siteSpaceIds,
                 cacheBust,
             ),
-            siteSpaceIds ? null : api.getSiteSpaces({
-                organizationId: pointer.organizationId,
-                siteId: pointer.siteId,
-                siteShareKey: pointer.siteShareKey,
-            }),
+            siteSpaceIds
+                ? null
+                : api.getSiteSpaces({
+                      organizationId: pointer.organizationId,
+                      siteId: pointer.siteId,
+                      siteShareKey: pointer.siteShareKey,
+                  }),
         ]);
 
         if (!siteSpaceIds) {
             // We are searching all of this Site's content
             return searchResults.items
                 .map((spaceItem) => {
-                    const siteSpace = allSiteSpaces.find(
+                    const siteSpace = allSiteSpaces?.find(
                         (siteSpace) => siteSpace.space.id === spaceItem.id,
                     );
 

--- a/src/components/Search/server-actions.tsx
+++ b/src/components/Search/server-actions.tsx
@@ -60,20 +60,20 @@ export async function searchSiteContent(args: {
     const pointer = getContentPointer();
 
     if ('siteId' in pointer && 'organizationId' in pointer) {
-        const searchResults = await api.searchSiteContent(
-            pointer.organizationId,
-            pointer.siteId,
-            query,
-            siteSpaceIds,
-            cacheBust,
-        );
-
-        // resolve all SiteSpaces so we can match up with the spaceId
-        const allSiteSpaces = await api.getSiteSpaces({
-            organizationId: pointer.organizationId,
-            siteId: pointer.siteId,
-            siteShareKey: pointer.siteShareKey,
-        });
+        const [searchResults, allSiteSpaces] = await Promise.all([
+            api.searchSiteContent(
+                pointer.organizationId,
+                pointer.siteId,
+                query,
+                siteSpaceIds,
+                cacheBust,
+            ),
+            api.getSiteSpaces({
+                organizationId: pointer.organizationId,
+                siteId: pointer.siteId,
+                siteShareKey: pointer.siteShareKey,
+            }),
+        ]);
 
         if (siteSpaceIds.length === 0) {
             // We are searching all of this Site's content

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1047,7 +1047,7 @@ export const searchParentContent = cache(
 );
 
 /**
- * Search content accross all spaces in a parent (site or collection).
+ * Search content in a Site or specific SiteSpaces.
  */
 export const searchSiteContent = cache(
     'api.searchSiteContent',
@@ -1056,14 +1056,13 @@ export const searchSiteContent = cache(
         siteId: string,
         query: string,
         siteSpaceIds: string[] = [],
-        /** The revision ID is used as a cache bust key, to avoid revalidating lot of cache entries by tags */
-        revisionId: string,
         options: CacheFunctionOptions,
     ) => {
         const response = await api().orgs.searchSiteContent(organizationId, siteId, {
             query,
             siteSpaceIds,
         });
+
         return cacheResponse(response, {
             ttl: 60 * 60,
             tags: [],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1056,12 +1056,22 @@ export const searchSiteContent = cache(
         siteId: string,
         query: string,
         siteSpaceIds: string[] = [],
-        options: CacheFunctionOptions,
+        cacheKey?: string,
+        options?: CacheFunctionOptions,
     ) => {
-        const response = await api().orgs.searchSiteContent(organizationId, siteId, {
-            query,
-            siteSpaceIds,
-        });
+        const response = await api().orgs.searchSiteContent(
+            organizationId,
+            siteId,
+            {
+                query,
+                siteSpaceIds,
+            },
+            undefined,
+            {
+                ...noCacheFetchOptions,
+                signal: options?.signal,
+            },
+        );
 
         return cacheResponse(response, {
             ttl: 60 * 60,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1056,8 +1056,8 @@ export const searchSiteContent = cache(
         siteId: string,
         query: string,
         siteSpaceIds: string[] = [],
-        /** A cache bust key to avoid revalidating lot of cache entries by tags */
-        cacheKey?: string,
+        /** A cache bust param to avoid revalidating lot of cache entries by tags */
+        cacheBust?: string,
         options?: CacheFunctionOptions,
     ) => {
         const response = await api().orgs.searchSiteContent(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1056,6 +1056,7 @@ export const searchSiteContent = cache(
         siteId: string,
         query: string,
         siteSpaceIds: string[] = [],
+        /** A cache bust key to avoid revalidating lot of cache entries by tags */
         cacheKey?: string,
         options?: CacheFunctionOptions,
     ) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1047,6 +1047,29 @@ export const searchParentContent = cache(
 );
 
 /**
+ * Search content accross all spaces in a parent (site or collection).
+ */
+export const searchSiteContent = cache(
+    'api.searchSiteContent',
+    async (
+        organizationId: string,
+        siteId: string,
+        query: string,
+        siteSpaceIds: string[] = [],
+        options: CacheFunctionOptions,
+    ) => {
+        const response = await api().orgs.searchSiteContent(organizationId, siteId, {
+            query,
+            siteSpaceIds,
+        });
+        return cacheResponse(response, {
+            ttl: 60 * 60,
+            tags: [],
+        });
+    },
+);
+
+/**
  * Get a list of recommended questions in a space.
  */
 export const getRecommendedQuestionsInSpace = cache(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1047,7 +1047,7 @@ export const searchParentContent = cache(
 );
 
 /**
- * Search content in a Site or specific SiteSpaces.
+ * Search content accross all spaces in a parent (site or collection).
  */
 export const searchSiteContent = cache(
     'api.searchSiteContent',
@@ -1056,6 +1056,8 @@ export const searchSiteContent = cache(
         siteId: string,
         query: string,
         siteSpaceIds: string[] = [],
+        /** The revision ID is used as a cache bust key, to avoid revalidating lot of cache entries by tags */
+        revisionId: string,
         options: CacheFunctionOptions,
     ) => {
         const response = await api().orgs.searchSiteContent(organizationId, siteId, {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1047,7 +1047,7 @@ export const searchParentContent = cache(
 );
 
 /**
- * Search content accross all spaces in a parent (site or collection).
+ * Search content in a Site or specific SiteSpaces.
  */
 export const searchSiteContent = cache(
     'api.searchSiteContent',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1055,7 +1055,7 @@ export const searchSiteContent = cache(
         organizationId: string,
         siteId: string,
         query: string,
-        siteSpaceIds: string[] = [],
+        siteSpaceIds?: string[],
         /** A cache bust param to avoid revalidating lot of cache entries by tags */
         cacheBust?: string,
         options?: CacheFunctionOptions,


### PR DESCRIPTION
This updates the endpoint used for sites to enable specific multi-space search support as well as proper analytics per site-space as opposed to per space (which can be used in multiple sites).

It also centralizes the logic into a function that can replace both `searchSpaceContent` and `searchParentContent` in the future.

