### PR TITLE
Fix hint block decoration color

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -44,7 +44,7 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
                         hintStyle.bodyColor,
                         // render hash icon on the other side of the heading
                         'flip-heading-hash',
-                        'decoration-inherit'
+                        'decoration-inherit',
                     )}
                     style={['flex-1', 'space-y-4', '[&_.hint]:border', '[&_pre]:border']}
                 />

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -91,6 +91,7 @@ const HINT_STYLES: {
             '[&_.can-override-bg]:bg-orange-500/3',
             '[&_.can-override-text]:text-orange-800',
             'dark:[&_.can-override-text]:text-orange-400',
+            'decoration-orange-800'
         ],
         style: ['bg-orange-500/2', 'border-orange-500/4'],
     },
@@ -104,6 +105,7 @@ const HINT_STYLES: {
             'dark:[&_a:hover]:text-red-300',
             '[&_.can-override-bg]:bg-red-500/3',
             '[&_.can-override-text]:text-red-400',
+            'decoration-red-800'
         ],
         style: ['bg-red-500/2', 'border-red-500/4'],
     },
@@ -118,6 +120,7 @@ const HINT_STYLES: {
             '[&_.can-override-bg]:bg-green-500/3',
             '[&_.can-override-text]:text-green-800',
             'dark:[&_.can-override-text]:text-green-400',
+            'decoration-green-800'
         ],
         style: ['bg-green-500/2', 'border-green-500/4'],
     },

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -44,6 +44,7 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
                         hintStyle.bodyColor,
                         // render hash icon on the other side of the heading
                         'flip-heading-hash',
+                        'decoration-inherit'
                     )}
                     style={['flex-1', 'space-y-4', '[&_.hint]:border', '[&_pre]:border']}
                 />
@@ -91,7 +92,6 @@ const HINT_STYLES: {
             '[&_.can-override-bg]:bg-orange-500/3',
             '[&_.can-override-text]:text-orange-800',
             'dark:[&_.can-override-text]:text-orange-400',
-            'decoration-orange-800'
         ],
         style: ['bg-orange-500/2', 'border-orange-500/4'],
     },
@@ -105,7 +105,6 @@ const HINT_STYLES: {
             'dark:[&_a:hover]:text-red-300',
             '[&_.can-override-bg]:bg-red-500/3',
             '[&_.can-override-text]:text-red-400',
-            'decoration-red-800'
         ],
         style: ['bg-red-500/2', 'border-red-500/4'],
     },
@@ -120,7 +119,6 @@ const HINT_STYLES: {
             '[&_.can-override-bg]:bg-green-500/3',
             '[&_.can-override-text]:text-green-800',
             'dark:[&_.can-override-text]:text-green-400',
-            'decoration-green-800'
         ],
         style: ['bg-green-500/2', 'border-green-500/4'],
     },


### PR DESCRIPTION
Links inside hint blocks correctly change their color to match the hint block, but the `text-decoration` property is not changed with them. Let’s fix that by making them inherit their text color properly.

## Preview
<img width="1800" alt="Screenshot 2024-11-27 at 20 59 41" src="https://github.com/user-attachments/assets/4dbe91c8-4dad-4e78-ba62-3608784c5df5">