### PR TITLE
Ignore errors from event flushing

### DIFF
--- a/.changeset/fair-frogs-fetch.md
+++ b/.changeset/fair-frogs-fetch.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Ignore errors from event flushing

--- a/packages/gitbook/src/components/Insights/InsightsProvider.tsx
+++ b/packages/gitbook/src/components/Insights/InsightsProvider.tsx
@@ -241,6 +241,9 @@ function sendEvents(args: {
         body: JSON.stringify({
             events,
         }),
+    }).catch((error) => {
+        // We don't want to throw when this fails.
+        console.error('Error sending events', error);
     });
 }
 


### PR DESCRIPTION
A fetch error does not mean a wrong status code it means the fetch cannot be done because of CORS or connection. So we ignore it.

Fix GITBOOK-OPEN-1W8D
Fix GITBOOK-OPEN-1W95
Fix GITBOOK-OPEN-1W8R
Fix GITBOOK-OPEN-1W8E
Fix GITBOOK-OPEN-1W9N
