### PR TITLE
Fix header logo margin

### DIFF
--- a/packages/gitbook/src/components/Header/HeaderLogo.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLogo.tsx
@@ -53,7 +53,7 @@ export function HeaderLogo(props: HeaderLogoProps) {
                             width: 128,
                         },
                         {
-                            width: 192,
+                            width: 260,
                         },
                     ]}
                     priority="high"
@@ -61,13 +61,14 @@ export function HeaderLogo(props: HeaderLogoProps) {
                         'rounded',
                         'straight-corners:rounded-sm',
                         'overflow-hidden',
-                        'object-contain',
-                        'object-left',
-                        'min-w-20',
+                        'shrink',
+                        'min-w-0',
                         'max-w-40',
                         'lg:max-w-64',
                         'max-h-10',
                         'lg:max-h-12',
+                        'h-full',
+                        'w-auto',
                     )}
                 />
             ) : (


### PR DESCRIPTION
# Before

<img width="631" alt="Screenshot 2024-12-16 at 12 13 29" src="https://github.com/user-attachments/assets/04b40fb6-ade3-47f4-8c6c-0a8511e206a7" />

# After

<img width="673" alt="Screenshot 2024-12-16 at 12 13 32" src="https://github.com/user-attachments/assets/cc63907b-da04-419c-b7d4-7e9285a784be" />
