### PR TITLE
Bump `heading-3` font size to offset it from paragraphs

### DIFF
--- a/.changeset/wild-lemons-camp.md
+++ b/.changeset/wild-lemons-camp.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Bump `heading-3` font size to offset it from paragraphs

--- a/packages/gitbook/src/components/DocumentView/spacing.ts
+++ b/packages/gitbook/src/components/DocumentView/spacing.ts
@@ -37,7 +37,7 @@ export function getBlockTextStyle(block: DocumentBlock): {
             };
         case 'heading-3':
             return {
-                textSize: 'text-base font-semibold',
+                textSize: 'text-xl font-semibold',
                 lineHeight: 'leading-snug',
                 marginTop: 'mt-[0.5em]',
             };


### PR DESCRIPTION
This one-line change sets the `heading-3` font size to `1.25rem` (or Tailwind `text-xl`), to differentiate these headings from paragraphs.

# Before & After
<img width="375" alt="Screenshot 2025-01-09 at 12 53 49" src="https://github.com/user-attachments/assets/9355fdc9-d9d7-4af0-a57b-305e12db03bd" />
<img width="375" alt="Screenshot 2025-01-09 at 12 53 43" src="https://github.com/user-attachments/assets/6b393695-4044-43f1-b7e0-612cfca3fa7c" />