### PR TITLE
Fix VA e2e tests when ran locally

### DIFF
--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -769,7 +769,7 @@ function getLookupResultForVisitorAuth(
                           ),
                           options: {
                               httpOnly: true,
-                              sameSite: 'none',
+                              sameSite: process.env.NODE_ENV === 'production' ? 'none' : undefined,
                               secure: process.env.NODE_ENV === 'production',
                               maxAge: 7 * 24 * 60 * 60,
                           },


### PR DESCRIPTION
This PR aims to prevent the e2e va test to fail when ran against local env (localhost) and also allow manually testing VA locally.