### PR TITLE
Fix paragraph top margin in quote blocks

### DIFF
--- a/.changeset/odd-beds-walk.md
+++ b/.changeset/odd-beds-walk.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix margin for paragraphs in quote blocks

--- a/packages/gitbook/src/components/DocumentView/Annotation/Annotation.tsx
+++ b/packages/gitbook/src/components/DocumentView/Annotation/Annotation.tsx
@@ -27,6 +27,7 @@ export async function Annotation(props: InlineProps<DocumentInlineAnnotation>) {
                     ancestorBlocks={[]}
                     context={context}
                     nodes={fragment.nodes}
+                    style={['[&>:not(h1,h2,h3,h4)]:mt-5']}
                 />
             }
         >

--- a/packages/gitbook/src/components/DocumentView/Annotation/Annotation.tsx
+++ b/packages/gitbook/src/components/DocumentView/Annotation/Annotation.tsx
@@ -27,7 +27,7 @@ export async function Annotation(props: InlineProps<DocumentInlineAnnotation>) {
                     ancestorBlocks={[]}
                     context={context}
                     nodes={fragment.nodes}
-                    style={['[&>:not(h1,h2,h3,h4)]:mt-5']}
+                    style={['space-y-4']}
                 />
             }
         >

--- a/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
@@ -128,7 +128,7 @@ export function Expandable(props: BlockProps<DocumentBlockExpandable>) {
                 document={document}
                 ancestorBlocks={[...ancestorBlocks, block]}
                 context={context}
-                style={['px-10', 'pb-5', 'space-y-3']}
+                style={['px-10', 'pb-5', 'space-y-4']}
             />
         </details>
     );

--- a/packages/gitbook/src/components/DocumentView/Quote.tsx
+++ b/packages/gitbook/src/components/DocumentView/Quote.tsx
@@ -21,7 +21,7 @@ export function Quote(props: BlockProps<DocumentBlockQuote>) {
                 'border-dark/2',
                 'dark:text-light/7',
                 'dark:border-light/2',
-                '[&>:not(h1,h2,h3,h4)]:mt-5',
+                'space-y-4',
             ]}
         />
     );

--- a/packages/gitbook/src/components/DocumentView/Quote.tsx
+++ b/packages/gitbook/src/components/DocumentView/Quote.tsx
@@ -21,6 +21,7 @@ export function Quote(props: BlockProps<DocumentBlockQuote>) {
                 'border-dark/2',
                 'dark:text-light/7',
                 'dark:border-light/2',
+                '[&>*+*]:mt-5'
             ]}
         />
     );

--- a/packages/gitbook/src/components/DocumentView/Quote.tsx
+++ b/packages/gitbook/src/components/DocumentView/Quote.tsx
@@ -21,7 +21,7 @@ export function Quote(props: BlockProps<DocumentBlockQuote>) {
                 'border-dark/2',
                 'dark:text-light/7',
                 'dark:border-light/2',
-                '[&>*+*]:mt-5'
+                '[&>*+*]:mt-5',
             ]}
         />
     );

--- a/packages/gitbook/src/components/DocumentView/Quote.tsx
+++ b/packages/gitbook/src/components/DocumentView/Quote.tsx
@@ -21,7 +21,7 @@ export function Quote(props: BlockProps<DocumentBlockQuote>) {
                 'border-dark/2',
                 'dark:text-light/7',
                 'dark:border-light/2',
-                '[&>*+*]:mt-5',
+                '[&>:not(h1,h2,h3,h4)]:mt-5',
             ]}
         />
     );

--- a/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
@@ -19,7 +19,7 @@ export function Tabs(props: BlockProps<DocumentBlockTabs>) {
                 ancestorBlocks={[...ancestorBlocks, block, tab]}
                 context={context}
                 blockStyle={tcls('flip-heading-hash')}
-                style={tcls('w-full', 'space-y-6')}
+                style={tcls('w-full', 'space-y-4')}
             />
         ),
     }));


### PR DESCRIPTION
And also align other blocks that render children blocks

**Before**
e.g: https://www.isaacbowen.com/2024/05/20

![Screenshot 2024-08-08 at 15 55 02](https://github.com/user-attachments/assets/7be0b53f-1926-431d-8104-8a823a6bdee6)

**After**

e.g: https://4bae8341.gitbook-open.pages.dev/www.isaacbowen.com/2024/05/20

<img width="885" alt="Screenshot 2024-08-08 at 22 00 05" src="https://github.com/user-attachments/assets/49fb3ac4-a49b-4202-8b58-ad5fc0aad998">


**Preview for other blocks:**

https://4bae8341.gitbook-open.pages.dev/test-gitbook-organization.gitbook.io/paragraphs-spacing

Fix RND-3986