### PR TITLE
Fix cookie banner button being non responsive

### DIFF
--- a/.changeset/clean-days-juggle.md
+++ b/.changeset/clean-days-juggle.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix an issue with the cookie banner buttons being non responsive

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -15,7 +15,6 @@ type ButtonProps = {
 
 export function Button({
     href,
-    onClick,
     children,
     variant = 'primary',
     size = 'default',


### PR DESCRIPTION
We missed removing `onClick` in https://github.com/GitbookIO/gitbook/pull/2596