### PR TITLE
Set adjustFallbackFont to false for mono font

### DIFF
--- a/.changeset/large-kangaroos-fly.md
+++ b/.changeset/large-kangaroos-fly.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Don't adjust fallback font for mono font.

--- a/packages/gitbook/src/fonts/index.ts
+++ b/packages/gitbook/src/fonts/index.ts
@@ -39,6 +39,7 @@ export const ibmPlexMono = IBM_Plex_Mono({
     display: 'swap',
     preload: false,
     fallback: ['monospace'],
+    adjustFontFallback: false,
 });
 
 const firaSans = Fira_Sans_Extra_Condensed({


### PR DESCRIPTION
Fixes RND-5461

Next option to `adjustFallbackFont` can lead to some glyphs not falling back to a monospace font for code blocks. Setting it to false for `IBM Plex Mono` to prevent this.

Before
![Screenshot 2024-11-12 at 11 40 32](https://github.com/user-attachments/assets/23db2718-f2f2-40d5-a97e-db8f99cc4e6f)

After
![Screenshot 2024-11-12 at 11 40 39](https://github.com/user-attachments/assets/a815e886-4302-4570-8271-0ffc904e233d)

