### PR TITLE
Image optimization endpoint redirects to underlying image URL if the signature is not the latest.

### DIFF
--- a/.changeset/tender-bags-guess.md
+++ b/.changeset/tender-bags-guess.md
@@ -1,0 +1,5 @@
+---
+'gitbook': minor
+---
+
+Image optimization endpoint redirects to underlying image URL if the signature is not the latest.

--- a/packages/gitbook/src/app/(global)/~gitbook/image/route.ts
+++ b/packages/gitbook/src/app/(global)/~gitbook/image/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest } from 'next/server';
 
-import { CURRENT_SIGNATURE_VERSION, isSignatureVersion, SignatureVersion, verifyImageSignature } from '@/lib/image-signatures';
+import {
+    CURRENT_SIGNATURE_VERSION,
+    isSignatureVersion,
+    SignatureVersion,
+    verifyImageSignature,
+} from '@/lib/image-signatures';
 import { resizeImage, CloudflareImageOptions, checkIsSizableImageURL } from '@/lib/images';
 import { parseImageAPIURL } from '@/lib/urls';
 

--- a/packages/gitbook/src/app/(global)/~gitbook/image/route.ts
+++ b/packages/gitbook/src/app/(global)/~gitbook/image/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 
-import { isSignatureVersion, SignatureVersion, verifyImageSignature } from '@/lib/image-signatures';
+import { CURRENT_SIGNATURE_VERSION, isSignatureVersion, SignatureVersion, verifyImageSignature } from '@/lib/image-signatures';
 import { resizeImage, CloudflareImageOptions, checkIsSizableImageURL } from '@/lib/images';
 import { parseImageAPIURL } from '@/lib/urls';
 
@@ -37,6 +37,10 @@ export async function GET(request: NextRequest) {
     const verified = await verifyImageSignature(url, { signature, version: signatureVersion });
     if (!verified) {
         return new Response(`Invalid signature "${signature ?? ''}" for "${url}"`, { status: 400 });
+    }
+
+    if (signatureVersion !== CURRENT_SIGNATURE_VERSION) {
+        return Response.redirect(url, 302);
     }
 
     // Cloudflare-specific options are in the cf object.

--- a/packages/gitbook/src/lib/image-signatures.ts
+++ b/packages/gitbook/src/lib/image-signatures.ts
@@ -12,6 +12,11 @@ import { host } from './links';
 export type SignatureVersion = '0' | '1' | '2';
 
 /**
+ * The current version of the signature.
+ */
+export const CURRENT_SIGNATURE_VERSION: SignatureVersion = '2';
+
+/**
  * A mapping of signature versions to signature functions.
  */
 const IMAGE_SIGNATURE_FUNCTIONS: Record<SignatureVersion, (input: string) => MaybePromise<string>> =
@@ -48,7 +53,7 @@ export function generateImageSignature(input: string): {
     version: SignatureVersion;
 } {
     const result = generateSignatureV2(input);
-    return { signature: result, version: '2' };
+    return { signature: result, version: CURRENT_SIGNATURE_VERSION };
 }
 
 // Reused buffer for FNV-1a hashing in the v2 algorithm


### PR DESCRIPTION
Rather than serve images that are using older signatures, we redirect to them. It exposes the real underlying domain of the image rather than showing the GitBook domain.