### PR TITLE
Update search/ask wording for Japanese localization to fit UI better

### DIFF
--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -7,7 +7,7 @@ export const ja: TranslationLanguage = {
     switch_to_light_theme: 'ライトテーマに切り替え',
     switch_to_system_theme: 'システムのテーマに切り替え',
     search: '検索',
-    search_or_ask: '質問するか検索する',
+    search_or_ask: '質問または検索',
     search_input_placeholder: 'コンテンツを検索',
     search_ask_input_placeholder: 'コンテンツを検索するか質問をする',
     search_no_results: '"${1}" の結果はありません。',


### PR DESCRIPTION
First discussed here: https://github.com/orgs/GitbookIO/discussions/721

Current UI: 
<img width="290" alt="Screenshot 2024-09-12 at 09 38 42" src="https://github.com/user-attachments/assets/c189a0ee-674c-43a1-a29b-5e6ab7e5746f">

Proposed search/ask wording will fit the search bar on 1 line only.