### PR TITLE
RND-3532: drop down menu for hidden links at small screen size

### DIFF
--- a/.changeset/clean-balloons-travel.md
+++ b/.changeset/clean-balloons-travel.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+RND-3532: drop down menu for hidden links at small screen size

--- a/packages/gitbook/src/components/Header/Dropdown.tsx
+++ b/packages/gitbook/src/components/Header/Dropdown.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@gitbook/icons';
 import { DetailedHTMLProps, HTMLAttributes, useId } from 'react';
 
-import { tcls } from '@/lib/tailwind';
+import { ClassValue, tcls } from '@/lib/tailwind';
 
 import { Link } from '../primitives';
 
@@ -19,7 +19,7 @@ export function Dropdown<E extends HTMLElement>(props: {
     /** Content of the dropdown */
     children: React.ReactNode;
     /** Custom styles */
-    className?: string;
+    className?: ClassValue;
 }) {
     const { button, children, className } = props;
     const dropdownId = useId();

--- a/packages/gitbook/src/components/Header/Dropdown.tsx
+++ b/packages/gitbook/src/components/Header/Dropdown.tsx
@@ -18,8 +18,10 @@ export function Dropdown<E extends HTMLElement>(props: {
     button: (buttonProps: DropdownButtonProps<E>) => React.ReactNode;
     /** Content of the dropdown */
     children: React.ReactNode;
+    /** Custom styles */
+    className?: string;
 }) {
-    const { button, children } = props;
+    const { button, children, className } = props;
     const dropdownId = useId();
 
     return (
@@ -47,6 +49,7 @@ export function Dropdown<E extends HTMLElement>(props: {
                     'duration-1000',
                     'group-hover/dropdown:visible',
                     'group-focus-within/dropdown:visible',
+                    className
                 )}
             >
                 <div

--- a/packages/gitbook/src/components/Header/Dropdown.tsx
+++ b/packages/gitbook/src/components/Header/Dropdown.tsx
@@ -49,7 +49,7 @@ export function Dropdown<E extends HTMLElement>(props: {
                     'duration-1000',
                     'group-hover/dropdown:visible',
                     'group-focus-within/dropdown:visible',
-                    className
+                    className,
                 )}
             >
                 <div

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -91,10 +91,11 @@ export function Header(props: {
                                 />
                             );
                         })}
-                        <HeaderLinkMore label={t(
-                            getSpaceLanguage(customization),
-                            'more'
-                        )} links={customization.header.links} context={context} />
+                        <HeaderLinkMore
+                            label={t(getSpaceLanguage(customization), 'more')}
+                            links={customization.header.links}
+                            context={context}
+                        />
                     </HeaderLinks>
                     <div
                         className={tcls(

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -14,6 +14,7 @@ import { ContentRefContext } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
 import { HeaderLink } from './HeaderLink';
+import { HeaderLinkMore } from './HeaderLinkMore';
 import { HeaderLinks } from './HeaderLinks';
 import { HeaderLogo } from './HeaderLogo';
 import { SpacesDropdown } from './SpacesDropdown';
@@ -90,6 +91,7 @@ export function Header(props: {
                                 />
                             );
                         })}
+                        <HeaderLinkMore links={customization.header.links} context={context} />
                     </HeaderLinks>
                     <div
                         className={tcls(

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -91,7 +91,10 @@ export function Header(props: {
                                 />
                             );
                         })}
-                        <HeaderLinkMore links={customization.header.links} context={context} />
+                        <HeaderLinkMore label={t(
+                            getSpaceLanguage(customization),
+                            'more'
+                        )} links={customization.header.links} context={context} />
                     </HeaderLinks>
                     <div
                         className={tcls(

--- a/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
@@ -17,7 +17,7 @@ export function HeaderLinkMore(props: {
     const { label, links, context } = props;
 
     const renderButton = () => (
-        <button>
+        <button className="px-1">
             <span className="sr-only">{label}</span>
             <DropdownChevron />
         </button>

--- a/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
@@ -1,7 +1,6 @@
 import { CustomizationHeaderLink } from '@gitbook/api';
 import React from 'react';
 
-//import { useLanguage, tString } from '@/intl/client';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 
 
@@ -14,18 +13,19 @@ import {
 import styles from './headerLinks.module.css';
 
 
-export function HeaderLinkMore({ links, context }: { links: CustomizationHeaderLink[]; context: ContentRefContext; }) {
+export function HeaderLinkMore(props: { label: React.ReactNode; links: CustomizationHeaderLink[]; context: ContentRefContext; }) {
+    const { label, links, context } = props;
 
-    //const language = useLanguage();
     const renderButton = () => (
-        <button 
-            aria-label='More' /* TODO: translation */
-        ><DropdownChevron /></button>
+        <button>
+            <span className="sr-only">{label}</span>
+            <DropdownChevron />
+        </button>
     );
    
     return (
         <div className={`${styles.linkEllipsis} items-center`}>
-            <Dropdown button={renderButton}
+            <Dropdown button={renderButton} className='-translate-x-48 md:translate-x-0'
             >
                 <DropdownMenu>
                     {links.map((link, index) => (

--- a/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
@@ -1,0 +1,49 @@
+import { CustomizationHeaderLink } from '@gitbook/api';
+import React from 'react';
+
+//import { useLanguage, tString } from '@/intl/client';
+import { ContentRefContext, resolveContentRef } from '@/lib/references';
+
+
+import {
+    Dropdown,
+    DropdownChevron,
+    DropdownMenu,
+    DropdownMenuItem,
+} from './Dropdown';
+import styles from './headerLinks.module.css';
+
+
+export function HeaderLinkMore({ links, context }: { links: CustomizationHeaderLink[]; context: ContentRefContext; }) {
+
+    //const language = useLanguage();
+    const renderButton = () => (
+        <button 
+            aria-label='More' /* TODO: translation */
+        ><DropdownChevron /></button>
+    );
+   
+    return (
+        <div className={`${styles.linkEllipsis} items-center`}>
+            <Dropdown button={renderButton}
+            >
+                <DropdownMenu>
+                    {links.map((link, index) => (
+                        <MoreMenuLink key={index} link={link} context={context} />
+                    ))}    
+                </DropdownMenu>
+            </Dropdown>
+        </div>);
+}
+
+async function MoreMenuLink(props: { context: ContentRefContext; link: CustomizationHeaderLink }) {
+    const { context, link } = props;
+
+    const target = await resolveContentRef(link.to, context);
+
+    if (!target) {
+        return null;
+    }
+
+    return <DropdownMenuItem href={target.href}>{link.title}</DropdownMenuItem>;
+}

--- a/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
@@ -6,6 +6,9 @@ import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { Dropdown, DropdownChevron, DropdownMenu, DropdownMenuItem } from './Dropdown';
 import styles from './headerLinks.module.css';
 
+/**
+ * Dropdown menu for header links hidden at small screen size.
+ */
 export function HeaderLinkMore(props: {
     label: React.ReactNode;
     links: CustomizationHeaderLink[];

--- a/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
@@ -3,17 +3,14 @@ import React from 'react';
 
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 
-
-import {
-    Dropdown,
-    DropdownChevron,
-    DropdownMenu,
-    DropdownMenuItem,
-} from './Dropdown';
+import { Dropdown, DropdownChevron, DropdownMenu, DropdownMenuItem } from './Dropdown';
 import styles from './headerLinks.module.css';
 
-
-export function HeaderLinkMore(props: { label: React.ReactNode; links: CustomizationHeaderLink[]; context: ContentRefContext; }) {
+export function HeaderLinkMore(props: {
+    label: React.ReactNode;
+    links: CustomizationHeaderLink[];
+    context: ContentRefContext;
+}) {
     const { label, links, context } = props;
 
     const renderButton = () => (
@@ -22,18 +19,18 @@ export function HeaderLinkMore(props: { label: React.ReactNode; links: Customiza
             <DropdownChevron />
         </button>
     );
-   
+
     return (
         <div className={`${styles.linkEllipsis} items-center`}>
-            <Dropdown button={renderButton} className='-translate-x-48 md:translate-x-0'
-            >
+            <Dropdown button={renderButton} className="-translate-x-48 md:translate-x-0">
                 <DropdownMenu>
                     {links.map((link, index) => (
                         <MoreMenuLink key={index} link={link} context={context} />
-                    ))}    
+                    ))}
                 </DropdownMenu>
             </Dropdown>
-        </div>);
+        </div>
+    );
 }
 
 async function MoreMenuLink(props: { context: ContentRefContext; link: CustomizationHeaderLink }) {

--- a/packages/gitbook/src/components/Header/headerLinks.module.css
+++ b/packages/gitbook/src/components/Header/headerLinks.module.css
@@ -3,37 +3,73 @@
     container-name: headerlinks;
 }
 
-.containerHeaderlinks > * {
+.containerHeaderlinks > a {
+    display: flex;
+}
+.linkEllipsis {
     display: none;
+    & div > a {
+        display: none;
+    }
 }
 
-@container headerlinks ( width > 150px ) {
-    .containerHeaderlinks > *:nth-child(1) {
+@container headerlinks ( width < 150px ) {
+    .containerHeaderlinks > a:nth-of-type(n+2) {
+        display: none;
+    }
+    .containerHeaderlinks > a:nth-of-type(n+2)  ~ .linkEllipsis {
         display: flex;
+        & div > a:nth-of-type(n+2) {
+            display: flex;
+        }
     }
 }
-@container headerlinks ( width > 300px ) {
-    .containerHeaderlinks > *:nth-child(2) {
-        display: flex;
+@container headerlinks ( width < 300px ) {
+    .containerHeaderlinks > a:nth-of-type(n+3) {
+        display: none;
     }
+    .containerHeaderlinks > a:nth-of-type(n+3)  ~ .linkEllipsis {
+        display: flex;
+        & div > a:nth-of-type(n+3) {
+            display: flex;
+        }
+     }
 }
-@container headerlinks ( width > 450px ) {
-    .containerHeaderlinks > *:nth-child(3) {
-        display: flex;
+@container headerlinks ( width < 450px ) {
+    .containerHeaderlinks > a:nth-of-type(n+4) {
+        display: none;
     }
+    .containerHeaderlinks > a:nth-of-type(n+4)  ~ .linkEllipsis {
+        display: flex;
+        & div > a:nth-of-type(n+4) {
+            display: flex;
+        }
+     }
 }
-@container headerlinks ( width > 600px ) {
-    .containerHeaderlinks > *:nth-child(4) {
-        display: flex;
+@container headerlinks ( width < 600px ) {
+    .containerHeaderlinks > a:nth-of-type(n+5) {
+        display: none;
     }
+    .containerHeaderlinks > a:nth-of-type(n+5) ~ .linkEllipsis {
+        display: flex;
+        & div > a:nth-of-type(n+5) {
+            display: flex;
+        }
+     }
+}
+@container headerlinks ( width < 750px ) {
+    .containerHeaderlinks > a:nth-of-type(n+6) {
+        display: none;
+    }
+    .containerHeaderlinks > a:nth-of-type(n+6) ~ .linkEllipsis {
+        display: flex;
+        & div > a:nth-of-type(n+6) {
+            display: flex;
+        }
+     }
 }
 @container headerlinks ( width > 750px ) {
-    .containerHeaderlinks > *:nth-child(5) {
-        display: flex;
-    }
-}
-@container headerlinks ( width > 900px ) {
-    .containerHeaderlinks > *:nth-child(n + 5) {
+    .containerHeaderlinks > a {
         display: flex;
     }
 }

--- a/packages/gitbook/src/components/Header/headerLinks.module.css
+++ b/packages/gitbook/src/components/Header/headerLinks.module.css
@@ -14,70 +14,70 @@
 }
 
 @container headerlinks ( width < 150px ) {
-    .containerHeaderlinks > a:nth-of-type(n+1) {
+    .containerHeaderlinks > a:nth-of-type(n + 1) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n+1)  ~ .linkEllipsis {
+    .containerHeaderlinks > a:nth-of-type(n + 1) ~ .linkEllipsis {
         display: flex;
-        & div > a:nth-of-type(n+1) {
+        & div > a:nth-of-type(n + 1) {
             display: flex;
         }
     }
 }
 @container headerlinks ( width < 300px ) {
-    .containerHeaderlinks > a:nth-of-type(n+2) {
+    .containerHeaderlinks > a:nth-of-type(n + 2) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n+2)  ~ .linkEllipsis {
+    .containerHeaderlinks > a:nth-of-type(n + 2) ~ .linkEllipsis {
         display: flex;
-        & div > a:nth-of-type(n+2) {
+        & div > a:nth-of-type(n + 2) {
             display: flex;
         }
-     }
+    }
 }
 @container headerlinks ( width < 450px ) {
-    .containerHeaderlinks > a:nth-of-type(n+3) {
+    .containerHeaderlinks > a:nth-of-type(n + 3) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n+3)  ~ .linkEllipsis {
+    .containerHeaderlinks > a:nth-of-type(n + 3) ~ .linkEllipsis {
         display: flex;
-        & div > a:nth-of-type(n+3) {
+        & div > a:nth-of-type(n + 3) {
             display: flex;
         }
-     }
+    }
 }
 @container headerlinks ( width < 600px ) {
-    .containerHeaderlinks > a:nth-of-type(n+4) {
+    .containerHeaderlinks > a:nth-of-type(n + 4) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n+4) ~ .linkEllipsis {
+    .containerHeaderlinks > a:nth-of-type(n + 4) ~ .linkEllipsis {
         display: flex;
-        & div > a:nth-of-type(n+4) {
+        & div > a:nth-of-type(n + 4) {
             display: flex;
         }
-     }
+    }
 }
 @container headerlinks ( width < 750px ) {
-    .containerHeaderlinks > a:nth-of-type(n+5) {
+    .containerHeaderlinks > a:nth-of-type(n + 5) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n+5) ~ .linkEllipsis {
+    .containerHeaderlinks > a:nth-of-type(n + 5) ~ .linkEllipsis {
         display: flex;
-        & div > a:nth-of-type(n+5) {
+        & div > a:nth-of-type(n + 5) {
             display: flex;
         }
-     }
+    }
 }
 @container headerlinks ( width < 900px ) {
-    .containerHeaderlinks > a:nth-of-type(n+6) {
+    .containerHeaderlinks > a:nth-of-type(n + 6) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n+6) ~ .linkEllipsis {
+    .containerHeaderlinks > a:nth-of-type(n + 6) ~ .linkEllipsis {
         display: flex;
-        & div > a:nth-of-type(n+6) {
+        & div > a:nth-of-type(n + 6) {
             display: flex;
         }
-     }
+    }
 }
 @container headerlinks ( width > 900px ) {
     .containerHeaderlinks > a {

--- a/packages/gitbook/src/components/Header/headerLinks.module.css
+++ b/packages/gitbook/src/components/Header/headerLinks.module.css
@@ -3,7 +3,7 @@
     container-name: headerlinks;
 }
 
-.containerHeaderlinks > a {
+.containerHeaderlinks > * {
     display: flex;
 }
 .linkEllipsis {
@@ -14,10 +14,10 @@
 }
 
 @container headerlinks ( width < 150px ) {
-    .containerHeaderlinks > a:nth-of-type(n + 1) {
+    .containerHeaderlinks > :nth-child(n + 1) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n + 1) ~ .linkEllipsis {
+    .containerHeaderlinks > :nth-child(n + 1) ~ .linkEllipsis {
         display: flex;
         & div > a:nth-of-type(n + 1) {
             display: flex;
@@ -25,10 +25,10 @@
     }
 }
 @container headerlinks ( width < 300px ) {
-    .containerHeaderlinks > a:nth-of-type(n + 2) {
+    .containerHeaderlinks > :nth-child(n + 2) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n + 2) ~ .linkEllipsis {
+    .containerHeaderlinks > :nth-child(n + 2) ~ .linkEllipsis {
         display: flex;
         & div > a:nth-of-type(n + 2) {
             display: flex;
@@ -36,10 +36,10 @@
     }
 }
 @container headerlinks ( width < 450px ) {
-    .containerHeaderlinks > a:nth-of-type(n + 3) {
+    .containerHeaderlinks > :nth-child(n + 3) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n + 3) ~ .linkEllipsis {
+    .containerHeaderlinks > :nth-child(n + 3) ~ .linkEllipsis {
         display: flex;
         & div > a:nth-of-type(n + 3) {
             display: flex;
@@ -47,10 +47,10 @@
     }
 }
 @container headerlinks ( width < 600px ) {
-    .containerHeaderlinks > a:nth-of-type(n + 4) {
+    .containerHeaderlinks > :nth-child(n + 4) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n + 4) ~ .linkEllipsis {
+    .containerHeaderlinks > :nth-child(n + 4) ~ .linkEllipsis {
         display: flex;
         & div > a:nth-of-type(n + 4) {
             display: flex;
@@ -58,21 +58,21 @@
     }
 }
 @container headerlinks ( width < 750px ) {
-    .containerHeaderlinks > a:nth-of-type(n + 5) {
+    .containerHeaderlinks > :nth-child(n + 5) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n + 5) ~ .linkEllipsis {
+    .containerHeaderlinks > :nth-child(n + 5) ~ .linkEllipsis {
         display: flex;
-        & div > a:nth-of-type(n + 5) {
+        & div > :nth-child(n + 5) {
             display: flex;
         }
     }
 }
 @container headerlinks ( width < 900px ) {
-    .containerHeaderlinks > a:nth-of-type(n + 6) {
+    .containerHeaderlinks > :nth-child(n + 6) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n + 6) ~ .linkEllipsis {
+    .containerHeaderlinks > :nth-child(n + 6) ~ .linkEllipsis {
         display: flex;
         & div > a:nth-of-type(n + 6) {
             display: flex;
@@ -80,7 +80,7 @@
     }
 }
 @container headerlinks ( width > 900px ) {
-    .containerHeaderlinks > a {
+    .containerHeaderlinks > *:not(.linkEllipsis) {
         display: flex;
     }
 }

--- a/packages/gitbook/src/components/Header/headerLinks.module.css
+++ b/packages/gitbook/src/components/Header/headerLinks.module.css
@@ -14,6 +14,17 @@
 }
 
 @container headerlinks ( width < 150px ) {
+    .containerHeaderlinks > a:nth-of-type(n+1) {
+        display: none;
+    }
+    .containerHeaderlinks > a:nth-of-type(n+1)  ~ .linkEllipsis {
+        display: flex;
+        & div > a:nth-of-type(n+1) {
+            display: flex;
+        }
+    }
+}
+@container headerlinks ( width < 300px ) {
     .containerHeaderlinks > a:nth-of-type(n+2) {
         display: none;
     }
@@ -22,9 +33,9 @@
         & div > a:nth-of-type(n+2) {
             display: flex;
         }
-    }
+     }
 }
-@container headerlinks ( width < 300px ) {
+@container headerlinks ( width < 450px ) {
     .containerHeaderlinks > a:nth-of-type(n+3) {
         display: none;
     }
@@ -35,18 +46,18 @@
         }
      }
 }
-@container headerlinks ( width < 450px ) {
+@container headerlinks ( width < 600px ) {
     .containerHeaderlinks > a:nth-of-type(n+4) {
         display: none;
     }
-    .containerHeaderlinks > a:nth-of-type(n+4)  ~ .linkEllipsis {
+    .containerHeaderlinks > a:nth-of-type(n+4) ~ .linkEllipsis {
         display: flex;
         & div > a:nth-of-type(n+4) {
             display: flex;
         }
      }
 }
-@container headerlinks ( width < 600px ) {
+@container headerlinks ( width < 750px ) {
     .containerHeaderlinks > a:nth-of-type(n+5) {
         display: none;
     }
@@ -57,7 +68,7 @@
         }
      }
 }
-@container headerlinks ( width < 750px ) {
+@container headerlinks ( width < 900px ) {
     .containerHeaderlinks > a:nth-of-type(n+6) {
         display: none;
     }
@@ -68,7 +79,7 @@
         }
      }
 }
-@container headerlinks ( width > 750px ) {
+@container headerlinks ( width > 900px ) {
     .containerHeaderlinks > a {
         display: flex;
     }

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -53,4 +53,5 @@ export const de = {
     pdf_limit_reached:
         'Das PDF konnte für ${1} Seiten nicht generiert werden, Generierung wurde bei ${2} gestoppt.',
     pdf_limit_reached_continue: 'Mit ${1} weiteren Seiten erweitern.',
+    more: 'Mehr',
 };

--- a/packages/gitbook/src/intl/translations/en.ts
+++ b/packages/gitbook/src/intl/translations/en.ts
@@ -51,4 +51,5 @@ export const en = {
     pdf_mode_all: 'All pages',
     pdf_limit_reached: "Couldn't generate the PDF for ${1} pages, generation stopped at ${2}.",
     pdf_limit_reached_continue: 'Extend with ${1} more pages.',
+    more: 'More',
 };

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -55,4 +55,5 @@ export const es: TranslationLanguage = {
     pdf_limit_reached:
         'No se pudo generar el PDF para ${1} páginas, la generación se detuvo en ${2}.',
     pdf_limit_reached_continue: 'Extender con ${1} páginas más.',
+    more: 'Más',
 };

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -53,5 +53,5 @@ export const fr: TranslationLanguage = {
     pdf_mode_all: 'Toutes les pages',
     pdf_limit_reached: 'Impossible de générer le PDF pour ${1} pages, génération arrêtée à ${2}.',
     pdf_limit_reached_continue: 'Étendre avec ${1} pages supplémentaires.',
-    more: 'Plus'
+    more: 'Plus',
 };

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -53,4 +53,5 @@ export const fr: TranslationLanguage = {
     pdf_mode_all: 'Toutes les pages',
     pdf_limit_reached: 'Impossible de générer le PDF pour ${1} pages, génération arrêtée à ${2}.',
     pdf_limit_reached_continue: 'Étendre avec ${1} pages supplémentaires.',
+    more: 'Plus'
 };

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -53,4 +53,5 @@ export const ja: TranslationLanguage = {
     pdf_mode_all: '全てのページ',
     pdf_limit_reached: '${1}ページのPDFを生成できませんでした、${2}で生成が停止しました。',
     pdf_limit_reached_continue: 'さらに${1}ページで拡張',
+    more: '詳細',
 };

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -53,4 +53,5 @@ export const pt_br = {
     pdf_limit_reached:
         'Não foi possível gerar o PDF para ${1} páginas, generation stopped at ${2}.',
     pdf_limit_reached_continue: 'Extender com mais ${1} páginas.',
+    more: 'Mais',
 };

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -51,4 +51,5 @@ export const zh: TranslationLanguage = {
     pdf_mode_all: '所有页面',
     pdf_limit_reached: '无法为${1}页生成 PDF，生成在${2}页时停止。',
     pdf_limit_reached_continue: '使用${1}页进行扩展。',
+    more: '更多'
 };

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -51,5 +51,5 @@ export const zh: TranslationLanguage = {
     pdf_mode_all: '所有页面',
     pdf_limit_reached: '无法为${1}页生成 PDF，生成在${2}页时停止。',
     pdf_limit_reached_continue: '使用${1}页进行扩展。',
-    more: '更多'
+    more: '更多',
 };


### PR DESCRIPTION
Adds a `HeaderLinkMore` button when links are hidden which shows a drop down menu with the hidden links.

This PR extends the container query based css solution so the components don't need to 'use client'.

![Screenshot 2024-08-19 at 09 49 17](https://github.com/user-attachments/assets/fad53cd5-e6fd-4fd2-8678-483b8aed3d04)

![Screenshot 2024-08-19 at 09 49 38](https://github.com/user-attachments/assets/e09c6fae-817e-4a00-a174-6eddc3a2e629)

