### PR TITLE
Improve styles of Tables

### DIFF
--- a/packages/gitbook/e2e/pages.spec.ts
+++ b/packages/gitbook/e2e/pages.spec.ts
@@ -1018,6 +1018,90 @@ const testCases: TestsCase[] = [
             },
         ],
     },
+    {
+        name: 'Tables',
+        baseUrl: 'https://gitbook.gitbook.io/test-gitbook-open/',
+        tests: [
+            {
+                name: 'Default table',
+                url: 'blocks/tables',
+                run: waitForCookiesDialog,
+                fullPage: true,
+            },
+            {
+                name: 'Table with straight corners',
+                url:
+                    'blocks/tables' +
+                    getCustomizationURL({
+                        styling: {
+                            corners: CustomizationCorners.Straight,
+                        },
+                    }),
+                run: waitForCookiesDialog,
+                fullPage: true,
+            },
+            {
+                name: 'Table with primary color',
+                url:
+                    'blocks/tables' +
+                    getCustomizationURL({
+                        styling: {
+                            tint: { color: { light: '#346DDB', dark: '#346DDB' } },
+                        },
+                    }),
+                run: waitForCookiesDialog,
+                fullPage: true,
+            },
+            // Test dark mode for each variant
+            ...allThemeModes.flatMap((theme) => [
+                {
+                    name: `Table in ${theme} mode`,
+                    url:
+                        'blocks/tables' +
+                        getCustomizationURL({
+                            themes: {
+                                default: theme,
+                                toggeable: false,
+                            },
+                        }),
+                    run: waitForCookiesDialog,
+                    fullPage: true,
+                },
+                {
+                    name: `Table with straight corners in ${theme} mode`,
+                    url:
+                        'blocks/tables' +
+                        getCustomizationURL({
+                            styling: {
+                                corners: CustomizationCorners.Straight,
+                            },
+                            themes: {
+                                default: theme,
+                                toggeable: false,
+                            },
+                        }),
+                    run: waitForCookiesDialog,
+                    fullPage: true,
+                },
+                {
+                    name: `Table with primary color in ${theme} mode`,
+                    url:
+                        'blocks/tables' +
+                        getCustomizationURL({
+                            styling: {
+                                tint: { color: { light: '#346DDB', dark: '#346DDB' } },
+                            },
+                            themes: {
+                                default: theme,
+                                toggeable: false,
+                            },
+                        }),
+                    run: waitForCookiesDialog,
+                    fullPage: true,
+                },
+            ]),
+        ],
+    },
 ];
 
 for (const testCase of testCases) {

--- a/packages/gitbook/src/components/DocumentView/Table/RecordRow.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordRow.tsx
@@ -4,11 +4,6 @@ import React from 'react';
 import { RecordColumnValue } from './RecordColumnValue';
 import { TableRecordKV, TableViewProps } from './Table';
 import styles from './table.module.css';
-
-import { tcls } from '@/lib/tailwind';
-
-import { RecordColumnValue } from './RecordColumnValue';
-import { TableRecordKV, TableViewProps } from './Table';
 import { getColumnWidth } from './ViewGrid';
 
 export function RecordRow(

--- a/packages/gitbook/src/components/DocumentView/Table/RecordRow.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordRow.tsx
@@ -4,6 +4,11 @@ import React from 'react';
 import { RecordColumnValue } from './RecordColumnValue';
 import { TableRecordKV, TableViewProps } from './Table';
 import styles from './table.module.css';
+
+import { tcls } from '@/lib/tailwind';
+
+import { RecordColumnValue } from './RecordColumnValue';
+import { TableRecordKV, TableViewProps } from './Table';
 import { getColumnWidth } from './ViewGrid';
 
 export function RecordRow(

--- a/packages/gitbook/src/components/DocumentView/Table/ViewGrid.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/ViewGrid.tsx
@@ -34,8 +34,15 @@ export function ViewGrid(props: TableViewProps<DocumentTableViewGrid>) {
             <div role="table" className={tcls('flex', 'flex-col')}>
                 {/* Header */}
                 {withHeader && (
-                    <div role="rowgroup" className={tcls('flex flex-col', tableWidth)}>
-                        <div role="row" className={tcls('flex', 'w-full', '[&>*+*]:border-l')}>
+                    <div
+                        role="rowgroup"
+                        className={tcls(
+                            tableWidth,
+                            styles.rowGroup,
+                            'straight-corners:rounded-none',
+                        )}
+                    >
+                        <div role="row" className={tcls('flex', 'w-full')}>
                             {view.columns.map((column) => {
                                 const alignment = getColumnAlignment(block.data.definition[column]);
                                 return (

--- a/packages/gitbook/src/components/DocumentView/Table/table.module.css
+++ b/packages/gitbook/src/components/DocumentView/Table/table.module.css
@@ -23,21 +23,37 @@
 }
 
 :global(.dark) .tableWrapper {
-    @apply border-light/2;
-}
-
-.row {
-    @apply flex border-dark/3 dark:border-light/2;
-}
-
-.row > * + * {
-    @apply border-l;
-}
-
-.cell {
-    @apply flex-1 align-middle border-dark/2 py-2 px-3 text-sm lg:text-base dark:border-light/2;
+    @apply border-tint-50;
 }
 
 .columnHeader {
-    @apply align-middle text-left text-base font-medium border-b dark:border-l-light/2 dark:border-b-light/4 py-2 px-3;
+    @apply text-sm font-medium py-3 px-4 text-tint-900;
+}
+
+:global(.dark) .columnHeader {
+    @apply text-white;
+}
+
+.row {
+    @apply flex border-tint-700/2;
+}
+
+:global(.dark) .row {
+    @apply border-tint-300/3;
+}
+
+.rowGroup {
+    @apply flex flex-col border rounded-lg bg-tint-800/1 border-tint-700/2;
+}
+
+:global(.dark) .rowGroup {
+    @apply bg-tint-300/2 border-tint-300/3;
+}
+
+.cell {
+    @apply flex-1 align-middle border-dark/2 py-2 px-4 text-sm;
+}
+
+:global(.dark) .cell {
+    @apply border-light/2;
 }


### PR DESCRIPTION
This PR changes some of the styling of Tables to make them feel more up to date.
- we use the `tint` if provided by the customization settings
- we inherit the rounded or sharp angles if provided by customization

# Screenshots
Examples of sample and existing public docs in light and dark mode

## Before
Keeper:
![CleanShot 2024-12-11 at 21 56 06@2x](https://github.com/user-attachments/assets/9f627003-d43b-4a41-8443-a889124e99d5)

Snyk:
![CleanShot 2024-12-11 at 21 57 34@2x](https://github.com/user-attachments/assets/f4c4a280-8ff0-417a-99b1-58dc6d815578)


## After
Keeper:
![CleanShot 2024-12-11 at 21 53 41@2x](https://github.com/user-attachments/assets/1fbe7779-0dfb-49a7-82c2-fa4eeeff20be)

Snyk:
![CleanShot 2024-12-11 at 21 53 49@2x](https://github.com/user-attachments/assets/d6b5dbea-1ad2-4928-b29d-5d034c9da217)

Snyk dark:
![CleanShot 2024-12-11 at 21 54 15@2x](https://github.com/user-attachments/assets/0f039518-fe95-4fca-ba1d-dfa36fe3de43)

Local, sharp radius set in customization settings:
![CleanShot 2024-12-11 at 21 53 55@2x](https://github.com/user-attachments/assets/28fd90e7-0ce5-4158-935e-a39875b5fec7)