### PR TITLE
Bump getPublishedContentByUrl cache to fix a recent issue with the GitBook API

### DIFF
--- a/packages/gitbook/e2e/pages.spec.ts
+++ b/packages/gitbook/e2e/pages.spec.ts
@@ -403,11 +403,11 @@ const testCases: TestsCase[] = [
     },
     {
         name: 'Share links',
-        baseUrl: 'https://gitbook.gitbook.io/test-share-links/',
+        baseUrl: 'https://gitbook.gitbook.io/gbo-tests-share-links/',
         tests: [
             {
                 name: 'Valid link',
-                url: 'Fc6mMII9FKgnwm7qqynx/',
+                url: 'TGs8PkF4GWVtbmPnWhYL/',
                 run: waitForCookiesDialog,
             },
             {

--- a/packages/gitbook/src/lib/api.ts
+++ b/packages/gitbook/src/lib/api.ts
@@ -218,7 +218,7 @@ export const getSyncedBlockContent = cache(
  * Resolve a URL to the content to render.
  */
 export const getPublishedContentByUrl = cache(
-    'api.getPublishedContentByUrl.v2',
+    'api.getPublishedContentByUrl.v3',
     async (url: string, visitorAuthToken: string | undefined, options: CacheFunctionOptions) => {
         const parsedURL = new URL(url);
 


### PR DESCRIPTION
A recent issue with the GitBook API caused invalid URLs to be returned for some users. The fix has been applied to the URL, so we're bumping the cache to invalidate.
