### PR TITLE
Update Playwright test for share links

### DIFF
--- a/packages/gitbook/e2e/pages.spec.ts
+++ b/packages/gitbook/e2e/pages.spec.ts
@@ -495,7 +495,7 @@ const testCases: TestsCase[] = [
         tests: [
             {
                 name: 'Valid link',
-                url: 'TGs8PkF4GWVtbmPnWhYL/',
+                url: 'thDznyWXCeEoT55WB7HC/',
             },
             {
                 name: 'Invalid link',


### PR DESCRIPTION
The share link we used for Playwright was recently revoked, so we generated a new one. The old link in `pages.spec.ts` needs to be updated.