### PR TITLE
Mock data for getSpaceCustomization and getSpaceIntegrationScripts

### DIFF
--- a/packages/gitbook/src/app/(site)/(content)/[[...pathname]]/not-found.tsx
+++ b/packages/gitbook/src/app/(site)/(content)/[[...pathname]]/not-found.tsx
@@ -1,5 +1,5 @@
 import { getSpaceLanguage, t } from '@/intl/server';
-import { getSiteLayoutData, getSpaceLayoutData } from '@/lib/api';
+import { getSiteLayoutData } from '@/lib/api';
 import { getSiteContentPointer } from '@/lib/pointer';
 import { tcls } from '@/lib/tailwind';
 

--- a/packages/gitbook/src/app/(site)/layout.tsx
+++ b/packages/gitbook/src/app/(site)/layout.tsx
@@ -1,5 +1,5 @@
 import { CustomizationRootLayout } from '@/components/RootLayout';
-import { getSiteLayoutData, getSpaceLayoutData } from '@/lib/api';
+import { getSiteLayoutData } from '@/lib/api';
 import { getSiteContentPointer } from '@/lib/pointer';
 
 /**

--- a/packages/gitbook/src/app/(space)/~gitbook/pdf/layout.tsx
+++ b/packages/gitbook/src/app/(space)/~gitbook/pdf/layout.tsx
@@ -1,5 +1,7 @@
+import { SpaceIntegrationScript } from '@gitbook/api';
+
 import { CustomizationRootLayout } from '@/components/RootLayout';
-import { getSiteLayoutData, getSpaceLayoutData } from '@/lib/api';
+import { getSiteLayoutData, getSpaceCustomization } from '@/lib/api';
 
 import { getSiteOrSpacePointerForPDF } from './pointer';
 
@@ -18,4 +20,19 @@ export default async function PDFRootLayout(props: { children: React.ReactNode }
     return (
         <CustomizationRootLayout customization={customization}>{children}</CustomizationRootLayout>
     );
+}
+
+/**
+ * Fetch all the layout data about a space at once.
+ */
+async function getSpaceLayoutData(spaceId: string) {
+    const [customization, scripts] = await Promise.all([
+        getSpaceCustomization(spaceId),
+        [] as SpaceIntegrationScript[],
+    ]);
+
+    return {
+        customization,
+        scripts,
+    };
 }

