### PR TITLE
Unify section tab styles with page item styles

### DIFF
--- a/.changeset/heavy-walls-collect.md
+++ b/.changeset/heavy-walls-collect.md
@@ -1,0 +1,5 @@
+---
+'gitbook': minor
+---
+
+Unify section tab styles with page item styles

--- a/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
@@ -119,7 +119,8 @@ const Tab = React.forwardRef<
             className={tcls(
                 'px-3 py-1 my-2 rounded straight-corners:rounded-none transition-colors',
                 active && 'text-primary dark:text-primary-400',
-                !active && ' hover:bg-light-2 dark:hover:bg-dark-3',
+                !active &&
+                    'text-dark/8 hover:bg-dark/1 hover:text-dark/9 dark:text-light/8 dark:hover:bg-light/2 dark:hover:text-light/9',
             )}
             role="tab"
             href={href}


### PR DESCRIPTION
### Before
<img width="304" alt="image" src="https://github.com/user-attachments/assets/9669fd94-6378-4bf8-b9fe-043371229c50">

### After
<img width="309" alt="image" src="https://github.com/user-attachments/assets/28b5f9bf-bd78-417a-af55-fcf65bb17a9f">
