### PR TITLE
Response examples with status code tabs

### DIFF
--- a/.changeset/strange-eyes-notice.md
+++ b/.changeset/strange-eyes-notice.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Adds tabs to Response Example section e.g. for status code examples

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -36,37 +36,36 @@ export function OpenAPIResponseExample(props: {
         }
         return Number(a) - Number(b);
     });
-    // Take the first one
-    const response = responses[0];
 
-    if (!response) {
-        return null;
-    }
+    const examples = responses.map(response => {
+        const responseObject = noReference(response[1]);
 
-    const responseObject = noReference(response[1]);
+        const schema = noReference(
+            (
+                responseObject.content?.['application/json'] ??
+                responseObject.content?.[Object.keys(responseObject.content)[0]]
+            )?.schema,
+        );
 
-    const schema = noReference(
-        (
-            responseObject.content?.['application/json'] ??
-            responseObject.content?.[Object.keys(responseObject.content)[0]]
-        )?.schema,
-    );
+        if (!schema) { return null; }
+        
+        const example = generateSchemaExample(schema);
+        return ({
+            key: `${response[0]}`,
+            label: `${response[0]}`,
+            body: <context.CodeBlock
+                code={typeof example === 'string' ? example : JSON.stringify(example, null, 2)}
+                syntax="json"
+        />
+        })
+    })
+    .filter((val): val is { key: string, label: string, body: any } => Boolean(val));
 
-    if (!schema) {
-        return null;
-    }
-
-    const example = generateSchemaExample(schema);
-    if (example === undefined) {
+    if (examples.length === 0) {
         return null;
     }
 
     return (
-        <InteractiveSection header="Response" className="openapi-response-example">
-            <context.CodeBlock
-                code={typeof example === 'string' ? example : JSON.stringify(example, null, 2)}
-                syntax="json"
-            />
-        </InteractiveSection>
+        <InteractiveSection header="Response" className="openapi-response-example" tabs={examples} />
     );
 }

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -37,35 +37,46 @@ export function OpenAPIResponseExample(props: {
         return Number(a) - Number(b);
     });
 
-    const examples = responses.map(response => {
-        const responseObject = noReference(response[1]);
+    const examples = responses
+        .map((response) => {
+            const responseObject = noReference(response[1]);
 
-        const schema = noReference(
-            (
-                responseObject.content?.['application/json'] ??
-                responseObject.content?.[Object.keys(responseObject.content)[0]]
-            )?.schema,
-        );
+            const schema = noReference(
+                (
+                    responseObject.content?.['application/json'] ??
+                    responseObject.content?.[Object.keys(responseObject.content)[0]]
+                )?.schema,
+            );
 
-        if (!schema) { return null; }
-        
-        const example = generateSchemaExample(schema);
-        return ({
-            key: `${response[0]}`,
-            label: `${response[0]}`,
-            body: <context.CodeBlock
-                code={typeof example === 'string' ? example : JSON.stringify(example, null, 2)}
-                syntax="json"
-        />
+            if (!schema) {
+                return null;
+            }
+
+            const example = generateSchemaExample(schema);
+            return {
+                key: `${response[0]}`,
+                label: `${response[0]}`,
+                body: (
+                    <context.CodeBlock
+                        code={
+                            typeof example === 'string' ? example : JSON.stringify(example, null, 2)
+                        }
+                        syntax="json"
+                    />
+                ),
+            };
         })
-    })
-    .filter((val): val is { key: string, label: string, body: any } => Boolean(val));
+        .filter((val): val is { key: string; label: string; body: any } => Boolean(val));
 
     if (examples.length === 0) {
         return null;
     }
 
     return (
-        <InteractiveSection header="Response" className="openapi-response-example" tabs={examples} />
+        <InteractiveSection
+            header="Response"
+            className="openapi-response-example"
+            tabs={examples}
+        />
     );
 }


### PR DESCRIPTION
This PR adds tabs to responses examples section allowing access to all the example status codes.

It does not currently connect the status code selection in the Response section with the example in the Response example section as suggested in the original ticket (RND-3387).

Contributes to RND-3387