### PR TITLE
Filter out short searches less then 2 chars, bigger debounce

### DIFF
--- a/packages/gitbook/src/components/Search/SearchResults.tsx
+++ b/packages/gitbook/src/components/Search/SearchResults.tsx
@@ -98,7 +98,7 @@ export const SearchResults = React.forwardRef(function SearchResults(
                     : searchSpaceContent(spaceId, revisionId, query));
 
                 setResults(withAsk ? withQuestionResult(fetchedResults, query) : fetchedResults);
-            }, 250);
+            }, 400);
 
             return () => {
                 if (debounceTimeout.current) {

--- a/packages/gitbook/src/components/Search/SearchResults.tsx
+++ b/packages/gitbook/src/components/Search/SearchResults.tsx
@@ -98,7 +98,7 @@ export const SearchResults = React.forwardRef(function SearchResults(
                     : searchSpaceContent(spaceId, revisionId, query));
 
                 setResults(withAsk ? withQuestionResult(fetchedResults, query) : fetchedResults);
-            }, 400);
+            }, 350);
 
             return () => {
                 if (debounceTimeout.current) {

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -60,6 +60,10 @@ export async function searchSiteContent(args: {
     const { siteSpaceIds, query, cacheBust } = args;
     const pointer = getContentPointer();
 
+    if (query.length < 3) {
+        return [];
+    }
+
     if (siteSpaceIds?.length === 0) {
         // if we have no siteSpaces to search in then we won't find anything. skip the call.
         return [];

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -60,7 +60,7 @@ export async function searchSiteContent(args: {
     const { siteSpaceIds, query, cacheBust } = args;
     const pointer = getContentPointer();
 
-    if (query.length < 3) {
+    if (query.length <= 1) {
         return [];
     }
 


### PR DESCRIPTION
This filters out searches that are too short for any kind of useful results and adjusts the search debounce time to better match typing speeds.
