### PR TITLE
generate upto URL with 3 segments to support the new site url format

### DIFF
--- a/.changeset/tiny-lobsters-remember.md
+++ b/.changeset/tiny-lobsters-remember.md
@@ -1,0 +1,5 @@
+---
+'gitbook': minor
+---
+
+Support resolution of new site URLs without the variant prefix /v/

--- a/packages/gitbook/src/lib/middleware.test.ts
+++ b/packages/gitbook/src/lib/middleware.test.ts
@@ -4,7 +4,9 @@ import { getURLLookupAlternatives, normalizeURL } from './middleware';
 
 describe('getURLLookupAlternatives', () => {
     it('should return all URLs up to the root', () => {
-        expect(getURLLookupAlternatives(new URL('https://docs.mycompany.com/a/b/c'))).toEqual({
+        const res = getURLLookupAlternatives(new URL('https://docs.mycompany.com/a/b/c'));
+        console.log(res);
+        expect(res).toEqual({
             revision: undefined,
             changeRequest: undefined,
             basePath: undefined,
@@ -22,6 +24,11 @@ describe('getURLLookupAlternatives', () => {
                 {
                     extraPath: 'c',
                     url: 'https://docs.mycompany.com/a/b',
+                    primary: false,
+                },
+                {
+                    extraPath: '',
+                    url: 'https://docs.mycompany.com/a/b/c',
                     primary: true,
                 },
             ],
@@ -229,6 +236,11 @@ describe('getURLLookupAlternatives', () => {
                 {
                     extraPath: 'c/d',
                     url: 'https://docs.mycompany.com/a/b',
+                    primary: false,
+                },
+                {
+                    extraPath: 'd',
+                    url: 'https://docs.mycompany.com/a/b/c',
                     primary: true,
                 },
             ],
@@ -254,6 +266,11 @@ describe('getURLLookupAlternatives', () => {
                 {
                     extraPath: 'b/c/d',
                     url: 'https://docs.mycompany.com/a/~',
+                    primary: false,
+                },
+                {
+                    extraPath: 'c/d',
+                    url: 'https://docs.mycompany.com/a/~/b',
                     primary: true,
                 },
             ],

--- a/packages/gitbook/src/lib/middleware.test.ts
+++ b/packages/gitbook/src/lib/middleware.test.ts
@@ -4,9 +4,7 @@ import { getURLLookupAlternatives, normalizeURL } from './middleware';
 
 describe('getURLLookupAlternatives', () => {
     it('should return all URLs up to the root', () => {
-        const res = getURLLookupAlternatives(new URL('https://docs.mycompany.com/a/b/c'));
-        console.log(res);
-        expect(res).toEqual({
+        expect(getURLLookupAlternatives(new URL('https://docs.mycompany.com/a/b/c'))).toEqual({
             revision: undefined,
             changeRequest: undefined,
             basePath: undefined,

--- a/packages/gitbook/src/lib/middleware.ts
+++ b/packages/gitbook/src/lib/middleware.ts
@@ -91,7 +91,7 @@ export function getURLLookupAlternatives(input: URL) {
         }
 
         // Otherwise match with the first two segments of the path
-        for (let i = 1; i <= 2; i++) {
+        for (let i = 1; i <= 3; i++) {
             if (pathSegments.length >= i) {
                 const shortURL = new URL(url);
                 shortURL.pathname = pathSegments.slice(0, i).join('/');


### PR DESCRIPTION
With the new site URLs that doesn't include `/v/` for variant we still want to be able to match for scenarios like:
`company.gitbook.io/siteSlug/shareKey/variantSlug` (up to 3 segments)