--- a/packages/gitbook/src/lib/api.ts
+++ b/packages/gitbook/src/lib/api.ts
@@ -814,23 +814,6 @@ export async function getCurrentSiteCustomization(args: {
 /**
  * Get the customization settings for a space from the API.
  */
-export const getSpaceCustomizationFromAPI = cache({
-    name: 'api.getSpaceCustomization',
-    tag: (spaceId) => getAPICacheTag({ tag: 'space', space: spaceId }),
-    get: async (spaceId: string, options: CacheFunctionOptions) => {
-        const response = await api().spaces.getSpacePublishingCustomizationById(spaceId, {
-            signal: options.signal,
-            ...noCacheFetchOptions,
-        });
-        return cacheResponse(response, {
-            revalidateBefore: 60 * 60,
-        });
-    },
-});
-
-/**
- * Get the customization settings for a space from the API.
- */
 export async function getSpaceCustomization(spaceId: string): Promise<CustomizationSettings> {
     const headersList = headers();
     const raw = defaultCustomizationForSpace();

--- a/packages/gitbook/src/lib/api.ts
+++ b/packages/gitbook/src/lib/api.ts
@@ -876,24 +876,6 @@ export const getCollectionSpaces = cache({
 });
 
 /**
- * Fetch all the data to render a space at once.
- */
-export async function getSpaceData(pointer: SpaceContentPointer, shareKey: string | undefined) {
-    const [{ space, pages, contentTarget }, { customization, scripts }] = await Promise.all([
-        getSpaceContentData(pointer, shareKey),
-        getSpaceLayoutData(pointer.spaceId),
-    ]);
-
-    return {
-        space,
-        pages,
-        contentTarget,
-        customization,
-        scripts,
-    };
-}
-
-/**
  * Fetch all the content data about a space at once.
  * This function executes the requests in parallel and should be used as early as possible
  * instead of calling the individual functions.
@@ -923,21 +905,6 @@ export async function getSpaceContentData(
         space,
         pages,
         contentTarget,
-    };
-}
-
-/**
- * Fetch all the layout data about a space at once.
- */
-export async function getSpaceLayoutData(spaceId: string) {
-    const [customization, scripts] = await Promise.all([
-        getSpaceCustomization(spaceId),
-        [] as SpaceIntegrationScript[],
-    ]);
-
-    return {
-        customization,
-        scripts,
     };
 }
 

--- a/packages/gitbook/src/lib/api.ts
+++ b/packages/gitbook/src/lib/api.ts
@@ -12,7 +12,6 @@ import {
     RequestRenderIntegrationUI,
     RevisionFile,
     SiteCustomizationSettings,
-    Space,
     SpaceIntegrationScript,
 } from '@gitbook/api';
 import assertNever from 'assert-never';

--- a/packages/gitbook/src/lib/utils.ts
+++ b/packages/gitbook/src/lib/utils.ts
@@ -1,18 +1,12 @@
-import {
-    Collection,
-    CustomizationSettings,
-    Site,
-    SiteCustomizationSettings,
-    Space,
-} from '@gitbook/api';
+import * as api from '@gitbook/api';
 
 /**
  * Get the title to display for a content.
  */
 export function getContentTitle(
-    space: Space,
-    customization: CustomizationSettings | SiteCustomizationSettings,
-    parent: Site | null,
+    space: api.Space,
+    customization: api.CustomizationSettings | api.SiteCustomizationSettings,
+    parent: api.Site | null,
 ) {
     // When we are rendering a site, always give priority to the customization title first
     // and then fallback to the site title
@@ -23,4 +17,58 @@ export function getContentTitle(
 
     // Otherwise the legacy behavior is not changed to avoid regressions
     return parent ? parent.title : (customization.title ?? space.title);
+}
+
+/**
+ * Return the customizations with the default values for a space.
+ */
+export function defaultCustomizationForSpace(): api.CustomizationSettings {
+    return {
+        internationalization: {
+            inherit: false,
+            locale: api.CustomizationLocale.En,
+        },
+        styling: {
+            primaryColor: {
+                dark: '#346DDB',
+                light: '#346DDB',
+            },
+            corners: api.CustomizationCorners.Rounded,
+            font: api.CustomizationFont.Inter,
+            background: api.CustomizationBackground.Plain,
+        },
+        favicon: {},
+        header: {
+            preset: api.CustomizationHeaderPreset.Default,
+            links: [],
+        },
+        footer: {
+            groups: [],
+        },
+        themes: {
+            default: api.CustomizationThemeMode.Light,
+            toggeable: false,
+        },
+        trademark: {
+            enabled: true,
+        },
+        feedback: {
+            enabled: false,
+        },
+        pdf: {
+            enabled: true,
+        },
+        aiSearch: {
+            enabled: true,
+        },
+        pagination: {
+            enabled: true,
+        },
+        privacyPolicy: {},
+        socialPreview: {},
+        git: {
+            showEditLink: false,
+        },
+        inherit: false,
+    };
 }

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -13,7 +13,6 @@ import {
     getSpaceContentData,
     userAgent,
     withAPI,
-    getSpaceLayoutData,
     DEFAULT_API_ENDPOINT,
     getSiteLayoutData,
     getSite,
@@ -181,7 +180,7 @@ export async function middleware(request: NextRequest) {
                       siteId: resolved.site,
                       siteSpaceId: resolved.siteSpace,
                   })
-                : getSpaceLayoutData(resolved.space));
+                : { scripts: [] });
             return getContentSecurityPolicy(scripts, nonce);
         },
     );


### PR DESCRIPTION
Making API calls to these endpoints are useless now with sites. We only need to the default data to ensure rendering works end to end