### PR TITLE
Fix whitespace added with image

### DIFF
--- a/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSectionTabs/SiteSectionTabs.tsx
@@ -150,7 +150,7 @@ const Tab = React.forwardRef<
             role="tab"
             href={href}
         >
-            <span ref={ref} className={tcls('inline-flex gap-2 items-center w-full truncate')}>
+            <span ref={ref} className={tcls('flex gap-2 items-center w-full truncate')}>
                 {icon}
                 {label}
             </span>


### PR DESCRIPTION
Fix annoying inline whitespace thing when showing icons in section tabs.

After fix (tab section same height with and without icons):
<img width="1512" alt="Screenshot 2024-11-29 at 16 41 04" src="https://github.com/user-attachments/assets/540a3275-0840-4a66-9931-885d62fd5e7e">

Before fix (adding some random whitespace):
<img width="1512" alt="Screenshot 2024-11-29 at 16 40 01" src="https://github.com/user-attachments/assets/7eed055d-cdf5-42f7-92f3-148d96412414">

