### PR TITLE
Remove getContentPointer usage from search 

### DIFF
--- a/packages/gitbook/src/app/(space)/(content)/[[...pathname]]/not-found.tsx
+++ b/packages/gitbook/src/app/(space)/(content)/[[...pathname]]/not-found.tsx
@@ -1,5 +1,5 @@
 import { getSpaceLanguage, t } from '@/intl/server';
-import { getCurrentSiteLayoutData, getSpaceLayoutData } from '@/lib/api';
+import { getSiteLayoutData, getSpaceLayoutData } from '@/lib/api';
 import { tcls } from '@/lib/tailwind';
 
 import { getContentPointer } from '../../fetch';
@@ -7,7 +7,7 @@ import { getContentPointer } from '../../fetch';
 export default async function NotFound() {
     const pointer = getContentPointer();
     const { customization } = await ('siteId' in pointer
-        ? getCurrentSiteLayoutData(pointer)
+        ? getSiteLayoutData(pointer)
         : getSpaceLayoutData(pointer.spaceId));
 
     const language = getSpaceLanguage(customization);

--- a/packages/gitbook/src/app/(space)/(content)/[[...pathname]]/page.tsx
+++ b/packages/gitbook/src/app/(space)/(content)/[[...pathname]]/page.tsx
@@ -30,7 +30,7 @@ export default async function Page(props: {
         content: contentPointer,
         contentTarget,
         space,
-        parent,
+        site,
         customization,
         pages,
         page,
@@ -94,7 +94,7 @@ export default async function Page(props: {
                 {page.layout.outline ? (
                     <PageAside
                         space={space}
-                        site={parent?.object === 'site' ? parent : undefined}
+                        site={site?.object === 'site' ? site : undefined}
                         customization={customization}
                         page={page}
                         document={document}
@@ -130,7 +130,7 @@ export async function generateMetadata({
     params: PagePathParams;
     searchParams: { fallback?: string };
 }): Promise<Metadata> {
-    const { space, pages, page, customization, parent, ancestors } = await getPageDataWithFallback({
+    const { space, pages, page, customization, site, ancestors } = await getPageDataWithFallback({
         pagePathParams: params,
         searchParams,
     });
@@ -140,7 +140,7 @@ export async function generateMetadata({
     }
 
     return {
-        title: [page.title, getContentTitle(space, customization, parent)]
+        title: [page.title, getContentTitle(space, customization, site ?? null)]
             .filter(Boolean)
             .join(' | '),
         description: page.description ?? '',
@@ -154,7 +154,7 @@ export async function generateMetadata({
             ],
         },
         robots:
-            isSpaceIndexable({ space, parent }) && isPageIndexable(ancestors, page)
+            isSpaceIndexable({ space, site: site ?? null }) && isPageIndexable(ancestors, page)
                 ? 'index, follow'
                 : 'noindex, nofollow',
     };

--- a/packages/gitbook/src/app/(space)/(content)/[[...pathname]]/page.tsx
+++ b/packages/gitbook/src/app/(space)/(content)/[[...pathname]]/page.tsx
@@ -94,7 +94,7 @@ export default async function Page(props: {
                 {page.layout.outline ? (
                     <PageAside
                         space={space}
-                        site={site?.object === 'site' ? site : undefined}
+                        site={site}
                         customization={customization}
                         page={page}
                         document={document}

--- a/packages/gitbook/src/app/(space)/(content)/layout.tsx
+++ b/packages/gitbook/src/app/(space)/(content)/layout.tsx
@@ -18,7 +18,7 @@ import { getContentTitle } from '@/lib/utils';
 
 import { ClientContexts } from './ClientContexts';
 import { RocketLoaderDetector } from './RocketLoaderDetector';
-import { fetchSpaceData } from '../fetch';
+import { fetchContentData } from '../fetch';
 
 export const runtime = 'edge';
 
@@ -35,11 +35,11 @@ export default async function ContentLayout(props: { children: React.ReactNode }
         contentTarget,
         customization,
         pages,
-        parent,
+        site,
         spaces,
         ancestors,
         scripts,
-    } = await fetchSpaceData();
+    } = await fetchContentData();
 
     ReactDOM.preconnect(api().endpoint);
     if (assetsDomain) {
@@ -64,7 +64,7 @@ export default async function ContentLayout(props: { children: React.ReactNode }
             <SpaceLayout
                 space={space}
                 contentTarget={contentTarget}
-                parent={parent}
+                site={site}
                 spaces={spaces}
                 customization={customization}
                 pages={pages}
@@ -97,7 +97,7 @@ export default async function ContentLayout(props: { children: React.ReactNode }
 }
 
 export async function generateViewport(): Promise<Viewport> {
-    const { customization } = await fetchSpaceData();
+    const { customization } = await fetchContentData();
     return {
         colorScheme: customization.themes.toggeable
             ? customization.themes.default === CustomizationThemeMode.Dark
@@ -108,11 +108,11 @@ export async function generateViewport(): Promise<Viewport> {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-    const { space, parent, customization } = await fetchSpaceData();
+    const { space, site, customization } = await fetchContentData();
     const customIcon = 'icon' in customization.favicon ? customization.favicon.icon : null;
 
     return {
-        title: getContentTitle(space, customization, parent),
+        title: getContentTitle(space, customization, site),
         generator: `GitBook (${buildVersion()})`,
         metadataBase: new URL(baseUrl()),
         icons: {
@@ -133,7 +133,7 @@ export async function generateMetadata(): Promise<Metadata> {
                 },
             ],
         },
-        robots: isSpaceIndexable({ space, parent }) ? 'index, follow' : 'noindex, nofollow',
+        robots: isSpaceIndexable({ space, site }) ? 'index, follow' : 'noindex, nofollow',
     };
 }
 

--- a/packages/gitbook/src/app/(space)/(core)/robots.txt/route.ts
+++ b/packages/gitbook/src/app/(space)/(core)/robots.txt/route.ts
@@ -18,17 +18,12 @@ export async function GET(req: NextRequest) {
         pointer.spaceId,
         'siteId' in pointer ? pointer.siteShareKey : undefined,
     );
-    const parent =
-        'siteId' in pointer
-            ? await getSite(pointer.organizationId, pointer.siteId)
-            : space.visibility === ContentVisibility.InCollection && space.parent
-              ? await getCollection(space.parent)
-              : null;
+    const site = 'siteId' in pointer ? await getSite(pointer.organizationId, pointer.siteId) : null;
 
     const lines = [
         `User-agent: *`,
         'Disallow: /~gitbook/',
-        ...(isSpaceIndexable({ space, parent })
+        ...(isSpaceIndexable({ space, site })
             ? [`Allow: /`, `Sitemap: ${absoluteHref(`/sitemap.xml`, true)}`]
             : [`Disallow: /`]),
     ];

--- a/packages/gitbook/src/app/(space)/(core)/~gitbook/icon/route.tsx
+++ b/packages/gitbook/src/app/(space)/(core)/~gitbook/icon/route.tsx
@@ -49,13 +49,8 @@ export async function GET(req: NextRequest) {
         getSpace(spaceId, 'siteId' in pointer ? pointer.siteShareKey : undefined),
         'siteId' in pointer ? getCurrentSiteCustomization(pointer) : getSpaceCustomization(spaceId),
     ]);
-    const parent =
-        'siteId' in pointer
-            ? await getSite(pointer.organizationId, pointer.siteId)
-            : space.visibility === ContentVisibility.InCollection && space.parent
-              ? await getCollection(space.parent)
-              : null;
-    const contentTitle = getContentTitle(space, customization, parent);
+    const site = 'siteId' in pointer ? await getSite(pointer.organizationId, pointer.siteId) : null;
+    const contentTitle = getContentTitle(space, customization, site);
 
     return new ImageResponse(
         (

--- a/packages/gitbook/src/app/(space)/(core)/~gitbook/ogimage/[pageId]/route.tsx
+++ b/packages/gitbook/src/app/(space)/(core)/~gitbook/ogimage/[pageId]/route.tsx
@@ -13,7 +13,7 @@ export const runtime = 'edge';
  * Render the OpenGraph image for a space.
  */
 export async function GET(req: NextRequest, { params }: { params: PageIdParams }) {
-    const { space, page, customization, parent } = await fetchPageData(params);
+    const { space, page, customization, site } = await fetchPageData(params);
     const url = new URL(space.urls.published ?? space.urls.app);
 
     if (customization.socialPreview.url) {
@@ -33,7 +33,7 @@ export async function GET(req: NextRequest, { params }: { params: PageIdParams }
                 }}
             >
                 <h2 tw="text-7xl font-bold tracking-tight text-left">
-                    {getContentTitle(space, customization, parent)}
+                    {getContentTitle(space, customization, site ?? null)}
                 </h2>
                 <div tw="flex flex-1">
                     <p tw="text-4xl">{page ? page.title : 'Not found'}</p>

--- a/packages/gitbook/src/app/(space)/fetch.ts
+++ b/packages/gitbook/src/app/(space)/fetch.ts
@@ -10,7 +10,7 @@ import {
     getSpaceData,
     ContentTarget,
     SiteContentPointer,
-    getCurrentSiteData,
+    getSiteData,
     getSite,
     getSiteSpaces,
     getCurrentSiteCustomization,
@@ -67,39 +67,42 @@ export function getContentPointer(): ContentPointer | SiteContentPointer {
 }
 
 /**
- * Fetch all the data needed to render the space layout.
+ * Fetch all the data needed to render the content layout.
  */
-export async function fetchSpaceData() {
+export async function fetchContentData() {
     const content = getContentPointer();
 
     const siteShareKey = 'siteId' in content ? content.siteShareKey : undefined;
 
-    const [{ space, contentTarget, pages, customization, scripts }, parentSite] = await Promise.all(
-        'siteId' in content
-            ? [
-                  getCurrentSiteData(content),
-                  fetchParentSite({
-                      organizationId: content.organizationId,
-                      siteId: content.siteId,
-                      siteShareKey,
-                  }),
-              ]
-            : [getSpaceData(content, siteShareKey)],
-    );
+    const [{ space, contentTarget, pages, customization, scripts }, siteStructure] =
+        await Promise.all(
+            'siteId' in content
+                ? [
+                      getSiteData(content),
+                      fetchSiteStructure({
+                          organizationId: content.organizationId,
+                          siteId: content.siteId,
+                          siteShareKey,
+                      }),
+                  ]
+                : [getSpaceData(content, siteShareKey)],
+        );
 
-    const parent = await (parentSite ?? fetchParentCollection(space));
+    const site = siteStructure ? siteStructure.site : null;
+    const spaces = siteStructure ? siteStructure.spaces : [];
     // we grab the space attached to the parent as it contains overriden customizations
-    const spaceRelativeToParent = parent?.spaces.find((space) => space.id === content.spaceId);
+    const spaceRelativeToParent = spaces.find((space) => space.id === content.spaceId);
 
     return {
         content,
         contentTarget,
         space: spaceRelativeToParent ?? space,
         pages,
+        site,
+        spaces,
         customization,
         scripts,
         ancestors: [],
-        ...parent,
     };
 }
 
@@ -111,18 +114,18 @@ export async function fetchPageData(params: PagePathParams | PageIdParams) {
     const content = getContentPointer();
     const siteShareKey = 'siteId' in content ? content.siteShareKey : undefined;
     const { space, contentTarget, pages, customization, scripts } = await ('siteId' in content
-        ? getCurrentSiteData(content)
+        ? getSiteData(content)
         : getSpaceData(content, siteShareKey));
 
     const page = await resolvePage(contentTarget, pages, params);
-    const [parent, document] = await Promise.all([
+    const [siteStructure, document] = await Promise.all([
         'siteId' in content
-            ? fetchParentSite({
+            ? fetchSiteStructure({
                   organizationId: content.organizationId,
                   siteId: content.siteId,
                   siteShareKey: content.siteShareKey,
               })
-            : fetchParentCollection(space),
+            : null,
         page?.page.documentId ? getDocument(space.id, page.page.documentId) : null,
     ]);
 
@@ -135,7 +138,7 @@ export async function fetchPageData(params: PagePathParams | PageIdParams) {
         scripts,
         ancestors: [],
         ...page,
-        ...parent,
+        ...siteStructure,
         document,
     };
 }
@@ -181,24 +184,28 @@ async function resolvePage(
     return undefined;
 }
 
-async function fetchParentCollection(space: Space) {
-    const parentCollectionId =
-        space.visibility === ContentVisibility.InCollection ? space.parent : undefined;
-    const [collection, spaces] = await Promise.all([
-        parentCollectionId ? getCollection(parentCollectionId) : null,
-        parentCollectionId ? getCollectionSpaces(parentCollectionId) : ([] as Space[]),
-    ]);
+// async function fetchParentCollection(space: Space) {
+//     const parentCollectionId =
+//         space.visibility === ContentVisibility.InCollection ? space.parent : undefined;
+//     const [collection, spaces] = await Promise.all([
+//         parentCollectionId ? getCollection(parentCollectionId) : null,
+//         parentCollectionId ? getCollectionSpaces(parentCollectionId) : ([] as Space[]),
+//     ]);
 
-    return { parent: collection, spaces };
-}
+//     return { parent: collection, spaces };
+// }
 
-async function fetchParentSite(args: {
+/**
+ * Fetch the structure of an organization site.
+ * This includes the site and its spaces.
+ */
+async function fetchSiteStructure(args: {
     organizationId: string;
     siteId: string;
     siteShareKey: string | undefined;
 }) {
     const { organizationId, siteId, siteShareKey } = args;
-    const [site, siteSpaces, siteParentCustomizations] = await Promise.all([
+    const [orgSite, siteSpaces, siteParentCustomizations] = await Promise.all([
         getSite(organizationId, siteId),
         getSiteSpaces({ organizationId, siteId, siteShareKey }),
         getCurrentSiteCustomization({ organizationId, siteId, siteSpaceId: undefined }),
@@ -217,13 +224,13 @@ async function fetchParentSite(args: {
     });
 
     // override the title with the customization title
-    const parent = {
-        ...site,
+    const site = {
+        ...orgSite,
         ...(siteParentCustomizations?.title ? { title: siteParentCustomizations.title } : {}),
     };
 
     return {
-        parent,
+        site,
         spaces: Object.values(spaces),
     };
 }

--- a/packages/gitbook/src/app/(space)/fetch.ts
+++ b/packages/gitbook/src/app/(space)/fetch.ts
@@ -184,17 +184,6 @@ async function resolvePage(
     return undefined;
 }
 
-// async function fetchParentCollection(space: Space) {
-//     const parentCollectionId =
-//         space.visibility === ContentVisibility.InCollection ? space.parent : undefined;
-//     const [collection, spaces] = await Promise.all([
-//         parentCollectionId ? getCollection(parentCollectionId) : null,
-//         parentCollectionId ? getCollectionSpaces(parentCollectionId) : ([] as Space[]),
-//     ]);
-
-//     return { parent: collection, spaces };
-// }
-
 /**
  * Fetch the structure of an organization site.
  * This includes the site and its spaces.

--- a/packages/gitbook/src/app/(space)/layout.tsx
+++ b/packages/gitbook/src/app/(space)/layout.tsx
@@ -14,7 +14,7 @@ import colors from 'tailwindcss/colors';
 import { emojiFontClassName } from '@/components/primitives';
 import { fonts, ibmPlexMono } from '@/fonts';
 import { getSpaceLanguage } from '@/intl/server';
-import { getCurrentSiteLayoutData, getSpaceLayoutData } from '@/lib/api';
+import { getSiteLayoutData, getSpaceLayoutData } from '@/lib/api';
 import { getStaticFileURL } from '@/lib/assets';
 import { hexToRgb, shadesOfColor } from '@/lib/colors';
 import { tcls } from '@/lib/tailwind';
@@ -33,7 +33,7 @@ export default async function SpaceRootLayout(props: { children: React.ReactNode
 
     const pointer = getContentPointer();
     const { customization } = await ('siteId' in pointer
-        ? getCurrentSiteLayoutData(pointer)
+        ? getSiteLayoutData(pointer)
         : getSpaceLayoutData(pointer.spaceId));
     const headerTheme = generateHeaderTheme(customization);
     const language = getSpaceLanguage(customization);
@@ -88,7 +88,7 @@ export default async function SpaceRootLayout(props: { children: React.ReactNode
                                 ),
                             )
                         }
-                        
+
                         ${generateColorVariable(
                             'primary-base',
                             customization.styling.primaryColor.light,

--- a/packages/gitbook/src/components/Header/CompactHeader.tsx
+++ b/packages/gitbook/src/components/Header/CompactHeader.tsx
@@ -20,15 +20,12 @@ import { SearchButton } from '../Search';
  */
 export function CompactHeader(props: {
     space: Space;
-    parent: Site | Collection | null;
+    site: Site | null;
     spaces: Space[];
     customization: CustomizationSettings | SiteCustomizationSettings;
 }) {
-    const { space, spaces, parent, customization } = props;
-
-    const isMultiVariants =
-        parent?.object === 'collection' ||
-        (parent && parent.object === 'site' && spaces.length > 1);
+    const { space, spaces, site, customization } = props;
+    const isMultiVariants = site && site.object === 'site' && spaces.length > 1;
 
     return (
         <div
@@ -45,7 +42,7 @@ export function CompactHeader(props: {
             )}
         >
             <div className={tcls('flex-grow-0', 'mt-5')}>
-                <HeaderLogo parent={parent} space={space} customization={customization} />
+                <HeaderLogo site={site} space={space} customization={customization} />
             </div>
             <div
                 className={tcls(

--- a/packages/gitbook/src/components/Header/CompactHeader.tsx
+++ b/packages/gitbook/src/components/Header/CompactHeader.tsx
@@ -25,7 +25,7 @@ export function CompactHeader(props: {
     customization: CustomizationSettings | SiteCustomizationSettings;
 }) {
     const { space, spaces, site, customization } = props;
-    const isMultiVariants = site && site.object === 'site' && spaces.length > 1;
+    const isMultiVariants = site && spaces.length > 1;
 
     return (
         <div

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -33,7 +33,7 @@ export function Header(props: {
     const { context, space, site, spaces, customization, withTopHeader } = props;
     const isCustomizationDefault =
         customization.header.preset === CustomizationHeaderPreset.Default;
-    const isMultiVariants = site && site.object === 'site' && spaces.length > 1;
+    const isMultiVariants = site && spaces.length > 1;
 
     return (
         <header

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -24,19 +24,16 @@ import { SearchButton } from '../Search';
  */
 export function Header(props: {
     space: Space;
-    parent: Site | Collection | null;
+    site: Site | null;
     spaces: Space[];
     context: ContentRefContext;
     customization: CustomizationSettings | SiteCustomizationSettings;
     withTopHeader?: boolean;
 }) {
-    const { context, space, parent, spaces, customization, withTopHeader } = props;
-
+    const { context, space, site, spaces, customization, withTopHeader } = props;
     const isCustomizationDefault =
         customization.header.preset === CustomizationHeaderPreset.Default;
-    const isMultiVariants =
-        parent?.object === 'collection' ||
-        (parent && parent.object === 'site' && spaces.length > 1);
+    const isMultiVariants = site && site.object === 'site' && spaces.length > 1;
 
     return (
         <header
@@ -76,7 +73,7 @@ export function Header(props: {
                         CONTAINER_STYLE,
                     )}
                 >
-                    <HeaderLogo parent={parent} space={space} customization={customization} />
+                    <HeaderLogo site={site} space={space} customization={customization} />
                     <span>
                         {isMultiVariants ? <SpacesDropdown space={space} spaces={spaces} /> : null}
                     </span>

--- a/packages/gitbook/src/components/Header/HeaderLogo.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLogo.tsx
@@ -17,7 +17,7 @@ import { Link } from '../primitives';
 import { SpaceIcon } from '../Space/SpaceIcon';
 
 interface HeaderLogoProps {
-    parent: Site | Collection | null;
+    site: Site | null;
     space: Space;
     customization: CustomizationSettings | SiteCustomizationSettings;
 }
@@ -93,7 +93,7 @@ export function HeaderLogo(props: HeaderLogoProps) {
 }
 
 function LogoFallback(props: HeaderLogoProps) {
-    const { parent, space, customization } = props;
+    const { site, space, customization } = props;
     const customIcon = 'icon' in customization.favicon ? customization.favicon.icon : undefined;
     const customEmoji = 'emoji' in customization.favicon ? customization.favicon.emoji : undefined;
 
@@ -124,7 +124,7 @@ function LogoFallback(props: HeaderLogoProps) {
                         : 'text-header-link',
                 )}
             >
-                {getContentTitle(space, customization, parent)}
+                {getContentTitle(space, customization, site)}
             </div>
         </>
     );

--- a/packages/gitbook/src/components/Search/SearchModal.tsx
+++ b/packages/gitbook/src/components/Search/SearchModal.tsx
@@ -21,7 +21,7 @@ interface SearchModalProps {
     spaceId: string;
     revisionId: string;
     spaceTitle: string;
-    parent: Site | Collection | null;
+    site: Site | null;
     withAsk: boolean;
 }
 
@@ -136,8 +136,7 @@ function SearchModalBody(
         onClose: (to?: string) => void;
     },
 ) {
-    const { spaceId, revisionId, spaceTitle, withAsk, parent, state, onChangeQuery, onClose } =
-        props;
+    const { spaceId, revisionId, spaceTitle, withAsk, site, state, onChangeQuery, onClose } = props;
 
     const language = useLanguage();
     const resultsRef = React.useRef<SearchResultsRef>(null);
@@ -239,7 +238,7 @@ function SearchModalBody(
                     ref={resultsRef}
                     spaceId={spaceId}
                     revisionId={revisionId}
-                    parent={state.global ? parent : null}
+                    site={state.global ? site : null}
                     query={state.query}
                     withAsk={withAsk}
                     onSwitchToAsk={() => {
@@ -250,7 +249,7 @@ function SearchModalBody(
                         });
                     }}
                 >
-                    {parent && state.query ? <SearchScopeToggle spaceTitle={spaceTitle} /> : null}
+                    {site && state.query ? <SearchScopeToggle spaceTitle={spaceTitle} /> : null}
                 </SearchResults>
             ) : null}
             {state.query && state.ask && withAsk ? (

--- a/packages/gitbook/src/components/Search/SearchModal.tsx
+++ b/packages/gitbook/src/components/Search/SearchModal.tsx
@@ -9,6 +9,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { useRecoilValue } from 'recoil';
 
 import { tString, useLanguage } from '@/intl/client';
+import { ContentPointer, SiteContentPointer } from '@/lib/api';
 import { tcls } from '@/lib/tailwind';
 
 import { SearchAskAnswer, searchAskState } from './SearchAskAnswer';
@@ -21,8 +22,9 @@ interface SearchModalProps {
     spaceId: string;
     revisionId: string;
     spaceTitle: string;
-    site: Site | null;
+    isMultiVariants: boolean;
     withAsk: boolean;
+    pointer: ContentPointer | SiteContentPointer;
 }
 
 /**
@@ -136,7 +138,17 @@ function SearchModalBody(
         onClose: (to?: string) => void;
     },
 ) {
-    const { spaceId, revisionId, spaceTitle, withAsk, site, state, onChangeQuery, onClose } = props;
+    const {
+        pointer,
+        spaceId,
+        revisionId,
+        spaceTitle,
+        withAsk,
+        isMultiVariants,
+        state,
+        onChangeQuery,
+        onClose,
+    } = props;
 
     const language = useLanguage();
     const resultsRef = React.useRef<SearchResultsRef>(null);
@@ -236,9 +248,10 @@ function SearchModalBody(
             {!state.ask || !withAsk ? (
                 <SearchResults
                     ref={resultsRef}
+                    pointer={pointer}
                     spaceId={spaceId}
                     revisionId={revisionId}
-                    site={state.global ? site : null}
+                    global={isMultiVariants && state.global}
                     query={state.query}
                     withAsk={withAsk}
                     onSwitchToAsk={() => {
@@ -249,7 +262,9 @@ function SearchModalBody(
                         });
                     }}
                 >
-                    {site && state.query ? <SearchScopeToggle spaceTitle={spaceTitle} /> : null}
+                    {isMultiVariants && state.query ? (
+                        <SearchScopeToggle spaceTitle={spaceTitle} />
+                    ) : null}
                 </SearchResults>
             ) : null}
             {state.query && state.ask && withAsk ? (

--- a/packages/gitbook/src/components/Search/SearchResults.tsx
+++ b/packages/gitbook/src/components/Search/SearchResults.tsx
@@ -12,7 +12,7 @@ import { SearchSectionResultItem } from './SearchSectionResultItem';
 import {
     getRecommendedQuestions,
     OrderedComputedResult,
-    searchParentContent,
+    searchSiteContent,
     searchSpaceContent,
 } from './server-actions';
 import { Loading } from '../primitives';
@@ -40,13 +40,13 @@ export const SearchResults = React.forwardRef(function SearchResults(
         query: string;
         spaceId: string;
         revisionId: string;
-        parent: Site | Collection | null;
+        site: Site | null;
         withAsk: boolean;
         onSwitchToAsk: () => void;
     },
     ref: React.Ref<SearchResultsRef>,
 ) {
-    const { children, query, spaceId, revisionId, parent, withAsk, onSwitchToAsk } = props;
+    const { children, query, spaceId, revisionId, site, withAsk, onSwitchToAsk } = props;
 
     const language = useLanguage();
     const debounceTimeout = React.useRef<Timer | null>(null);
@@ -93,8 +93,8 @@ export const SearchResults = React.forwardRef(function SearchResults(
             debounceTimeout.current = setTimeout(async () => {
                 setCursor(null);
 
-                const fetchedResults = await (parent
-                    ? searchParentContent(parent, query)
+                const fetchedResults = await (site
+                    ? searchSiteContent({ siteId: site.id, query })
                     : searchSpaceContent(spaceId, revisionId, query));
 
                 setResults(withAsk ? withQuestionResult(fetchedResults, query) : fetchedResults);

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -52,14 +52,16 @@ export interface AskAnswerResult {
     hasAnswer: boolean;
 }
 
+/**
+ * Search for content in the entire site.
+ */
 export async function searchSiteContent(args: {
+    pointer: api.ContentPointer | api.SiteContentPointer;
     query: string;
-    siteId: string;
     siteSpaceIds?: string[];
     cacheBust?: string;
 }): Promise<OrderedComputedResult[]> {
-    const { siteSpaceIds, query, cacheBust } = args;
-    const pointer = getContentPointer();
+    const { pointer, siteSpaceIds, query, cacheBust } = args;
 
     if (query.length <= 1) {
         return [];
@@ -70,72 +72,70 @@ export async function searchSiteContent(args: {
         return [];
     }
 
-    if ('siteId' in pointer && 'organizationId' in pointer) {
-        const [searchResults, allSiteSpaces] = await Promise.all([
-            api.searchSiteContent(
-                pointer.organizationId,
-                pointer.siteId,
-                query,
-                siteSpaceIds,
-                cacheBust,
-            ),
-            siteSpaceIds
-                ? null
-                : api.getSiteSpaces({
-                      organizationId: pointer.organizationId,
-                      siteId: pointer.siteId,
-                      siteShareKey: pointer.siteShareKey,
-                  }),
-        ]);
+    if (!('siteId' in pointer)) {
+        throw new Error(`Expected a site pointer for searching site content`);
+    }
 
-        if (!siteSpaceIds) {
-            // We are searching all of this Site's content
-            return searchResults.items
-                .map((spaceItem) => {
-                    const siteSpace = allSiteSpaces?.find(
-                        (siteSpace) => siteSpace.space.id === spaceItem.id,
-                    );
+    const [searchResults, allSiteSpaces] = await Promise.all([
+        api.searchSiteContent(
+            pointer.organizationId,
+            pointer.siteId,
+            query,
+            siteSpaceIds,
+            cacheBust,
+        ),
+        siteSpaceIds
+            ? null
+            : api.getSiteSpaces({
+                  organizationId: pointer.organizationId,
+                  siteId: pointer.siteId,
+                  siteShareKey: pointer.siteShareKey,
+              }),
+    ]);
 
-                    return spaceItem.pages.map((item) => transformSitePageResult(item, siteSpace));
-                })
-                .flat(2);
-        }
-
+    if (!siteSpaceIds) {
+        // We are searching all of this Site's content
         return searchResults.items
             .map((spaceItem) => {
-                return spaceItem.pages.map((item) => transformPageResult(item));
+                const siteSpace = allSiteSpaces?.find(
+                    (siteSpace) => siteSpace.space.id === spaceItem.id,
+                );
+
+                return spaceItem.pages.map((item) => transformSitePageResult(item, siteSpace));
             })
             .flat(2);
     }
 
-    // This should never happen
-    return [];
+    return searchResults.items
+        .map((spaceItem) => {
+            return spaceItem.pages.map((item) => transformPageResult(item));
+        })
+        .flat(2);
 }
 
 /**
- * Server action to search content in a space
+ * Server action to search content in the current space
  */
-export async function searchSpaceContent(
-    spaceId: string,
-    revisionId: string,
+export async function searchCurrentSpaceContent(
     query: string,
+    pointer: api.ContentPointer | api.SiteContentPointer,
+    revisionId: string,
 ): Promise<OrderedComputedResult[]> {
-    const pointer = getContentPointer();
-
-    if ('siteId' in pointer && 'organizationId' in pointer) {
+    if ('siteId' in pointer) {
         const siteSpaceIds = pointer.siteSpaceId ? [pointer.siteSpaceId] : []; // if we don't have a siteSpaceID search all content
 
         // This is a site so use a different function which we can eventually call directly
         // We also want to break cache for this specific space if the revisionId is different so use it as a cache busting key
         return await searchSiteContent({
-            siteId: pointer.siteId,
+            pointer,
             siteSpaceIds,
             query,
             cacheBust: revisionId,
         });
     }
 
-    const data = await api.searchSpaceContent(spaceId, revisionId, query);
+    // This is for legacy space content pointer and it should not be used anymore
+    const data = await api.searchSpaceContent(pointer.spaceId, revisionId, query);
     return data.items.map((item) => transformPageResult(item, undefined)).flat();
 }
 

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -117,7 +117,8 @@ export function SpaceLayout(props: {
                     revisionId={contentTarget.revisionId}
                     spaceTitle={customization.title ?? space.title}
                     withAsk={customization.aiSearch.enabled}
-                    site={site && spaces.length > 1 ? site : null}
+                    isMultiVariants={Boolean(site && spaces.length > 1)}
+                    pointer={content}
                 />
             </React.Suspense>
         </>

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -28,7 +28,7 @@ export function SpaceLayout(props: {
     content: ContentPointer | SiteContentPointer;
     contentTarget: ContentTarget;
     space: Space;
-    parent: Site | Collection | null;
+    site: Site | null;
     spaces: Space[];
     customization: CustomizationSettings | SiteCustomizationSettings;
     pages: Revision['pages'];
@@ -38,7 +38,7 @@ export function SpaceLayout(props: {
     const {
         space,
         contentTarget,
-        parent,
+        site,
         spaces,
         content,
         pages,
@@ -62,7 +62,7 @@ export function SpaceLayout(props: {
             <Header
                 withTopHeader={withTopHeader}
                 space={space}
-                parent={parent}
+                site={site}
                 spaces={spaces}
                 context={contentRefContext}
                 customization={customization}
@@ -92,7 +92,7 @@ export function SpaceLayout(props: {
                             withTopHeader ? null : (
                                 <CompactHeader
                                     space={space}
-                                    parent={parent}
+                                    site={site}
                                     spaces={spaces}
                                     customization={customization}
                                 />
@@ -117,7 +117,7 @@ export function SpaceLayout(props: {
                     revisionId={contentTarget.revisionId}
                     spaceTitle={customization.title ?? space.title}
                     withAsk={customization.aiSearch.enabled}
-                    parent={parent && spaces.length > 1 ? parent : null}
+                    site={site && spaces.length > 1 ? site : null}
                 />
             </React.Suspense>
         </>

--- a/packages/gitbook/src/lib/api.ts
+++ b/packages/gitbook/src/lib/api.ts
@@ -766,10 +766,10 @@ export const getSiteIntegrationScripts = cache({
 /**
  * Fetch all the data to render the current site at once.
  */
-export async function getCurrentSiteData(pointer: SiteContentPointer) {
+export async function getSiteData(pointer: SiteContentPointer) {
     const [{ space, pages, contentTarget }, { customization, scripts }] = await Promise.all([
-        getSpaceData(pointer, pointer.siteShareKey),
-        getCurrentSiteLayoutData(pointer),
+        getSpaceContentData(pointer, pointer.siteShareKey),
+        getSiteLayoutData(pointer),
     ]);
 
     return {
@@ -784,22 +784,13 @@ export async function getCurrentSiteData(pointer: SiteContentPointer) {
 /**
  * Fetch all the layout data about the current site at once.
  */
-export async function getCurrentSiteLayoutData(args: {
+export async function getSiteLayoutData(args: {
     organizationId: string;
     siteId: string;
     siteSpaceId: string | undefined;
 }) {
     const [customization, scripts] = await Promise.all([
-        args.siteSpaceId
-            ? getSiteSpaceCustomization({
-                  organizationId: args.organizationId,
-                  siteId: args.siteId,
-                  siteSpaceId: args.siteSpaceId,
-              })
-            : getSiteCustomization({
-                  organizationId: args.organizationId,
-                  siteId: args.siteId,
-              }),
+        getCurrentSiteCustomization(args),
         getSiteIntegrationScripts(args.organizationId, args.siteId),
     ]);
 

--- a/packages/gitbook/src/lib/seo.ts
+++ b/packages/gitbook/src/lib/seo.ts
@@ -49,7 +49,7 @@ export function isSpaceIndexable({ space, site }: { space: Space; site: Site | n
         return false;
     }
 
-    if (site && site.object === 'site') {
+    if (site) {
         return shouldIndexVisibility(site.visibility);
     }
 

--- a/packages/gitbook/src/lib/seo.ts
+++ b/packages/gitbook/src/lib/seo.ts
@@ -31,13 +31,7 @@ export function isPageIndexable(
 /**
  * Return true if a space should be indexed by search engines.
  */
-export function isSpaceIndexable({
-    space,
-    parent,
-}: {
-    space: Space;
-    parent: Site | Collection | null;
-}) {
+export function isSpaceIndexable({ space, site }: { space: Space; site: Site | null }) {
     const headerSet = headers();
 
     if (
@@ -55,16 +49,12 @@ export function isSpaceIndexable({
         return false;
     }
 
-    if (parent && parent.object === 'site') {
-        return shouldIndexVisibility(parent.visibility);
+    if (site && site.object === 'site') {
+        return shouldIndexVisibility(site.visibility);
     }
 
-    if (space.visibility === ContentVisibility.InCollection) {
-        return parent && parent.object === 'collection'
-            ? shouldIndexVisibility(parent.visibility)
-            : false;
-    }
-    return shouldIndexVisibility(space.visibility);
+    // space with no site should not be indexed
+    return false;
 }
 
 function shouldIndexVisibility(visibility: ContentVisibility | SiteVisibility) {

--- a/packages/gitbook/src/lib/utils.ts
+++ b/packages/gitbook/src/lib/utils.ts
@@ -12,7 +12,7 @@ import {
 export function getContentTitle(
     space: Space,
     customization: CustomizationSettings | SiteCustomizationSettings,
-    parent: Site | Collection | null,
+    parent: Site | null,
 ) {
     // When we are rendering a site, always give priority to the customization title first
     // and then fallback to the site title

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -15,7 +15,7 @@ import {
     withAPI,
     getSpaceLayoutData,
     DEFAULT_API_ENDPOINT,
-    getCurrentSiteLayoutData,
+    getSiteLayoutData,
     getSite,
 } from '@/lib/api';
 import { race } from '@/lib/async';
@@ -202,7 +202,7 @@ export async function middleware(request: NextRequest) {
             );
 
             const { scripts } = await ('site' in resolved
-                ? getCurrentSiteLayoutData({
+                ? getSiteLayoutData({
                       organizationId: resolved.organization,
                       siteId: resolved.site,
                       siteSpaceId: resolved.siteSpace,


### PR DESCRIPTION
This PR removes usage of `getContentPointer` in the Search components. They are being passed through props. I also took this opportunity to cleanup some legacy code such as support for Collections etc. More to come in later PRs