### PR TITLE
Use SpaceURL in getURL function to for cross-space searches

### DIFF
--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -266,7 +266,7 @@ function transformSectionsAndPage(args: {
         type: 'page',
         id: item.id,
         title: item.title,
-        href: getURL(item.path),
+        href: getURL(item.path, spaceURL),
         spaceTitle: space?.title,
     };
 


### PR DESCRIPTION
This fixes a bug where cross-space pages in search were not using the space URL properly
