### PR TITLE
Update Dutch "Ask or Search" terminology to fit on one line

### DIFF
--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -8,7 +8,7 @@ export const nl: TranslationLanguage = {
     switch_to_light_theme: 'Schakel over naar lichte modus',
     switch_to_system_theme: 'Schakel over naar systeemmodus',
     search: 'Zoeken',
-    search_or_ask: 'Stel een vraag of zoek',
+    search_or_ask: 'Zoek of vraag',
     search_input_placeholder: 'Zoek inhoud',
     search_ask_input_placeholder: 'Zoek inhoud of stel een vraag',
     search_no_results: 'Geen resultaten voor "${1}".',


### PR DESCRIPTION
Before:

![Screenshot 2024-09-17 at 15 15 30](https://github.com/user-attachments/assets/08c62a55-0afb-4bf8-b6e3-0fe59faaca26)

This PR shortens the wording to fit on one line/