### PR TITLE
Bump URL resolution caches after a recent hotfix.

### DIFF
--- a/packages/gitbook/src/lib/api.ts
+++ b/packages/gitbook/src/lib/api.ts
@@ -218,7 +218,7 @@ export const getSyncedBlockContent = cache(
  * Resolve a URL to the content to render.
  */
 export const getPublishedContentByUrl = cache(
-    'api.getPublishedContentByUrl',
+    'api.getPublishedContentByUrl.v2',
     async (url: string, visitorAuthToken: string | undefined, options: CacheFunctionOptions) => {
         const parsedURL = new URL(url);
 


### PR DESCRIPTION
After a recent hotfix to how URLs were resolved inside variants, we want to bump the caches to prevent users seeing old values.
