### PR TITLE
Increase token max length to fix code not highlighted

### DIFF
--- a/.changeset/ten-parrots-argue.md
+++ b/.changeset/ten-parrots-argue.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Increase token max length to fix code not highlighted

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
@@ -50,7 +50,7 @@ export async function highlight(block: DocumentBlockCode): Promise<HighlightLine
 
     const lines = highlighter.codeToTokensBase(code, {
         lang: langName,
-        tokenizeMaxLineLength: 120,
+        tokenizeMaxLineLength: 400,
     });
 
     let currentIndex = 0;


### PR DESCRIPTION
It was for memory issues, but it has been fixed in Shiki. So I think it's safe to increase it.