### PR TITLE
RND-2147: automatically scroll TOC

### DIFF
--- a/.changeset/lovely-hats-peel.md
+++ b/.changeset/lovely-hats-peel.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Automatically scroll to active item in TOC

--- a/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useParams } from 'next/navigation';
 import React from 'react';
 
 import { ClassValue, tcls } from '@/lib/tailwind';
+
+import { useHash } from '../hooks';
 
 const TOCScrollContainerContext = React.createContext<React.RefObject<HTMLDivElement> | null>(null);
 
@@ -34,7 +35,7 @@ export function useScrollToActiveTOCItem(tocItem: {
 }) {
     const { isActive, linkRef } = tocItem;
 
-    const params = useParams();
+    const hash = useHash();
     const scrollContainerRef = React.useContext(TOCScrollContainerContext);
 
     React.useLayoutEffect(() => {
@@ -57,8 +58,6 @@ export function useScrollToActiveTOCItem(tocItem: {
                 });
             }
         }
-        // We've included `param` from `useParams` hook to listen to respond to changes to hash or
-        // for updates to route from next and previous browser buttons.
-        // See https://github.com/vercel/next.js/discussions/49465#discussioncomment-5845312
-    }, [isActive, linkRef, scrollContainerRef, params]);
+        // We've included `hash` from `useHash` hook as a dependency so we trigger the effect in response to changes to the url hash
+    }, [isActive, hash, linkRef, scrollContainerRef]);
 }

--- a/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
@@ -65,11 +65,14 @@ export function useScrollToActiveTOCItem(props: {
             return;
         }
         const tocItem = linkRef.current;
-        tocItem?.scrollIntoView({
-            behavior: 'instant', // using instant as smooth can interrupt or get interrupted by other `scrollIntoView` changes
-            block: 'center',
+        const tocContainer = scrollContainerRef?.current;
+        if (!tocItem || !tocContainer) {
+            return;
+        }
+        tocContainer?.scrollTo({
+            top: tocItem.offsetTop - TOC_ITEM_OFFSET,
         });
         isScrolled.current = true;
         // We've included `hash` from `useHash` hook as a dependency so we trigger the effect in response to changes to the url hash
-    }, [hash, isActive, isOutOfView, linkRef]);
+    }, [hash, isActive, isOutOfView, linkRef, scrollContainerRef]);
 }

