### PR TITLE
Fix localised search string from wrapping search box

### DIFF
--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -123,7 +123,7 @@ export function Header(props: {
                         <div
                             className={tcls(
                                 'flex',
-                                'md:w-56',
+                                'md:min-w-56',
                                 'grow-0',
                                 'shrink-0',
                                 'justify-self-end',


### PR DESCRIPTION
# Before
<img width="482" alt="Screenshot 2024-12-13 at 16 35 31" src="https://github.com/user-attachments/assets/48e58924-3855-4dc1-b642-dac076a6ab36" />

# After
<img width="514" alt="Screenshot 2024-12-13 at 16 35 45" src="https://github.com/user-attachments/assets/77f86da6-24dc-4dc4-bdbb-e7351735f6e0" />