### PR TITLE
Fix closing search modal on Escape key press

### DIFF
--- a/packages/gitbook/src/components/Search/SearchModal.tsx
+++ b/packages/gitbook/src/components/Search/SearchModal.tsx
@@ -55,10 +55,6 @@ export function SearchModal(props: SearchModalProps) {
         };
     }, [isSearchOpened]);
 
-    // if (state === null) {
-    //     return null;
-    // }
-
     const onChangeQuery = (newQuery: SearchState) => {
         setSearchState(newQuery);
     };
@@ -170,10 +166,21 @@ function SearchModalBody(
         inputRef.current?.focus();
     }, []);
 
+    React.useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+  }, [onClose]);
+
     const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.key === 'Escape') {
-            onClose();
-        } else if (event.key === 'ArrowUp') {
+        if (event.key === 'ArrowUp') {
             event.preventDefault();
             resultsRef.current?.moveUp();
         } else if (event.key === 'ArrowDown') {

--- a/packages/gitbook/src/components/Search/SearchModal.tsx
+++ b/packages/gitbook/src/components/Search/SearchModal.tsx
@@ -177,7 +177,7 @@ function SearchModalBody(
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
         };
-  }, [onClose]);
+    }, [onClose]);
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
         if (event.key === 'ArrowUp') {


### PR DESCRIPTION
The current escape key press handler is only applied on the search text input. If the focus leaves the input (when user presses arrow or tab keys to navigate in the search results), then pressing the `Escape` key is handled anymore.

This PR moves the closing logic from the `input` to the `body`.