### PR TITLE
RND-3113: expand when expandable anchor 

### DIFF
--- a/.changeset/ninety-starfishes-refuse.md
+++ b/.changeset/ninety-starfishes-refuse.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Use url hash to open Expandable and scroll to anchor

--- a/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import React from 'react';
 
@@ -10,31 +10,40 @@ function useHash() {
     const [hash, setHash] = React.useState<string>(global.location?.hash?.slice(1));
     React.useEffect(() => {
         function updateHash() {
-            setHash( global.location?.hash?.slice(1));
+            setHash(global.location?.hash?.slice(1));
         }
         global.addEventListener('hashchange', updateHash);
         updateHash();
-        return () => global.removeEventListener('hashchange', updateHash); 
+        return () => global.removeEventListener('hashchange', updateHash);
     }, [params]);
     return hash;
 }
+
 /**
  * Details component rendered on client so it can expand dependent on url hash changes.
  */
-export function Details(props: { children : React.ReactNode; id: string; contentIds?: string[]; open?: boolean; className?: ClassValue; }) {
+export function Details(props: {
+    children: React.ReactNode;
+    id: string;
+    contentIds?: string[];
+    open?: boolean;
+    className?: ClassValue;
+}) {
     const { children, id, open, className } = props;
-    
+
     const detailsRef = React.useRef<HTMLDetailsElement>(null);
 
     const [anchorElement, setAnchorElement] = React.useState<Element | null | undefined>();
 
     const hash = useHash();
     React.useEffect(() => {
-        if (!hash) { return; }
-        const descendant = hash === id ? detailsRef.current : detailsRef.current?.querySelector(`#${hash}`);
+        if (!hash) {
+            return;
+        }
+        const descendant =
+            hash === id ? detailsRef.current : detailsRef.current?.querySelector(`#${hash}`);
         setAnchorElement(descendant);
     }, [hash, id]);
-
 
     React.useLayoutEffect(() => {
         if (anchorElement) {

--- a/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useParams } from 'next/navigation';
+import React from 'react';
+
+import { ClassValue, tcls } from '@/lib/tailwind';
+
+
+/**
+ * Details component rendered on client so it can expand dependent on url hash changes.
+ */
+export function Details(props: { children : React.ReactNode; id: string; contentIds?: string[]; open?: boolean; className?: ClassValue; }) {
+    const { children, id, contentIds = [], open, className } = props;
+    const params = useParams();
+    const [hash, setHash] = React.useState<string | null>(null);
+    
+    React.useEffect(() => {
+        function updateHash() {
+            const urlHash = global?.location?.hash;
+            if (urlHash !== hash) {
+                setHash(urlHash.slice(1));
+                const element = document.getElementById(urlHash.slice(1));
+                if (element) {
+                    element.scrollIntoView({
+                        block: 'start',
+                        behavior: 'smooth',
+                    });
+                }
+            }
+        }
+        addEventListener('hashchange', updateHash);
+        updateHash();
+        return () => removeEventListener('hashchange', updateHash); 
+    }, [params, hash, open])
+    
+    const isOpen = open || [id, ...contentIds].some(id => hash === id);
+
+    return (
+        <details
+            id={id}
+            open={isOpen}
+            className={tcls(
+                className,
+                'group/expandable',
+                'shadow-dark/1',
+                'bg-gradient-to-t',
+                'from-light-1',
+                'to-light-1',
+                'border',
+                'border-b-0',
+                'border-dark-3/3',
+                //all
+                '[&]:mt-[0px]',
+                //select first child
+                '[&:first-child]:mt-5',
+                '[&:first-child]:rounded-t-lg',
+                //select first in group
+                '[:not(&)_+&]:mt-5',
+                '[:not(&)_+&]:rounded-t-lg',
+                //select last in group
+                '[&:not(:has(+_&))]:mb-5',
+                '[&:not(:has(+_&))]:rounded-b-lg',
+                '[&:not(:has(+_&))]:border-b',
+                /* '[&:not(:has(+_&))]:shadow-1xs', */
+
+                'dark:border-light-2/[0.06]',
+                'dark:from-dark-2',
+                'dark:to-dark-2',
+                'dark:shadow-none',
+
+                'group open:dark:to-dark-2/8',
+                'group open:to-light-1/6',
+            )}
+        >
+            {children}
+        </details>
+    );
+}

--- a/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
@@ -2,8 +2,8 @@
 
 import React from 'react';
 
-import { ClassValue, tcls } from '@/lib/tailwind';
 import { useHash } from '@/components/hooks';
+import { ClassValue, tcls } from '@/lib/tailwind';
 
 /**
  * Details component rendered on client so it can expand dependent on url hash changes.
@@ -31,9 +31,8 @@ export function Details(props: {
             return;
         }
         if (hash === id) {
-            setAnchorElement(detailsRef.current)
-        }
-        else {
+            setAnchorElement(detailsRef.current);
+        } else {
             const activeElement = document.getElementById(hash);
             if (activeElement && detailsRef.current?.contains(activeElement)) {
                 setAnchorElement(activeElement);

--- a/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { useParams } from 'next/navigation';
 import React from 'react';
 
 import { ClassValue, tcls } from '@/lib/tailwind';
-import { useParams } from 'next/navigation';
 
 function useHash() {
     const params = useParams();

--- a/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
@@ -1,23 +1,9 @@
 'use client';
 
-import { useParams } from 'next/navigation';
 import React from 'react';
 
 import { ClassValue, tcls } from '@/lib/tailwind';
-
-function useHash() {
-    const params = useParams();
-    const [hash, setHash] = React.useState<string>(global.location?.hash?.slice(1));
-    React.useEffect(() => {
-        function updateHash() {
-            setHash(global.location?.hash?.slice(1));
-        }
-        global.addEventListener('hashchange', updateHash);
-        updateHash();
-        return () => global.removeEventListener('hashchange', updateHash);
-    }, [params]);
-    return hash;
-}
+import { useHash } from '@/components/hooks';
 
 /**
  * Details component rendered on client so it can expand dependent on url hash changes.
@@ -36,23 +22,24 @@ export function Details(props: {
     const [anchorElement, setAnchorElement] = React.useState<Element | null | undefined>();
 
     const hash = useHash();
+    /**
+     * Open the details element if the url hash refers to the id of the details element
+     * or the id of some element contained within the details element.
+     */
     React.useEffect(() => {
-        if (!hash) {
+        if (!hash || !detailsRef.current) {
             return;
         }
-        const descendant =
-            hash === id ? detailsRef.current : detailsRef.current?.querySelector(`#${hash}`);
-        setAnchorElement(descendant);
-    }, [hash, id]);
-
-    React.useLayoutEffect(() => {
-        if (anchorElement) {
-            anchorElement.scrollIntoView({
-                block: 'start',
-                behavior: 'smooth',
-            });
+        if (hash === id) {
+            setAnchorElement(detailsRef.current)
         }
-    }, [anchorElement]);
+        else {
+            const activeElement = document.getElementById(hash);
+            if (activeElement && detailsRef.current?.contains(activeElement)) {
+                setAnchorElement(activeElement);
+            }
+        }
+    }, [hash, id]);
 
     return (
         <details

--- a/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Details.tsx
@@ -15,11 +15,11 @@ export function Details(props: {
     open?: boolean;
     className?: ClassValue;
 }) {
-    const { children, id, open, className } = props;
+    const { children, id, className } = props;
 
     const detailsRef = React.useRef<HTMLDetailsElement>(null);
 
-    const [anchorElement, setAnchorElement] = React.useState<Element | null | undefined>();
+    const [openFromHash, setOpenFromHash] = React.useState(false);
 
     const hash = useHash();
     /**
@@ -31,20 +31,17 @@ export function Details(props: {
             return;
         }
         if (hash === id) {
-            setAnchorElement(detailsRef.current);
-        } else {
-            const activeElement = document.getElementById(hash);
-            if (activeElement && detailsRef.current?.contains(activeElement)) {
-                setAnchorElement(activeElement);
-            }
+            setOpenFromHash(true);
         }
+        const activeElement = document.getElementById(hash);
+        setOpenFromHash(Boolean(activeElement && detailsRef.current?.contains(activeElement)));
     }, [hash, id]);
 
     return (
         <details
             ref={detailsRef}
             id={id}
-            open={open || Boolean(anchorElement)}
+            open={props.open || openFromHash}
             className={tcls(
                 className,
                 'group/expandable',

--- a/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
@@ -9,20 +9,6 @@ import { BlockProps } from '../Block';
 import { Blocks } from '../Blocks';
 import { Inlines } from '../Inlines';
 
-/**
- * Find nodes with ids within Expandable section's content.
- */
-function getIdsInNodes(nodes: DocumentBlocksEssentials[]): string[] {
-    const ids = []
-    for (const node of nodes) {
-        if ('meta' in node && typeof node.meta?.id === 'string') { ids.push(node.meta?.id); }
-        if ('nodes' in node && node.nodes.length > 0) {
-            ids.push(...getIdsInNodes(node.nodes as any[]))
-        }
-    }
-    return ids.filter(Boolean);
-}
-
 export function Expandable(props: BlockProps<DocumentBlockExpandable>) {
     const { block, style, ancestorBlocks, document, context } = props;
 
@@ -41,7 +27,6 @@ export function Expandable(props: BlockProps<DocumentBlockExpandable>) {
     return (
         <Details
             id={id}
-            contentIds={getIdsInNodes(body.nodes)}
             open={context.mode === 'print'}
             className={style}
         >

--- a/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
@@ -1,4 +1,4 @@
-import { DocumentBlockExpandable, DocumentBlocksEssentials } from '@gitbook/api';
+import { DocumentBlockExpandable } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
 
 import { getNodeFragmentByType } from '@/lib/document';

--- a/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
+++ b/packages/gitbook/src/components/DocumentView/Expandable/Expandable.tsx
@@ -20,16 +20,12 @@ export function Expandable(props: BlockProps<DocumentBlockExpandable>) {
     if (!title || !body || titleParagraph?.type !== 'paragraph') {
         return null;
     }
-    
+
     let id = block.meta?.id ?? '';
     id = context.getId ? context.getId(id) : id;
-    
+
     return (
-        <Details
-            id={id}
-            open={context.mode === 'print'}
-            className={style}
-        >
+        <Details id={id} open={context.mode === 'print'} className={style}>
             <summary
                 className={tcls(
                     'cursor-pointer',

--- a/packages/gitbook/src/components/hooks/index.ts
+++ b/packages/gitbook/src/components/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useScrollActiveId';
 export * from './useScrollToHash';
+export * from './useHash';

--- a/packages/gitbook/src/components/hooks/useHash.ts
+++ b/packages/gitbook/src/components/hooks/useHash.ts
@@ -1,0 +1,19 @@
+import { useParams } from 'next/navigation';
+import React from 'react';
+
+export function useHash() {
+    const params = useParams();
+    const [hash, setHash] = React.useState<string>(global.location?.hash?.slice(1));
+    React.useEffect(() => {
+        function updateHash() {
+            setHash(global.location?.hash?.slice(1));
+        }
+        global.addEventListener('hashchange', updateHash);
+        updateHash();
+        return () => global.removeEventListener('hashchange', updateHash);
+    // With next.js, the hashchange event is not triggered when the hash changes
+    // Instead a hack is to use the `useParams` hook to listen to changes in the hash
+    // https://github.com/vercel/next.js/discussions/49465#discussioncomment-5845312
+    }, [params]);
+    return hash;
+}

--- a/packages/gitbook/src/components/hooks/useHash.ts
+++ b/packages/gitbook/src/components/hooks/useHash.ts
@@ -11,9 +11,9 @@ export function useHash() {
         global.addEventListener('hashchange', updateHash);
         updateHash();
         return () => global.removeEventListener('hashchange', updateHash);
-    // With next.js, the hashchange event is not triggered when the hash changes
-    // Instead a hack is to use the `useParams` hook to listen to changes in the hash
-    // https://github.com/vercel/next.js/discussions/49465#discussioncomment-5845312
+        // With next.js, the hashchange event is not triggered when the hash changes
+        // Instead a hack is to use the `useParams` hook to listen to changes in the hash
+        // https://github.com/vercel/next.js/discussions/49465#discussioncomment-5845312
     }, [params]);
     return hash;
 }

--- a/packages/gitbook/src/components/hooks/useScrollToHash.ts
+++ b/packages/gitbook/src/components/hooks/useScrollToHash.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useHash } from './useHash';
 
 /**

--- a/packages/gitbook/src/components/hooks/useScrollToHash.ts
+++ b/packages/gitbook/src/components/hooks/useScrollToHash.ts
@@ -1,16 +1,14 @@
-import { useParams } from 'next/navigation';
 import React from 'react';
+import { useHash } from './useHash';
 
 /**
  * Scroll to the current URL hash everytime the URL changes.
  */
 export function useScrollToHash() {
-    const params = useParams();
-
-    const scrollToHash = React.useCallback(() => {
-        const hash = window.location.hash;
+    const hash = useHash();
+    React.useLayoutEffect(() => {
         if (hash) {
-            const element = document.getElementById(hash.slice(1));
+            const element = document.getElementById(hash);
             if (element) {
                 element.scrollIntoView({
                     block: 'start',
@@ -18,12 +16,5 @@ export function useScrollToHash() {
                 });
             }
         }
-    }, []);
-
-    // With next.js, the hashchange event is not triggered when the hash changes
-    // Instead a hack is to use the `useParams` hook to listen to changes in the hash
-    // https://github.com/vercel/next.js/discussions/49465#discussioncomment-5845312
-    React.useEffect(() => {
-        scrollToHash();
-    }, [params, scrollToHash]);
+    }, [hash]);
 }


### PR DESCRIPTION
With this PR, anchor ids for expandable sections and also the content within expandable sections are now matched to the url hash. 

If there's a match, expand the expandable and scroll into view.