### PR TITLE
Add breadcrumbs to page header

### DIFF
--- a/.changeset/green-turtles-vanish.md
+++ b/.changeset/green-turtles-vanish.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Add breadcrumbs above page title

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -79,7 +79,7 @@ export function PageBody(props: {
                     <PageCover as="hero" page={page} cover={page.cover} context={context} />
                 ) : null}
 
-                <PageHeader page={page} />
+                <PageHeader page={page} pages={context.pages} />
                 {document && !isNodeEmpty(document) ? (
                     <React.Suspense
                         fallback={

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -1,8 +1,16 @@
-import { RevisionPage, RevisionPageDocument } from '@gitbook/api';
+import {
+    RevisionPage,
+    RevisionPageDocument,
+    RevisionPageGroup,
+    RevisionPageType,
+} from '@gitbook/api';
+import { Icon } from '@gitbook/icons';
 
+import { pageHref } from '@/lib/links';
 import { tcls } from '@/lib/tailwind';
 
 import { PageIcon } from '../PageIcon';
+import { StyledLink } from '../primitives';
 
 export function PageHeader(props: { page: RevisionPageDocument; pages: RevisionPage[] }) {
     const { page, pages } = props;
@@ -11,42 +19,65 @@ export function PageHeader(props: { page: RevisionPageDocument; pages: RevisionP
         return null;
     }
 
-    const pageGroup = pages.find(
-        /* Use the first segment of the page's path to find the page group it belongs to */
-        (item) => item.type == 'group' && item.path == page.path.split('/')?.[0],
-    );
+    const pathSegments = page.path.split('/').slice(0, -1); // Exclude the current page from the breadcrumbs
+    const flattenedPages = flattenPages(pages);
+    const breadcrumbs = pathSegments
+        .map((pathSegment) =>
+            flattenedPages.find((page) => 'slug' in page && page.slug == pathSegment),
+        )
+        .filter((page): page is RevisionPageDocument | RevisionPageGroup => page !== undefined);
 
     return (
         <header
             className={tcls('max-w-3xl', 'mx-auto', 'mb-6', 'space-y-3', 'page-api-block:ml-0')}
         >
+            {breadcrumbs && (
+                <nav>
+                    <ol className={tcls('flex', 'flex-wrap', 'items-center', 'gap-2')}>
+                        {breadcrumbs.map((breadcrumb, index) => (
+                            <>
+                                <li key={breadcrumb.id}>
+                                    <StyledLink
+                                        href={pageHref(pages, breadcrumb)}
+                                        style={tcls(
+                                            'no-underline',
+                                            'hover:underline',
+                                            'text-xs',
+                                            'tracking-wide',
+                                            'font-semibold',
+                                            'uppercase',
+                                            'flex',
+                                            'items-center',
+                                            'gap-1',
+                                        )}
+                                    >
+                                        <PageIcon
+                                            page={breadcrumb}
+                                            style={tcls('size-4', 'text-base', 'leading-none')}
+                                        />
+                                        {breadcrumb.title}
+                                    </StyledLink>
+                                </li>
+                                {index != breadcrumbs.length - 1 && (
+                                    <Icon
+                                        icon="chevron-right"
+                                        className={tcls(
+                                            'size-3',
+                                            'text-light-4',
+                                            'dark:text-dark-4',
+                                        )}
+                                    />
+                                )}
+                            </>
+                        ))}
+                    </ol>
+                </nav>
+            )}
             {page.layout.title ? (
-                <>
-                    {pageGroup && (
-                        <p
-                            className={tcls(
-                                'text-xs',
-                                'tracking-wide',
-                                'font-semibold',
-                                'uppercase',
-                                'text-tint',
-                                'flex',
-                                'items-center',
-                                'gap-2',
-                            )}
-                        >
-                            <PageIcon
-                                page={pageGroup}
-                                style={tcls('size-4', 'text-base', 'leading-none')}
-                            />
-                            {pageGroup.title}
-                        </p>
-                    )}
-                    <h1 className={tcls('text-4xl', 'font-bold', 'flex', 'items-center', 'gap-4')}>
-                        <PageIcon page={page} style={['text-dark/6', 'dark:text-light/6']} />
-                        {page.title}
-                    </h1>
-                </>
+                <h1 className={tcls('text-4xl', 'font-bold', 'flex', 'items-center', 'gap-4')}>
+                    <PageIcon page={page} style={['text-dark/6', 'dark:text-light/6']} />
+                    {page.title}
+                </h1>
             ) : null}
             {page.description && page.layout.description ? (
                 <p className={tcls('text-lg', 'text-dark-4', 'dark:text-light-4')}>
@@ -55,4 +86,11 @@ export function PageHeader(props: { page: RevisionPageDocument; pages: RevisionP
             ) : null}
         </header>
     );
+}
+
+function flattenPages(pages: RevisionPage[]): RevisionPage[] {
+    return pages.reduce<RevisionPage[]>((acc, page) => {
+        const nestedPages = 'pages' in page && page.pages ? flattenPages(page.pages) : [];
+        return acc.concat(page, ...nestedPages);
+    }, []);
 }

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -1,25 +1,53 @@
-import { RevisionPageDocument } from '@gitbook/api';
+import { RevisionPage, RevisionPageDocument } from '@gitbook/api';
 
 import { tcls } from '@/lib/tailwind';
 
 import { PageIcon } from '../PageIcon';
 
-export function PageHeader(props: { page: RevisionPageDocument }) {
-    const { page } = props;
+export function PageHeader(props: { page: RevisionPageDocument; pages: RevisionPage[] }) {
+    const { page, pages } = props;
 
     if (!page.layout.title && !page.layout.description) {
         return null;
     }
+
+    const pageGroup = pages.find(
+        (item) => item.type == 'group' && item.path == page.path.match(/([^\/]+)/g)?.[0],
+    );
 
     return (
         <header
             className={tcls('max-w-3xl', 'mx-auto', 'mb-6', 'space-y-3', 'page-api-block:ml-0')}
         >
             {page.layout.title ? (
-                <h1 className={tcls('text-4xl', 'font-bold', 'flex', 'items-center', 'gap-4')}>
-                    <PageIcon page={page} style={['text-dark/6', 'dark:text-light/6']} />
-                    {page.title}
-                </h1>
+                <>
+                    {pageGroup && (
+                        <p
+                            className={tcls(
+                                'text-xs',
+                                'tracking-wide',
+                                'font-semibold',
+                                'uppercase',
+                                'text-tint',
+                                'flex',
+                                'items-center',
+                                'gap-2',
+                            )}
+                        >
+                            <PageIcon
+                                page={pageGroup}
+                                style={tcls('size-4', 'text-base', 'leading-none')}
+                            />
+                            {/* {pageGroup.icon && <Icon icon={pageGroup.icon as IconName} className='size-4' />}
+                            {pageGroup.emoji && <span className='size-4'><Emoji code={pageGroup.emoji}> /></span>} */}
+                            {pageGroup.title}
+                        </p>
+                    )}
+                    <h1 className={tcls('text-4xl', 'font-bold', 'flex', 'items-center', 'gap-4')}>
+                        <PageIcon page={page} style={['text-dark/6', 'dark:text-light/6']} />
+                        {page.title}
+                    </h1>
+                </>
             ) : null}
             {page.description && page.layout.description ? (
                 <p className={tcls('text-lg', 'text-dark-4', 'dark:text-light-4')}>

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -12,7 +12,8 @@ export function PageHeader(props: { page: RevisionPageDocument; pages: RevisionP
     }
 
     const pageGroup = pages.find(
-        (item) => item.type == 'group' && item.path == page.path.match(/([^\/]+)/g)?.[0],
+        /* Use the first segment of the page's path to find the page group it belongs to */
+        (item) => item.type == 'group' && item.path == page.path.split('/')?.[0],
     );
 
     return (
@@ -38,8 +39,6 @@ export function PageHeader(props: { page: RevisionPageDocument; pages: RevisionP
                                 page={pageGroup}
                                 style={tcls('size-4', 'text-base', 'leading-none')}
                             />
-                            {/* {pageGroup.icon && <Icon icon={pageGroup.icon as IconName} className='size-4' />}
-                            {pageGroup.emoji && <span className='size-4'><Emoji code={pageGroup.emoji}> /></span>} */}
                             {pageGroup.title}
                         </p>
                     )}

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -31,7 +31,7 @@ export function PageHeader(props: { page: RevisionPageDocument; pages: RevisionP
         <header
             className={tcls('max-w-3xl', 'mx-auto', 'mb-6', 'space-y-3', 'page-api-block:ml-0')}
         >
-            {breadcrumbs && (
+            {breadcrumbs?.length > 0 && (
                 <nav>
                     <ol className={tcls('flex', 'flex-wrap', 'items-center', 'gap-2')}>
                         {breadcrumbs.map((breadcrumb, index) => (


### PR DESCRIPTION
If a page is nested within a page group or other pages, we can put breadcrumbs above the page title. It adds a sense of hierarchy to the page, and provides a nice touch of colour.

# Preview

<img width="1799" alt="Screenshot 2024-12-12 at 22 20 53" src="https://github.com/user-attachments/assets/0b570cc8-55cb-4ded-9e69-0c314572873b" />
<img width="1799" alt="Screenshot 2024-12-12 at 22 20 58" src="https://github.com/user-attachments/assets/a847d73e-9792-44ba-85cf-398926770a58" />
<img width="1799" alt="Screenshot 2024-12-12 at 22 21 05" src="https://github.com/user-attachments/assets/090eca76-92c8-443a-a55b-f64592d414ce" />
<img width="1799" alt="Screenshot 2024-12-12 at 22 21 09" src="https://github.com/user-attachments/assets/ddec2453-b01e-44a7-bc78-83ff2fc48a2b" />
<img width="1799" alt="Screenshot 2024-12-12 at 22 21 13" src="https://github.com/user-attachments/assets/d443d6a4-b1a3-4ac7-bb7e-4e7e3e126e40" />
<img width="1799" alt="Screenshot 2024-12-12 at 22 21 16" src="https://github.com/user-attachments/assets/70b99fd6-d950-4496-a17e-d6ee761d4640" />
<img width="1799" alt="Screenshot 2024-12-12 at 22 20 46" src="https://github.com/user-attachments/assets/b515d0de-be78-41e1-8ed9-ed7c4ff544f1" />