--- a/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
@@ -57,9 +57,9 @@ export function useScrollToActiveTOCItem(tocItem: {
     }, [linkRef, scrollContainerRef]);
 
     React.useLayoutEffect(() => {
-        if (!isActive) { 
+        if (!isActive) {
             isScrolled.current = false;
-            return; 
+            return;
         }
 
         if (!isOutOfView() || isScrolled.current) {

--- a/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
@@ -29,11 +29,11 @@ const TOC_ITEM_OFFSET = 200;
 /**
  * Scrolls the table of contents container to the page item when it becomes active
  */
-export function useScrollToActiveTOCItem(tocItem: {
+export function useScrollToActiveTOCItem(props: {
     isActive: boolean;
     linkRef: React.RefObject<HTMLAnchorElement>;
 }) {
-    const { isActive, linkRef } = tocItem;
+    const { isActive, linkRef } = props;
 
     const hash = useHash();
     const scrollContainerRef = React.useContext(TOCScrollContainerContext);
@@ -61,13 +61,10 @@ export function useScrollToActiveTOCItem(tocItem: {
             isScrolled.current = false;
             return;
         }
-
         if (!isOutOfView() || isScrolled.current) {
             return;
         }
-
         const tocItem = linkRef.current;
-        console.log({ isActive, scrollToView: tocItem?.textContent });
         tocItem?.scrollIntoView({
             behavior: 'instant', // using instant as smooth can interrupt or get interrupted by other `scrollIntoView` changes
             block: 'center',

--- a/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
@@ -4,20 +4,19 @@ import React from 'react';
 
 import { ClassValue, tcls } from '@/lib/tailwind';
 
-const TOCScrollContainerRefContext = React.createContext<React.RefObject<HTMLDivElement> | null>(null);
+const TOCScrollContainerRefContext = React.createContext<React.RefObject<HTMLDivElement> | null>(
+    null,
+);
 
 function useTOCScrollContainerRefContext() {
     const ctx = React.useContext(TOCScrollContainerRefContext);
     if (!ctx) {
-        throw new Error("Context `TOCScrollContainerRefContext` must be used within Provider");
+        throw new Error('Context `TOCScrollContainerRefContext` must be used within Provider');
     }
     return ctx;
 }
 
-export function TOCScrollContainer(props: {
-    children: React.ReactNode;
-    className?: ClassValue;
-}) {
+export function TOCScrollContainer(props: { children: React.ReactNode; className?: ClassValue }) {
     const { children, className } = props;
     const scrollContainerRef = React.createRef<HTMLDivElement>();
 
@@ -67,8 +66,5 @@ function isOutOfView(tocItem: HTMLElement, tocContainer: HTMLElement) {
     const tocItemTop = tocItem.offsetTop;
     const containerTop = tocContainer.scrollTop;
     const containerBottom = containerTop + tocContainer.clientHeight;
-    return (
-        tocItemTop < containerTop ||
-        tocItemTop > containerBottom 
-    );
+    return tocItemTop < containerTop || tocItemTop > containerBottom;
 }

--- a/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCScroller.tsx
@@ -39,7 +39,9 @@ export function useScrollToActiveTOCItem(tocItem: {
     const scrollContainerRef = React.useContext(TOCScrollContainerContext);
 
     React.useLayoutEffect(() => {
-        if (isActive && linkRef.current && scrollContainerRef?.current) {
+        if (!isActive) { return; }
+
+        if (linkRef.current && scrollContainerRef?.current) {
             const tocItem = linkRef.current;
             const tocContainer = scrollContainerRef.current;
 

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -13,7 +13,7 @@ import { ContentRefContext } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
 import { PagesList } from './PagesList';
-import { TOCScrollContainerProvider } from './TOCScroller';
+import { TOCScrollContainer } from './TOCScroller';
 import { Trademark } from './Trademark';
 
 export function TableOfContents(props: {
@@ -56,7 +56,7 @@ export function TableOfContents(props: {
             )}
         >
             {header ? header : null}
-            <TOCScrollContainerProvider
+            <TOCScrollContainer
                 className={tcls(
                     withHeaderOffset ? 'pt-4' : ['pt-4', 'lg:pt-0'],
                     'hidden',
@@ -88,7 +88,7 @@ export function TableOfContents(props: {
                 {customization.trademark.enabled ? (
                     <Trademark space={space} customization={customization} />
                 ) : null}
-            </TOCScrollContainerProvider>
+            </TOCScrollContainer>
         </aside>
     );
 }

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -13,6 +13,7 @@ import { ContentRefContext } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
 import { PagesList } from './PagesList';
+import { TOCScrollContainerProvider } from './TOCScroller';
 import { Trademark } from './Trademark';
 
 export function TableOfContents(props: {
@@ -55,7 +56,7 @@ export function TableOfContents(props: {
             )}
         >
             {header ? header : null}
-            <div
+            <TOCScrollContainerProvider
                 className={tcls(
                     withHeaderOffset ? 'pt-4' : ['pt-4', 'lg:pt-0'],
                     'hidden',
@@ -87,7 +88,7 @@ export function TableOfContents(props: {
                 {customization.trademark.enabled ? (
                     <Trademark space={space} customization={customization} />
                 ) : null}
-            </div>
+            </TOCScrollContainerProvider>
         </aside>
     );
 }

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -49,6 +49,7 @@ export function ToggleableLinkItem(props: {
     const [scope, animate] = useAnimate();
     const [isVisible, setIsVisible] = React.useState(hasActiveDescendant);
     const isMounted = useIsMounted();
+
     // Update the visibility of the children, if we are navigating to a descendant.
     React.useEffect(() => {
         if (!hasDescendants) {
@@ -64,7 +65,6 @@ export function ToggleableLinkItem(props: {
         if (!isMounted || !hasDescendants) {
             return;
         }
-
         try {
             animate(scope.current, isVisible ? show : hide, {
                 duration: 0.1,
@@ -89,7 +89,7 @@ export function ToggleableLinkItem(props: {
     }, [isVisible, isMounted, hasDescendants, animate, scope]);
 
     const linkRef = React.createRef<HTMLAnchorElement>();
-    useScrollToActiveTOCItem({ linkRef, isActive: isMounted && isActive });
+    useScrollToActiveTOCItem({ linkRef, isActive });
 
     return (
         <div>

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import { tcls } from '@/lib/tailwind';
 
+import { useScrollToActiveTOCItem } from './TOCScroller';
 import { Link } from '../primitives';
 
 const show = {
@@ -92,9 +93,13 @@ export function ToggleableLinkItem(props: {
         mountedRef.current = true;
     }, []);
 
+    const linkRef = React.createRef<HTMLAnchorElement>();
+    useScrollToActiveTOCItem({ linkRef, isActive });
+
     return (
         <div>
             <Link
+                ref={linkRef}
                 href={href}
                 aria-selected={isActive}
                 className={tcls(

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { tcls } from '@/lib/tailwind';
 
 import { useScrollToActiveTOCItem } from './TOCScroller';
+import { useIsMounted } from '../hooks';
 import { Link } from '../primitives';
 
 const show = {
@@ -47,7 +48,7 @@ export function ToggleableLinkItem(props: {
 
     const [scope, animate] = useAnimate();
     const [isVisible, setIsVisible] = React.useState(hasActiveDescendant);
-
+    const isMounted = useIsMounted();
     // Update the visibility of the children, if we are navigating to a descendant.
     React.useEffect(() => {
         if (!hasDescendants) {
@@ -60,7 +61,7 @@ export function ToggleableLinkItem(props: {
     // Animate the visibility of the children
     // only after the initial state.
     React.useEffect(() => {
-        if (!mountedRef.current || !hasDescendants) {
+        if (!isMounted || !hasDescendants) {
             return;
         }
 
@@ -85,16 +86,10 @@ export function ToggleableLinkItem(props: {
             // The selector can crash in some browsers, we ignore it as the animation is not critical.
             console.error(error);
         }
-    }, [isVisible, hasDescendants, animate, scope]);
-
-    // Track if the component is mounted.
-    const mountedRef = React.useRef(false);
-    React.useEffect(() => {
-        mountedRef.current = true;
-    }, []);
+    }, [isVisible, isMounted, hasDescendants, animate, scope]);
 
     const linkRef = React.createRef<HTMLAnchorElement>();
-    useScrollToActiveTOCItem({ linkRef, isActive });
+    useScrollToActiveTOCItem({ linkRef, isActive: isMounted && isActive });
 
     return (
         <div>


### PR DESCRIPTION
Bringing back the work @spastorelli did on automatically scrolling the TOC to current page (in https://github.com/GitbookIO/gitbook/pull/2425).

That work was rolled back due to a bug. Main fix is preventing multiple scroll triggers with a ref. 

[Note/out-of-scope]: The difference in rendering of the TOC in localhost v prod is kind of concerning and should be investigated further. I'd expect a dev build to render more often but the toc items re-render a lot more in prod which is why scrolling issues were only picked up in prod. 

I've been testing against the visual regression preview where I could replicate the issue, e.g. https://211cca89.gitbook-open.pages.dev/gitbook.gitbook.io/test-gitbook-open