### PR TITLE
Center-align inline images

### DIFF
--- a/packages/gitbook/src/components/DocumentView/InlineImage.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineImage.tsx
@@ -25,7 +25,7 @@ export async function InlineImage(props: InlineProps<DocumentInlineImage>) {
 
     return (
         /* Ensure images dont expand to the size of the container where this Image may be nested in. Now it's always nested in a size-restricted container */
-        <span className={tcls(size !== 'line' ? ['inline-flex', 'max-w-[300px]'] : null)}>
+        <span className={tcls(size !== 'line' ? ['inline-flex', 'max-w-[300px]', 'align-middle'] : null)}>
             <Image
                 alt={inline.data.caption ?? ''}
                 sizes={await getImageSizes(size, src)}


### PR DESCRIPTION
Inline images are often used to create badge-like elements. They currently don't align in the middle, which makes the layout look awkward.

Before:
![CleanShot 2024-12-09 at 08 41 40@2x](https://github.com/user-attachments/assets/bf596357-f115-4a2e-af98-203b23ca3352)


After:
![CleanShot 2024-12-09 at 08 40 58@2x](https://github.com/user-attachments/assets/475b1e02-bfe9-46ed-b67d-f66b4e1a527a)
