### PR TITLE
Fix the styling of site section tabs on smaller screens.

### DIFF
--- a/.changeset/weak-swans-battle.md
+++ b/.changeset/weak-swans-battle.md
@@ -1,0 +1,5 @@
+---
+'gitbook': minor
+---
+
+Fix the styling of site section tabs on smaller screens.

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -26,10 +26,8 @@ export function Header(props: {
     context: ContentRefContext;
     customization: CustomizationSettings | SiteCustomizationSettings;
     withTopHeader?: boolean;
-    children?: React.ReactNode;
 }) {
-    const { children, context, space, site, spaces, sections, customization, withTopHeader } =
-        props;
+    const { context, space, site, spaces, sections, customization, withTopHeader } = props;
     const isCustomizationDefault =
         customization.header.preset === CustomizationHeaderPreset.Default;
     const hasSiteSections = sections && sections.list.length > 1;
@@ -145,11 +143,11 @@ export function Header(props: {
                 <div
                     className={tcls(
                         'w-full shadow-thintop dark:shadow-light/1 bg-light dark:bg-dark z-[9] mt-0.5',
+                        // Handle long section tabs, particularly on smaller screens.
+                        'overflow-x-auto hide-scroll',
                     )}
                 >
-                    <div className={tcls(CONTAINER_STYLE)}>
-                        <SiteSectionTabs {...sections} />
-                    </div>
+                    <SiteSectionTabs {...sections} />
                 </div>
             ) : null}
         </header>

--- a/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
@@ -1,11 +1,11 @@
 'use client';
 import { SiteSection } from '@gitbook/api';
-import { Icon } from '@gitbook/icons';
 import React from 'react';
 
 import { tcls } from '@/lib/tailwind';
 
-import { Button, Link } from '../primitives';
+import { getContainerHorizontalPaddingStyle } from '../layout';
+import { Link } from '../primitives';
 
 /**
  * A set of navigational tabs representing site sections for multi-section sites
@@ -35,7 +35,11 @@ export function SiteSectionTabs(props: {
         if (currentTabRef.current && navRef.current) {
             const rect = currentTabRef.current.getBoundingClientRect();
             const navRect = navRef.current.getBoundingClientRect();
-            setTabDimensions({ left: rect.left - navRect.left, width: rect.width });
+
+            setTabDimensions({
+                left: rect.left - navRect.left,
+                width: rect.width,
+            });
         }
     }, []);
 
@@ -56,13 +60,11 @@ export function SiteSectionTabs(props: {
     const scale = (tabDimensions?.width ?? 0) * 0.01;
     const startPos = `${tabDimensions?.left ?? 0}px`;
 
-    const hasMoreSections = false; /** TODO: determine whether we need to show the more button */
-
     return tabs.length > 0 ? (
         <nav
             aria-label="Sections"
             ref={navRef}
-            className="flex flex-nowrap items-center max-w-screen mb-px"
+            className="flex-nowrap items-center mb-px"
             style={
                 {
                     '--tab-opacity': `${opacity}`,
@@ -77,6 +79,10 @@ export function SiteSectionTabs(props: {
                     'flex',
                     'gap-2',
                     'bg-transparent',
+
+                    // Calculate horizontal padding, considering the horizontal padding of the tabs themselves.
+                    getContainerHorizontalPaddingStyle(TAB_HORIZONTAL_PADDING),
+
                     /* add a pseudo element for active tab indicator */
                     'after:block',
                     "after:content-['']",
@@ -107,10 +113,14 @@ export function SiteSectionTabs(props: {
                     />
                 ))}
             </div>
-            {hasMoreSections ? <MoreSectionsButton /> : null}
         </nav>
     ) : null;
 }
+
+/**
+ * Horizontal padding for the tabs. Gives a nice hover effect and is used to calculate the padding of the container.
+ */
+const TAB_HORIZONTAL_PADDING = 3;
 
 /**
  * The tab item - a link to a site section
@@ -121,7 +131,8 @@ const Tab = React.forwardRef<HTMLSpanElement, { active: boolean; href: string; l
         return (
             <Link
                 className={tcls(
-                    'px-3 py-1 my-2 rounded straight-corners:rounded-none transition-colors',
+                    `px-${TAB_HORIZONTAL_PADDING}`,
+                    'py-1 my-2 rounded straight-corners:rounded-none transition-colors',
                     active && 'text-primary dark:text-primary-400',
                     !active &&
                         'text-dark/8 hover:bg-dark/1 hover:text-dark/9 dark:text-light/8 dark:hover:bg-light/2 dark:hover:text-light/9',
@@ -136,16 +147,3 @@ const Tab = React.forwardRef<HTMLSpanElement, { active: boolean; href: string; l
         );
     },
 );
-
-/**
- * Dropdown trigger for when there are too many sections to show them all
- */
-function MoreSectionsButton() {
-    return (
-        <div>
-            <Button variant="secondary" size="small">
-                <Icon icon="ellipsis-h" size={12} />
-            </Button>
-        </div>
-    );
-}

--- a/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
@@ -64,7 +64,7 @@ export function SiteSectionTabs(props: {
         <nav
             aria-label="Sections"
             ref={navRef}
-            className="flex-nowrap items-center mb-px"
+            className="flex flex-nowrap items-center mb-px"
             style={
                 {
                     '--tab-opacity': `${opacity}`,

--- a/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
@@ -80,8 +80,10 @@ export function SiteSectionTabs(props: {
                     'gap-2',
                     'bg-transparent',
 
-                    // Calculate horizontal padding, considering the horizontal padding of the tabs themselves.
-                    getContainerHorizontalPaddingStyle(TAB_HORIZONTAL_PADDING),
+                    // Horizontal padding, which is the layout padding minus the padding of the tabs themselves.
+                    'px-1',
+                    'sm:px-3',
+                    'md:px-5',
 
                     /* add a pseudo element for active tab indicator */
                     'after:block',
@@ -131,8 +133,7 @@ const Tab = React.forwardRef<HTMLSpanElement, { active: boolean; href: string; l
         return (
             <Link
                 className={tcls(
-                    `px-${TAB_HORIZONTAL_PADDING}`,
-                    'py-1 my-2 rounded straight-corners:rounded-none transition-colors',
+                    'px-3 py-1 my-2 rounded straight-corners:rounded-none transition-colors',
                     active && 'text-primary dark:text-primary-400',
                     !active &&
                         'text-dark/8 hover:bg-dark/1 hover:text-dark/9 dark:text-light/8 dark:hover:bg-light/2 dark:hover:text-light/9',

--- a/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 
 import { tcls } from '@/lib/tailwind';
 
-import { getContainerHorizontalPaddingStyle } from '../layout';
 import { Link } from '../primitives';
 
 /**
@@ -118,11 +117,6 @@ export function SiteSectionTabs(props: {
         </nav>
     ) : null;
 }
-
-/**
- * Horizontal padding for the tabs. Gives a nice hover effect and is used to calculate the padding of the container.
- */
-const TAB_HORIZONTAL_PADDING = 3;
 
 /**
  * The tab item - a link to a site section

--- a/packages/gitbook/src/components/layout.ts
+++ b/packages/gitbook/src/components/layout.ts
@@ -6,25 +6,12 @@ import { ClassValue } from '@/lib/tailwind';
 export const HEADER_HEIGHT_DESKTOP = 64 as const;
 
 /**
- * Returns horizontal padding classes for the application. Optionally provide
- * an offset to adjust the padding.
- */
-export function getContainerHorizontalPaddingStyle(offset: number = 0): ClassValue {
-    return [
-        // px-4
-        `px-${4 - offset}`,
-        // sm:px-6
-        `sm:px-${6 - offset}`,
-        // md:px-8
-        `md:px-${8 - offset}`,
-    ];
-}
-
-/**
  * Style for the container to adapt between normal and full width.
  */
 export const CONTAINER_STYLE: ClassValue = [
-    getContainerHorizontalPaddingStyle(),
+    'px-4',
+    'sm:px-6',
+    'md:px-8',
     'max-w-screen-2xl',
     'mx-auto',
     'page-full-width:max-w-full',

--- a/packages/gitbook/src/components/layout.ts
+++ b/packages/gitbook/src/components/layout.ts
@@ -5,13 +5,22 @@ import { ClassValue } from '@/lib/tailwind';
  */
 export const HEADER_HEIGHT_DESKTOP = 64 as const;
 
+export function getContainerHorizontalPaddingStyle(offset: number = 0): ClassValue {
+    return [
+        // px-4
+        `px-${4 - offset}`,
+        // sm:px-6
+        `sm:px-${6 - offset}`,
+        // md:px-8
+        `md:px-${8 - offset}`,
+    ];
+}
+
 /**
  * Style for the container to adapt between normal and full width.
  */
 export const CONTAINER_STYLE: ClassValue = [
-    'px-4',
-    'sm:px-6',
-    'md:px-8',
+    getContainerHorizontalPaddingStyle(),
     'max-w-screen-2xl',
     'mx-auto',
     'page-full-width:max-w-full',

--- a/packages/gitbook/src/components/layout.ts
+++ b/packages/gitbook/src/components/layout.ts
@@ -5,6 +5,10 @@ import { ClassValue } from '@/lib/tailwind';
  */
 export const HEADER_HEIGHT_DESKTOP = 64 as const;
 
+/**
+ * Returns horizontal padding classes for the application. Optionally provide
+ * an offset to adjust the padding.
+ */
 export function getContainerHorizontalPaddingStyle(offset: number = 0): ClassValue {
     return [
         // px-4


### PR DESCRIPTION
Fix the styling of site section tabs on smaller screens.

First, align the horizontal padding of the tabs with the rest of the content:

<img width="386" alt="Screenshot 2024-11-04 at 12 58 48" src="https://github.com/user-attachments/assets/dc487054-7a94-44d9-9291-080e62b984e7">

Second, add some horizontal scrolling when tabs go over the limit:

Before: 

![image](https://github.com/user-attachments/assets/5c4e16d4-9425-4143-8cad-b39051341a18)


After:

<img width="385" alt="Screenshot 2024-11-04 at 13 00 42" src="https://github.com/user-attachments/assets/e065113b-46d0-44ca-8d56-6e1b66640307">


https://github.com/user-attachments/assets/a582bb38-226e-42c8-93da-06be871ab284





