### PR TITLE
Improve contrast ratio for text color on image captions

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Caption.tsx
+++ b/packages/gitbook/src/components/DocumentView/Caption.tsx
@@ -71,7 +71,7 @@ export function Caption(
                     'text-center',
                     'mt-2',
                     'text-dark/7',
-                    'dark:text-light/6',
+                    'dark:text-light/7',
                 )}
             >
                 <Inlines


### PR DESCRIPTION
This PR improves the contrast of captions on Image blocks in dark mode, going from 3.79 to 7.43.

After:
![CleanShot 2024-11-25 at 13 02 45@2x](https://github.com/user-attachments/assets/ded4ba0b-d0d9-4742-a2c8-5443a13876f5)