### PR TITLE
Cleanup headers usage

### DIFF
--- a/.changeset/friendly-trains-exercise.md
+++ b/.changeset/friendly-trains-exercise.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix multiple bugs due to headers read in an anarchic way in the app.

--- a/packages/gitbook/src/app/(global)/~gitbook/image/route.ts
+++ b/packages/gitbook/src/app/(global)/~gitbook/image/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import {
     CURRENT_SIGNATURE_VERSION,
     isSignatureVersion,
@@ -39,7 +40,8 @@ export async function GET(request: NextRequest) {
     }
 
     // Verify the signature
-    const verified = await verifyImageSignature(url, { signature, version: signatureVersion });
+    const ctx = getGitBookContextFromHeaders(request.headers);
+    const verified = await verifyImageSignature(ctx, url, { signature, version: signatureVersion });
     if (!verified) {
         return new Response(`Invalid signature "${signature ?? ''}" for "${url}"`, { status: 400 });
     }

--- a/packages/gitbook/src/app/(site)/(content)/[[...pathname]]/not-found.tsx
+++ b/packages/gitbook/src/app/(site)/(content)/[[...pathname]]/not-found.tsx
@@ -1,14 +1,18 @@
+import { headers } from 'next/headers';
+
 import { TrackPageViewEvent } from '@/components/Insights';
 import { getSpaceLanguage, t } from '@/intl/server';
 import { getSiteData, getSpaceContentData } from '@/lib/api';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getSiteContentPointer } from '@/lib/pointer';
 import { tcls } from '@/lib/tailwind';
 
 export default async function NotFound() {
-    const pointer = await getSiteContentPointer();
+    const ctx = getGitBookContextFromHeaders(await headers());
+    const pointer = getSiteContentPointer(ctx);
     const [{ space }, { customization }] = await Promise.all([
-        getSpaceContentData(pointer, pointer.siteShareKey),
-        getSiteData(pointer),
+        getSpaceContentData(ctx, pointer, pointer.siteShareKey),
+        getSiteData(ctx, pointer),
     ]);
 
     const language = getSpaceLanguage(customization);

--- a/packages/gitbook/src/app/(site)/(core)/~gitbook/icon/route.tsx
+++ b/packages/gitbook/src/app/(site)/(core)/~gitbook/icon/route.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import { getSite, getSiteData, getSpace } from '@/lib/api';
 import { getEmojiForCode } from '@/lib/emojis';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getSiteContentPointer } from '@/lib/pointer';
 import { tcls } from '@/lib/tailwind';
 import { getContentTitle } from '@/lib/utils';
@@ -32,17 +33,18 @@ const SIZES = {
  * Render an icon for the space.
  */
 export async function GET(req: NextRequest) {
+    const ctx = getGitBookContextFromHeaders(req.headers);
     const options = getOptions(req.url);
     const size = SIZES[options.size];
 
-    const pointer = await getSiteContentPointer();
+    const pointer = getSiteContentPointer(ctx);
     const spaceId = pointer.spaceId;
 
     const [space, { customization }] = await Promise.all([
-        getSpace(spaceId, pointer.siteShareKey),
-        getSiteData(pointer),
+        getSpace(ctx, spaceId, pointer.siteShareKey),
+        getSiteData(ctx, pointer),
     ]);
-    const site = await getSite(pointer.organizationId, pointer.siteId);
+    const site = await getSite(ctx, pointer.organizationId, pointer.siteId);
     const contentTitle = getContentTitle(space, customization, site);
 
     return new ImageResponse(

--- a/packages/gitbook/src/app/(site)/layout.tsx
+++ b/packages/gitbook/src/app/(site)/layout.tsx
@@ -1,5 +1,8 @@
+import { headers } from 'next/headers';
+
 import { CustomizationRootLayout } from '@/components/RootLayout';
 import { getSiteData } from '@/lib/api';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getSiteContentPointer } from '@/lib/pointer';
 
 /**
@@ -8,9 +11,10 @@ import { getSiteContentPointer } from '@/lib/pointer';
  */
 export default async function SiteRootLayout(props: { children: React.ReactNode }) {
     const { children } = props;
+    const ctx = getGitBookContextFromHeaders(await headers());
 
-    const pointer = await getSiteContentPointer();
-    const { customization } = await getSiteData(pointer);
+    const pointer = getSiteContentPointer(ctx);
+    const { customization } = await getSiteData(ctx, pointer);
 
     return (
         <CustomizationRootLayout customization={customization}>{children}</CustomizationRootLayout>

--- a/packages/gitbook/src/app/(space)/~gitbook/pdf/pointer.ts
+++ b/packages/gitbook/src/app/(space)/~gitbook/pdf/pointer.ts
@@ -1,4 +1,5 @@
 import { SiteContentPointer, SpaceContentPointer } from '@/lib/api';
+import { GitBookContext } from '@/lib/gitbook-context';
 import { getSiteContentPointer, getSpacePointer } from '@/lib/pointer';
 
 /**
@@ -8,12 +9,12 @@ import { getSiteContentPointer, getSpacePointer } from '@/lib/pointer';
  *
  * This function returns the pointer depending on the context.
  */
-export async function getSiteOrSpacePointerForPDF(): Promise<
-    SiteContentPointer | SpaceContentPointer
-> {
+export function getSiteOrSpacePointerForPDF(
+    ctx: GitBookContext,
+): SiteContentPointer | SpaceContentPointer {
     try {
-        return await getSiteContentPointer();
+        return getSiteContentPointer(ctx);
     } catch (error) {
-        return getSpacePointer();
+        return getSpacePointer(ctx);
     }
 }

--- a/packages/gitbook/src/components/AdminToolbar/AdminToolbar.tsx
+++ b/packages/gitbook/src/components/AdminToolbar/AdminToolbar.tsx
@@ -1,8 +1,10 @@
 import { Space } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
+import { headers } from 'next/headers';
 import React from 'react';
 
 import { getChangeRequest, getRevision, SiteContentPointer } from '@/lib/api';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { tcls } from '@/lib/tailwind';
 
 import { RefreshChangeRequestButton } from './RefreshChangeRequestButton';
@@ -68,8 +70,9 @@ export function AdminToolbar(props: AdminToolbarProps) {
 
 async function ChangeRequestToolbar(props: { spaceId: string; changeRequestId: string }) {
     const { spaceId, changeRequestId } = props;
+    const ctx = getGitBookContextFromHeaders(await headers());
 
-    const changeRequest = await getChangeRequest(spaceId, changeRequestId);
+    const changeRequest = await getChangeRequest(ctx, spaceId, changeRequestId);
 
     return (
         <Toolbar>
@@ -89,6 +92,7 @@ async function ChangeRequestToolbar(props: { spaceId: string; changeRequestId: s
                     <Icon icon="arrow-up-right-from-square" className="size-4" />
                 </ToolbarButton>
                 <RefreshChangeRequestButton
+                    ctx={ctx}
                     spaceId={spaceId}
                     changeRequestId={changeRequestId}
                     revisionId={changeRequest.revision}
@@ -101,8 +105,9 @@ async function ChangeRequestToolbar(props: { spaceId: string; changeRequestId: s
 
 async function RevisionToolbar(props: { spaceId: string; revisionId: string }) {
     const { spaceId, revisionId } = props;
+    const ctx = getGitBookContextFromHeaders(await headers());
 
-    const revision = await getRevision(spaceId, revisionId, {
+    const revision = await getRevision(ctx, spaceId, revisionId, {
         metadata: true,
     });
 

--- a/packages/gitbook/src/components/AdminToolbar/RefreshChangeRequestButton.tsx
+++ b/packages/gitbook/src/components/AdminToolbar/RefreshChangeRequestButton.tsx
@@ -1,8 +1,10 @@
 'use client';
+
 import { Icon } from '@gitbook/icons';
 import React from 'react';
 
 import { useCheckForContentUpdate } from '@/components/AutoRefreshContent';
+import { GitBookContext } from '@/lib/gitbook-context';
 import { tcls } from '@/lib/tailwind';
 
 import { ToolbarButton } from './Toolbar';
@@ -14,6 +16,7 @@ const minInterval = 1000 * 30; // 5 minutes
  * Button to refresh the page if the content has been updated.
  */
 export function RefreshChangeRequestButton(props: {
+    ctx: GitBookContext;
     spaceId: string;
     changeRequestId: string;
     revisionId: string;

--- a/packages/gitbook/src/components/Ads/Ad.tsx
+++ b/packages/gitbook/src/components/Ads/Ad.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { SiteAds, SiteAdsStatus } from '@gitbook/api';
+import { headers } from 'next/headers';
 import * as React from 'react';
 
 import { t, useLanguage } from '@/intl/client';
+import { getIpAndUserAgentFromHeaders, IpAndUserAgent } from '@/lib/gitbook-context';
 import { ClassValue, tcls } from '@/lib/tailwind';
 
 import { renderAd } from './renderAd';
@@ -18,6 +20,7 @@ const PREVIEW_ZONE_ID = 'CVAIKKQM';
  * https://docs.buysellads.com/ad-serving-api
  */
 export function Ad({
+    ipAndUserAgent,
     zoneId,
     spaceId,
     placement,
@@ -26,6 +29,7 @@ export function Ad({
     style,
     mode = 'auto',
 }: {
+    ipAndUserAgent: IpAndUserAgent;
     zoneId: string | null;
     spaceId: string;
     placement: string;
@@ -92,7 +96,7 @@ export function Ad({
 
         (async () => {
             const result = showPlaceholderAd
-                ? await renderAd({ source: 'placeholder' })
+                ? await renderAd({ source: 'placeholder', ipAndUserAgent })
                 : realZoneId
                   ? await renderAd({
                         placement,
@@ -100,6 +104,7 @@ export function Ad({
                         zoneId: realZoneId,
                         mode,
                         source: 'live',
+                        ipAndUserAgent,
                     })
                   : undefined;
 
@@ -115,7 +120,7 @@ export function Ad({
         return () => {
             cancelled = true;
         };
-    }, [visible, zoneId, ignore, placement, mode, siteAdsStatus]);
+    }, [visible, zoneId, ignore, placement, mode, siteAdsStatus, ipAndUserAgent]);
 
     return (
         <div ref={containerRef} className={tcls(style)} data-visual-test="removed">

--- a/packages/gitbook/src/components/Ads/AdClassicRendering.tsx
+++ b/packages/gitbook/src/components/Ads/AdClassicRendering.tsx
@@ -1,5 +1,7 @@
+import { headers } from 'next/headers';
 import * as React from 'react';
 
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getResizedImageURL } from '@/lib/images';
 import { tcls } from '@/lib/tailwind';
 
@@ -9,10 +11,11 @@ import { AdItem } from './types';
  * Classic rendering for an ad.
  */
 export async function AdClassicRendering({ ad }: { ad: AdItem }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const smallImgSrc =
-        'smallImage' in ad ? await getResizedImageURL(ad.smallImage, { width: 192, dpr: 2 }) : null;
+        'smallImage' in ad ? getResizedImageURL(ctx, ad.smallImage, { width: 192, dpr: 2 }) : null;
     const logoSrc =
-        'logo' in ad ? await getResizedImageURL(ad.logo, { width: 192 - 48, dpr: 2 }) : null;
+        'logo' in ad ? getResizedImageURL(ctx, ad.logo, { width: 192 - 48, dpr: 2 }) : null;
     return (
         <a
             className={tcls(

--- a/packages/gitbook/src/components/Ads/AdCoverRendering.tsx
+++ b/packages/gitbook/src/components/Ads/AdCoverRendering.tsx
@@ -1,6 +1,8 @@
+import { headers } from 'next/headers';
 import * as React from 'react';
 
 import { hexToRgba } from '@/lib/colors';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getResizedImageURL } from '@/lib/images';
 import { tcls } from '@/lib/tailwind';
 
@@ -10,7 +12,8 @@ import { AdCover } from './types';
  * Cover rendering for an ad.
  */
 export async function AdCoverRendering({ ad }: { ad: AdCover }) {
-    const largeImage = await getResizedImageURL(ad.largeImage, { width: 128, dpr: 2 });
+    const ctx = getGitBookContextFromHeaders(await headers());
+    const largeImage = await getResizedImageURL(ctx, ad.largeImage, { width: 128, dpr: 2 });
 
     return (
         <a

--- a/packages/gitbook/src/components/AutoRefreshContent/server-actions.ts
+++ b/packages/gitbook/src/components/AutoRefreshContent/server-actions.ts
@@ -1,15 +1,23 @@
 'use server';
 
 import { getChangeRequest } from '@/lib/api';
+import { GitBookContext } from '@/lib/gitbook-context';
 
 /**
  * Return true if a change-request has been updated.
  */
-export async function hasContentBeenUpdated(props: {
-    spaceId: string;
-    changeRequestId: string;
-    revisionId: string;
-}) {
-    const changeRequest = await getChangeRequest.revalidate(props.spaceId, props.changeRequestId);
+export async function hasContentBeenUpdated(
+    ctx: GitBookContext,
+    props: {
+        spaceId: string;
+        changeRequestId: string;
+        revisionId: string;
+    },
+) {
+    const changeRequest = await getChangeRequest.revalidate(
+        ctx,
+        props.spaceId,
+        props.changeRequestId,
+    );
     return changeRequest.revision !== props.revisionId;
 }

--- a/packages/gitbook/src/components/AutoRefreshContent/useCheckForContentUpdate.ts
+++ b/packages/gitbook/src/components/AutoRefreshContent/useCheckForContentUpdate.ts
@@ -1,6 +1,9 @@
 'use client';
 
 import React from 'react';
+import { useEventCallback } from 'usehooks-ts';
+
+import { GitBookContext } from '@/lib/gitbook-context';
 
 import { hasContentBeenUpdated } from './server-actions';
 
@@ -8,17 +11,23 @@ import { hasContentBeenUpdated } from './server-actions';
  * Return a callback to check if a change request has been updated and to refresh the page if it has.
  */
 export function useCheckForContentUpdate(props: {
+    ctx: GitBookContext;
     spaceId: string;
     changeRequestId: string;
     revisionId: string;
 }) {
-    const { spaceId, changeRequestId, revisionId } = props;
+    const { ctx, spaceId, changeRequestId, revisionId } = props;
+    const getCtx = useEventCallback(() => ctx);
 
     return React.useCallback(async () => {
-        const updated = await hasContentBeenUpdated({ spaceId, changeRequestId, revisionId });
+        const updated = await hasContentBeenUpdated(getCtx(), {
+            spaceId,
+            changeRequestId,
+            revisionId,
+        });
 
         if (updated) {
             window.location.reload();
         }
-    }, [spaceId, changeRequestId, revisionId]);
+    }, [spaceId, changeRequestId, revisionId, getCtx]);
 }

--- a/packages/gitbook/src/components/DocumentView/BlockContentRef.tsx
+++ b/packages/gitbook/src/components/DocumentView/BlockContentRef.tsx
@@ -1,7 +1,9 @@
 import { DocumentBlockContentRef } from '@gitbook/api';
+import { headers } from 'next/headers';
 
 import { Card } from '@/components/primitives';
 import { getSpaceCustomization, ignoreAPIError } from '@/lib/api';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { ResolvedContentRef } from '@/lib/references';
 
 import { BlockProps } from './Block';
@@ -52,7 +54,9 @@ async function SpaceRefCard(
         return null;
     }
 
-    const { customization: spaceCustomization } = await getSpaceCustomization();
+    const ctx = getGitBookContextFromHeaders(await headers());
+
+    const { customization: spaceCustomization } = await getSpaceCustomization(ctx);
     const customFavicon = spaceCustomization?.favicon;
     const customEmoji = customFavicon && 'emoji' in customFavicon ? customFavicon.emoji : undefined;
     const customIcon = customFavicon && 'icon' in customFavicon ? customFavicon.icon : undefined;

--- a/packages/gitbook/src/components/DocumentView/Embed.tsx
+++ b/packages/gitbook/src/components/DocumentView/Embed.tsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 
 import { Card } from '@/components/primitives';
 import { getEmbedByUrlInSpace, getEmbedByUrl } from '@/lib/api';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { tcls } from '@/lib/tailwind';
 
 import { BlockProps } from './Block';
@@ -12,15 +13,15 @@ import { Caption } from './Caption';
 import { IntegrationBlock } from './Integration';
 
 export async function Embed(props: BlockProps<gitbookAPI.DocumentBlockEmbed>) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { block, context, ...otherProps } = props;
-    const headersList = await headers();
-    const nonce = headersList.get('x-nonce') || undefined;
+    const nonce = ctx.nonce || undefined;
 
     ReactDOM.preload('https://cdn.iframe.ly/embed.js', { as: 'script', nonce });
 
     const embed = await (context.content
-        ? getEmbedByUrlInSpace(context.content.spaceId, block.data.url)
-        : getEmbedByUrl(block.data.url));
+        ? getEmbedByUrlInSpace(ctx, context.content.spaceId, block.data.url)
+        : getEmbedByUrl(ctx, block.data.url));
 
     return (
         <Caption {...props}>

--- a/packages/gitbook/src/components/DocumentView/Integration/IntegrationBlock.tsx
+++ b/packages/gitbook/src/components/DocumentView/Integration/IntegrationBlock.tsx
@@ -1,9 +1,11 @@
 import { ContentKitContext, DocumentBlockIntegration } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
 import { ContentKit, ContentKitOutput, ContentKitServerContext } from '@gitbook/react-contentkit';
+import { headers } from 'next/headers';
 
 import { ignoreAPIError, renderIntegrationUi } from '@/lib/api';
 import { INTEGRATIONS_HOST } from '@/lib/csp';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { parseMarkdown } from '@/lib/markdown';
 import { tcls } from '@/lib/tailwind';
 
@@ -45,6 +47,8 @@ export async function IntegrationBlock(props: BlockProps<DocumentBlockIntegratio
         throw new Error('integration block requires a content.spaceId');
     }
 
+    const ctx = getGitBookContextFromHeaders(await headers());
+
     const contentKitContext: ContentKitContext = {
         type: 'document',
         spaceId: context.content.spaceId,
@@ -60,9 +64,10 @@ export async function IntegrationBlock(props: BlockProps<DocumentBlockIntegratio
     };
 
     const initialOutput = await ignoreAPIError(
-        renderIntegrationUi(block.data.integration, initialInput),
+        renderIntegrationUi(ctx, block.data.integration, initialInput),
         true,
     );
+
     if (!initialOutput || initialOutput.type === 'complete') {
         return null;
     }
@@ -76,7 +81,7 @@ export async function IntegrationBlock(props: BlockProps<DocumentBlockIntegratio
                 render={async (request) => {
                     'use server';
 
-                    const output = await renderIntegrationUi(block.data.integration, request);
+                    const output = await renderIntegrationUi(ctx, block.data.integration, request);
 
                     return {
                         children: <ContentKitOutput output={output} context={outputContext} />,

--- a/packages/gitbook/src/components/DocumentView/ReusableContent.tsx
+++ b/packages/gitbook/src/components/DocumentView/ReusableContent.tsx
@@ -1,11 +1,14 @@
 import { DocumentBlockReusableContent } from '@gitbook/api';
+import { headers } from 'next/headers';
 
 import { getDocument } from '@/lib/api';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 
 import { BlockProps } from './Block';
 import { UnwrappedBlocks } from './Blocks';
 
 export async function ReusableContent(props: BlockProps<DocumentBlockReusableContent>) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { block, context, ancestorBlocks } = props;
 
     if (!context.content) {
@@ -17,7 +20,11 @@ export async function ReusableContent(props: BlockProps<DocumentBlockReusableCon
         return null;
     }
 
-    const document = await getDocument(context.content.spaceId, resolved.reusableContent.document);
+    const document = await getDocument(
+        ctx,
+        context.content.spaceId,
+        resolved.reusableContent.document,
+    );
 
     if (!document) {
         return null;

--- a/packages/gitbook/src/components/Footer/FooterLinksGroup.tsx
+++ b/packages/gitbook/src/components/Footer/FooterLinksGroup.tsx
@@ -1,5 +1,7 @@
 import { CustomizationContentLink, CustomizationFooterGroup } from '@gitbook/api';
+import { headers } from 'next/headers';
 
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
@@ -22,8 +24,9 @@ export function FooterLinksGroup(props: {
 }
 
 async function FooterLink(props: { link: CustomizationContentLink; context: ContentRefContext }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { link, context } = props;
-    const resolved = await resolveContentRef(link.to, context);
+    const resolved = await resolveContentRef(ctx, link.to, context);
 
     if (!resolved) {
         return null;

--- a/packages/gitbook/src/components/Header/HeaderLink.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLink.tsx
@@ -7,7 +7,9 @@ import {
     ContentRef,
 } from '@gitbook/api';
 import assertNever from 'assert-never';
+import { headers } from 'next/headers';
 
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
@@ -25,9 +27,10 @@ export async function HeaderLink(props: {
     link: CustomizationHeaderItem;
     customization: CustomizationSettings | SiteCustomizationSettings;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { context, link, customization } = props;
 
-    const target = link.to ? await resolveContentRef(link.to, context) : null;
+    const target = link.to ? await resolveContentRef(ctx, link.to, context) : null;
     const headerPreset = customization.header.preset;
     const linkStyle = link.style ?? 'link';
 
@@ -207,9 +210,10 @@ async function SubHeaderLink(props: {
     context: ContentRefContext;
     link: CustomizationContentLink;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { context, link } = props;
 
-    const target = await resolveContentRef(link.to, context);
+    const target = await resolveContentRef(ctx, link.to, context);
 
     if (!target) {
         return null;

--- a/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinkMore.tsx
@@ -6,8 +6,10 @@ import {
     SiteCustomizationSettings,
 } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
+import { headers } from 'next/headers';
 import React from 'react';
 
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
@@ -67,9 +69,10 @@ async function MoreMenuLink(props: {
     context: ContentRefContext;
     link: CustomizationHeaderItem | CustomizationContentLink;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { context, link } = props;
 
-    const target = link.to ? await resolveContentRef(link.to, context) : null;
+    const target = link.to ? await resolveContentRef(ctx, link.to, context) : null;
 
     return (
         <>

--- a/packages/gitbook/src/components/Header/HeaderLogo.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLogo.tsx
@@ -5,8 +5,10 @@ import {
     SiteCustomizationSettings,
     Space,
 } from '@gitbook/api';
+import { headers } from 'next/headers';
 
 import { Image } from '@/components/utils';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getAbsoluteHref } from '@/lib/links';
 import { tcls } from '@/lib/tailwind';
 import { getContentTitle } from '@/lib/utils';
@@ -25,8 +27,9 @@ interface HeaderLogoProps {
  */
 
 export async function HeaderLogo(props: HeaderLogoProps) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { customization } = props;
-    const href = await getAbsoluteHref('');
+    const href = getAbsoluteHref(ctx, '');
 
     return (
         <Link

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -5,12 +5,14 @@ import {
     SiteCustomizationSettings,
     Space,
 } from '@gitbook/api';
+import { headers } from 'next/headers';
 import React from 'react';
 
 import { getSpaceLanguage } from '@/intl/server';
 import { t } from '@/intl/translate';
-import { ContentTarget, SiteContentPointer, api } from '@/lib/api';
+import { ContentTarget, SiteContentPointer } from '@/lib/api';
 import { hasFullWidthBlock, isNodeEmpty } from '@/lib/document';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { AncestorRevisionPage } from '@/lib/pages';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
@@ -25,7 +27,7 @@ import { TrackPageViewEvent } from '../Insights';
 import { PageFeedbackForm } from '../PageFeedback';
 import { DateRelative } from '../primitives';
 
-export function PageBody(props: {
+export async function PageBody(props: {
     space: Space;
     pointer: SiteContentPointer;
     contentTarget: ContentTarget;
@@ -36,6 +38,7 @@ export function PageBody(props: {
     context: ContentRefContext;
     withPageFeedback: boolean;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const {
         space,
         contentTarget,
@@ -99,7 +102,7 @@ export function PageBody(props: {
                                 content: contentTarget,
                                 contentRefContext: context,
                                 resolveContentRef: (ref, options) =>
-                                    resolveContentRef(ref, context, options),
+                                    resolveContentRef(ctx, ref, context, options),
                             }}
                         />
                     </React.Suspense>
@@ -140,7 +143,7 @@ export function PageBody(props: {
                         </p>
                     ) : null}
                     {withPageFeedback ? (
-                        <PageFeedbackForm orientation="horizontal" pageId={page.id} />
+                        <PageFeedbackForm ctx={ctx} orientation="horizontal" pageId={page.id} />
                     ) : null}
                 </div>
             </main>

--- a/packages/gitbook/src/components/PageBody/PageBodyBlankslate.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBodyBlankslate.tsx
@@ -1,6 +1,8 @@
 import { RevisionPage, RevisionPageDocument, RevisionPageType } from '@gitbook/api';
+import { headers } from 'next/headers';
 
 import { Card } from '@/components/primitives';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getPageHref } from '@/lib/links';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
@@ -15,6 +17,7 @@ export async function PageBodyBlankslate(props: {
     rootPages: RevisionPage[];
     context: ContentRefContext;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { page, rootPages, context } = props;
 
     const pages = page.pages.filter((child) =>
@@ -35,7 +38,7 @@ export async function PageBodyBlankslate(props: {
                     'Unexpected computed page, it should have been computed in the API',
                 );
             } else if (child.type === RevisionPageType.Link) {
-                const resolved = await resolveContentRef(child.target, context);
+                const resolved = await resolveContentRef(ctx, child.target, context);
                 if (!resolved) {
                     return null;
                 }
@@ -53,7 +56,7 @@ export async function PageBodyBlankslate(props: {
                     />
                 );
             } else {
-                const href = await getPageHref(rootPages, child);
+                const href = getPageHref(ctx, rootPages, child);
                 return <Card key={child.id} title={child.title} leadingIcon={icon} href={href} />;
             }
         }),

--- a/packages/gitbook/src/components/PageBody/PageCover.tsx
+++ b/packages/gitbook/src/components/PageBody/PageCover.tsx
@@ -1,6 +1,8 @@
 import { RevisionPageDocument, RevisionPageDocumentCover } from '@gitbook/api';
+import { headers } from 'next/headers';
 
 import { Image, ImageSize } from '@/components/utils';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
@@ -17,8 +19,9 @@ export async function PageCover(props: {
     cover: RevisionPageDocumentCover;
     context: ContentRefContext;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { as, page, cover, context } = props;
-    const resolved = cover.ref ? await resolveContentRef(cover.ref, context) : null;
+    const resolved = cover.ref ? await resolveContentRef(ctx, cover.ref, context) : null;
 
     return (
         <div

--- a/packages/gitbook/src/components/PageBody/PageFooterNavigation.tsx
+++ b/packages/gitbook/src/components/PageBody/PageFooterNavigation.tsx
@@ -6,9 +6,11 @@ import {
     Space,
 } from '@gitbook/api';
 import { Icon, IconName } from '@gitbook/icons';
+import { headers } from 'next/headers';
 import React from 'react';
 
 import { t, getSpaceLanguage } from '@/intl/server';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getPageHref } from '@/lib/links';
 import { resolvePrevNextPages } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
@@ -24,11 +26,12 @@ export async function PageFooterNavigation(props: {
     pages: Revision['pages'];
     page: RevisionPageDocument;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { customization, pages, page } = props;
     const { previous, next } = resolvePrevNextPages(pages, page);
     const language = getSpaceLanguage(customization);
-    const previousHref = previous ? await getPageHref(pages, previous) : '';
-    const nextHref = next ? await getPageHref(pages, next) : '';
+    const previousHref = previous ? getPageHref(ctx, pages, previous) : '';
+    const nextHref = next ? getPageHref(ctx, pages, next) : '';
 
     return (
         <div

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -1,7 +1,9 @@
 import { RevisionPage, RevisionPageDocument } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
+import { headers } from 'next/headers';
 import { Fragment } from 'react';
 
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getPageHref } from '@/lib/links';
 import { AncestorRevisionPage } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
@@ -14,6 +16,7 @@ export async function PageHeader(props: {
     ancestors: AncestorRevisionPage[];
     pages: RevisionPage[];
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { page, ancestors, pages } = props;
 
     if (!page.layout.title && !page.layout.description) {
@@ -22,7 +25,7 @@ export async function PageHeader(props: {
 
     const ancestorElements = await Promise.all(
         ancestors.map(async (breadcrumb, index) => {
-            const href = await getPageHref(pages, breadcrumb);
+            const href = await getPageHref(ctx, pages, breadcrumb);
             return (
                 <Fragment key={breadcrumb.id}>
                     <li key={breadcrumb.id}>

--- a/packages/gitbook/src/components/PageFeedback/PageFeedbackForm.tsx
+++ b/packages/gitbook/src/components/PageFeedback/PageFeedbackForm.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { PageFeedbackRating } from '@gitbook/api';
+import { headers } from 'next/headers';
 import React from 'react';
 
 import { useLanguage } from '@/intl/client';
 import { t, tString } from '@/intl/translate';
+import { getGitBookContextFromHeaders, GitBookContext } from '@/lib/gitbook-context';
 import { tcls } from '@/lib/tailwind';
 
 import { getVisitorId, useTrackEvent } from '../Insights';
@@ -14,11 +16,12 @@ import { postPageFeedback } from './server-actions';
  * Form to submit feedback on a page.
  */
 export function PageFeedbackForm(props: {
+    ctx: GitBookContext;
     orientation?: 'horizontal' | 'vertical';
     pageId: string;
     className?: string;
 }) {
-    const { orientation = 'vertical', pageId, className } = props;
+    const { ctx, orientation = 'vertical', pageId, className } = props;
     const languages = useLanguage();
     const trackEvent = useTrackEvent();
     const [submitted, setSubmitted] = React.useState(false);
@@ -26,7 +29,7 @@ export function PageFeedbackForm(props: {
     const onSubmit = async (rating: PageFeedbackRating) => {
         setSubmitted(true);
         const visitorId = await getVisitorId();
-        await postPageFeedback({ pageId, visitorId, rating });
+        await postPageFeedback(ctx, { pageId, visitorId, rating });
 
         trackEvent({
             type: 'page_post_feedback',

--- a/packages/gitbook/src/components/PageFeedback/server-actions.ts
+++ b/packages/gitbook/src/components/PageFeedback/server-actions.ts
@@ -4,23 +4,25 @@ import { PageFeedbackRating } from '@gitbook/api';
 import { assert } from 'ts-essentials';
 
 import { api } from '@/lib/api';
+import { GitBookContext } from '@/lib/gitbook-context';
 import { getSiteContentPointer } from '@/lib/pointer';
 
-export async function postPageFeedback(args: {
-    pageId: string;
-    visitorId: string;
-    rating: PageFeedbackRating;
-}) {
-    const { organizationId, siteId, siteSpaceId } = await getSiteContentPointer();
+export async function postPageFeedback(
+    ctx: GitBookContext,
+    args: {
+        pageId: string;
+        visitorId: string;
+        rating: PageFeedbackRating;
+    },
+) {
+    const { organizationId, siteId, siteSpaceId } = getSiteContentPointer(ctx);
 
     assert(
         siteSpaceId,
         `No siteSpaceId in pointer. organizationId: ${organizationId}, siteId: ${siteId}, pageId: ${args.pageId}`,
     );
 
-    const apiCtx = await api();
-
-    await apiCtx.client.orgs.createSitesPageFeedback(
+    await api(ctx).client.orgs.createSitesPageFeedback(
         organizationId,
         siteId,
         siteSpaceId,

--- a/packages/gitbook/src/components/Search/SearchModal.tsx
+++ b/packages/gitbook/src/components/Search/SearchModal.tsx
@@ -8,6 +8,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 
 import { tString, useLanguage } from '@/intl/client';
 import { SiteContentPointer } from '@/lib/api';
+import { GitBookContext } from '@/lib/gitbook-context';
 import { tcls } from '@/lib/tailwind';
 
 import { SearchAskAnswer } from './SearchAskAnswer';
@@ -18,6 +19,7 @@ import { SearchState, UpdateSearchState, useSearch } from './useSearch';
 import { LoadingPane } from '../primitives/LoadingPane';
 
 interface SearchModalProps {
+    ctx: GitBookContext;
     spaceId: string;
     revisionId: string;
     spaceTitle: string;
@@ -308,6 +310,7 @@ function SearchModalBody(
             {!state.ask || !withAsk ? (
                 <SearchResults
                     ref={resultsRef}
+                    ctx={props.ctx}
                     pointer={pointer}
                     spaceId={spaceId}
                     revisionId={revisionId}
@@ -318,7 +321,7 @@ function SearchModalBody(
                 ></SearchResults>
             ) : null}
             {state.query && state.ask && withAsk ? (
-                <SearchAskAnswer pointer={pointer} query={state.query} />
+                <SearchAskAnswer ctx={props.ctx} pointer={pointer} query={state.query} />
             ) : null}
         </motion.div>
     );

--- a/packages/gitbook/src/components/Space/SpaceIcon.tsx
+++ b/packages/gitbook/src/components/Space/SpaceIcon.tsx
@@ -1,6 +1,8 @@
 import { CustomizationThemedURL } from '@gitbook/api';
+import { headers } from 'next/headers';
 
 import { Image } from '@/components/utils';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getAbsoluteHref } from '@/lib/links';
 
 import { Emoji } from '../primitives';
@@ -14,6 +16,7 @@ export async function SpaceIcon(
         'sources'
     >,
 ) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { icon, emoji, alt, ...imageProps } = props;
 
     if (emoji && !icon) {
@@ -37,14 +40,16 @@ export async function SpaceIcon(
                       }
                     : {
                           light: {
-                              src: await getAbsoluteHref(
+                              src: getAbsoluteHref(
+                                  ctx,
                                   '~gitbook/icon?size=medium&theme=light',
                                   true,
                               ),
                               size: { width: 256, height: 256 },
                           },
                           dark: {
-                              src: await getAbsoluteHref(
+                              src: getAbsoluteHref(
+                                  ctx,
                                   '~gitbook/icon?size=medium&theme=dark',
                                   true,
                               ),

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -9,6 +9,7 @@ import {
     SiteCustomizationSettings,
     Space,
 } from '@gitbook/api';
+import { headers } from 'next/headers';
 import React from 'react';
 
 import { Footer } from '@/components/Footer';
@@ -19,10 +20,10 @@ import { TableOfContents } from '@/components/TableOfContents';
 import { getSpaceLanguage } from '@/intl/server';
 import { t } from '@/intl/translate';
 import { api, ContentTarget, type SectionsList, SiteContentPointer } from '@/lib/api';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { ContentRefContext } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 import { shouldTrackEvents } from '@/lib/tracking';
-import { getCurrentVisitorToken } from '@/lib/visitor-token';
 
 import { SpacesDropdown } from '../Header/SpacesDropdown';
 import { InsightsProvider } from '../Insights';
@@ -42,6 +43,7 @@ export async function SpaceLayout(props: {
     ancestors: Array<RevisionPageDocument | RevisionPageGroup>;
     children: React.ReactNode;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const {
         space,
         contentTarget,
@@ -73,9 +75,9 @@ export async function SpaceLayout(props: {
             'sidebar' in customization.styling &&
             customization.styling.sidebar.background === CustomizationSidebarBackgroundStyle.Filled,
     };
-    const apiHost = (await api()).client.endpoint;
-    const visitorAuthToken = await getCurrentVisitorToken();
-    const enabled = await shouldTrackEvents();
+    const apiHost = api(ctx).client.endpoint;
+    const visitorAuthToken = ctx.visitorToken;
+    const enabled = shouldTrackEvents(ctx);
 
     return (
         <InsightsProvider
@@ -176,6 +178,7 @@ export async function SpaceLayout(props: {
 
             <React.Suspense fallback={null}>
                 <SearchModal
+                    ctx={ctx}
                     spaceId={contentTarget.spaceId}
                     revisionId={contentTarget.revisionId}
                     spaceTitle={customization.title ?? space.title}

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -1,5 +1,7 @@
 import { RevisionPage, RevisionPageDocument, RevisionPageGroup } from '@gitbook/api';
+import { headers } from 'next/headers';
 
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { getPageHref } from '@/lib/links';
 import { getPagePath } from '@/lib/pages';
 import { ContentRefContext } from '@/lib/references';
@@ -15,8 +17,9 @@ export async function PageDocumentItem(props: {
     ancestors: Array<RevisionPageDocument | RevisionPageGroup>;
     context: ContentRefContext;
 }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { rootPages, page, ancestors, context } = props;
-    const href = await getPageHref(rootPages, page);
+    const href = await getPageHref(ctx, rootPages, page);
 
     return (
         <li className={tcls('flex', 'flex-col')}>

--- a/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
@@ -1,16 +1,19 @@
 import { RevisionPageLink } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
+import { headers } from 'next/headers';
 
 import { Link } from '@/components/primitives';
+import { getGitBookContextFromHeaders } from '@/lib/gitbook-context';
 import { ContentRefContext, resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
 import { TOCPageIcon } from './TOCPageIcon';
 
 export async function PageLinkItem(props: { page: RevisionPageLink; context: ContentRefContext }) {
+    const ctx = getGitBookContextFromHeaders(await headers());
     const { page, context } = props;
 
-    const resolved = await resolveContentRef(page.target, context);
+    const resolved = await resolveContentRef(ctx, page.target, context);
 
     return (
         <li className={tcls('flex', 'flex-col')}>

--- a/packages/gitbook/src/components/utils/Image.tsx
+++ b/packages/gitbook/src/components/utils/Image.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable @next/next/no-img-element */
+import { headers } from 'next/headers';
 import ReactDOM from 'react-dom';
 
+import { getGitBookContextFromHeaders, GitBookContext } from '@/lib/gitbook-context';
 import { checkIsHttpURL, getImageSize, getResizedImageURLFactory } from '@/lib/images';
 import { ClassValue, tcls } from '@/lib/tailwind';
 
@@ -191,6 +193,8 @@ async function ImagePictureSized(
         } & ImageCommonProps
     >,
 ) {
+    const ctx = getGitBookContextFromHeaders(await headers());
+
     const {
         source,
         sizes,
@@ -210,7 +214,7 @@ async function ImagePictureSized(
         throw new Error('You must provide at least one size for the image.');
     }
 
-    const attrs = await getImageAttributes({ sizes, source, quality, resize });
+    const attrs = await getImageAttributes(ctx, { sizes, source, quality, resize });
     const canBeFetched = checkIsHttpURL(attrs.src);
     const fetchPriority = canBeFetched ? getFetchPriority(priority) : undefined;
     const loading = priority === 'lazy' ? 'lazy' : undefined;
@@ -243,12 +247,15 @@ async function ImagePictureSized(
  * Get the attributes for an image.
  * src, srcSet, sizes, width, height, etc.
  */
-async function getImageAttributes(params: {
-    sizes: ImageResponsiveSize[];
-    source: ImageSourceSized;
-    quality: number;
-    resize: boolean;
-}): Promise<{
+async function getImageAttributes(
+    ctx: GitBookContext,
+    params: {
+        sizes: ImageResponsiveSize[];
+        source: ImageSourceSized;
+        quality: number;
+        resize: boolean;
+    },
+): Promise<{
     src: string;
     srcSet?: string;
     sizes?: string;
@@ -258,7 +265,7 @@ async function getImageAttributes(params: {
     const { sizes, source, quality, resize } = params;
     let src = source.src;
 
-    const getURL = resize ? await getResizedImageURLFactory(source.src) : null;
+    const getURL = resize ? getResizedImageURLFactory(ctx, source.src) : null;
 
     if (!getURL) {
         return {

--- a/packages/gitbook/src/lib/cache/cache.test.ts
+++ b/packages/gitbook/src/lib/cache/cache.test.ts
@@ -74,7 +74,7 @@ describe('cache', () => {
 describe('cache with suffix key', () => {
     const impl = mock((arg: string) => 'test-' + arg);
     const getKeySuffixImpl: Mock<NonNullable<CacheDefinition<[string], string>['getKeySuffix']>> =
-        mock(async () => hash({ test: 1 }));
+        mock(() => hash({ test: 1 }));
 
     let fn: CacheFunction<[string], string>;
     let testId = 0;
@@ -112,7 +112,7 @@ describe('cache with suffix key', () => {
 
         expect(impl).toHaveBeenCalledTimes(2);
 
-        getKeySuffixImpl.mockImplementation(async () => hash({ test: 2 }));
+        getKeySuffixImpl.mockImplementation(() => hash({ test: 2 }));
         expect(await fn('a')).toEqual('test-a');
 
         expect(impl).toHaveBeenCalledTimes(3);
@@ -120,7 +120,7 @@ describe('cache with suffix key', () => {
 
     it('should preserve behaviour even when the returned key suffix is undefined', async () => {
         // Start with the returned suffix being undefined
-        getKeySuffixImpl.mockImplementation(async () => undefined);
+        getKeySuffixImpl.mockImplementation(() => undefined);
         const result = await fn('a');
         expect(result).toEqual('test-a');
 
@@ -128,19 +128,19 @@ describe('cache with suffix key', () => {
         expect(impl).toHaveBeenCalledTimes(1);
 
         // The returned suffix changes so we should get the value computed by the function
-        getKeySuffixImpl.mockImplementation(async () => hash({ test: 1 }));
+        getKeySuffixImpl.mockImplementation(() => hash({ test: 1 }));
         expect(await fn('a')).toEqual('test-a');
 
         expect(impl).toHaveBeenCalledTimes(2);
 
         // The returned suffix is undefined again so we should get the value from a previous cache entry
-        getKeySuffixImpl.mockImplementation(async () => undefined);
+        getKeySuffixImpl.mockImplementation(() => undefined);
         expect(await fn('a')).toEqual('test-a');
 
         expect(impl).toHaveBeenCalledTimes(2);
 
         // The returned suffix goes back to a previous hash so we should the value from a previous cache entry
-        getKeySuffixImpl.mockImplementation(async () => hash({ test: 1 }));
+        getKeySuffixImpl.mockImplementation(() => hash({ test: 1 }));
         expect(await fn('a')).toEqual('test-a');
 
         expect(impl).toHaveBeenCalledTimes(2);

--- a/packages/gitbook/src/lib/cache/cache.ts
+++ b/packages/gitbook/src/lib/cache/cache.ts
@@ -57,7 +57,7 @@ export interface CacheDefinition<Args extends any[], Result> {
     getKeyArgs?: (args: Args) => any[];
 
     /** Returns a precomputed hash that is used alongside arguments to generate the cache key */
-    getKeySuffix?: () => Promise<string | undefined>;
+    getKeySuffix?: (...args: Args) => string | undefined;
 
     /** Default ttl (in seconds) */
     defaultTtl?: number;
@@ -245,7 +245,7 @@ export function cache<Args extends any[], Result>(
         const [args, { signal }] = extractCacheFunctionOptions<Args>(rawArgs);
 
         const cacheArgs = cacheDef.getKeyArgs ? cacheDef.getKeyArgs(args) : args;
-        const cacheKeySuffix = cacheDef.getKeySuffix ? await cacheDef.getKeySuffix() : undefined;
+        const cacheKeySuffix = cacheDef.getKeySuffix ? cacheDef.getKeySuffix(...args) : undefined;
         const key = getCacheKey(cacheDef.name, cacheArgs, cacheKeySuffix);
 
         return await trace(
@@ -263,7 +263,7 @@ export function cache<Args extends any[], Result>(
     cacheFn.revalidate = async (...rawArgs: Args | [...Args, CacheFunctionOptions]) => {
         const [args, { signal }] = extractCacheFunctionOptions<Args>(rawArgs);
         const cacheArgs = cacheDef.getKeyArgs ? cacheDef.getKeyArgs(args) : args;
-        const cacheKeySuffix = cacheDef.getKeySuffix ? await cacheDef.getKeySuffix() : undefined;
+        const cacheKeySuffix = cacheDef.getKeySuffix ? cacheDef.getKeySuffix(...args) : undefined;
         const key = getCacheKey(cacheDef.name, cacheArgs, cacheKeySuffix);
 
         const result = await revalidate(key, signal, ...args);
@@ -272,7 +272,7 @@ export function cache<Args extends any[], Result>(
 
     cacheFn.hasInMemory = async (...args: Args) => {
         const cacheArgs = cacheDef.getKeyArgs ? cacheDef.getKeyArgs(args) : args;
-        const cacheKeySuffix = cacheDef.getKeySuffix ? await cacheDef.getKeySuffix() : undefined;
+        const cacheKeySuffix = cacheDef.getKeySuffix ? cacheDef.getKeySuffix(...args) : undefined;
         const key = getCacheKey(cacheDef.name, cacheArgs, cacheKeySuffix);
         const tag = cacheDef.tag?.(...args);
 

--- a/packages/gitbook/src/lib/csp.ts
+++ b/packages/gitbook/src/lib/csp.ts
@@ -3,18 +3,17 @@ import { merge } from 'content-security-policy-merger';
 import { headers } from 'next/headers';
 
 import { assetsDomain } from './assets';
+import { GitBookContext } from './gitbook-context';
 import { filterOutNullable } from './typescript';
 /**
  * Get the current nonce for the current request.
  */
-export async function getContentSecurityPolicyNonce(): Promise<string> {
-    const headersList = await headers();
-    const nonce = headersList.get('x-nonce');
-    if (!nonce) {
+export function getContentSecurityPolicyNonce(ctx: GitBookContext): string {
+    if (!ctx.nonce) {
         throw new Error('No nonce found in headers');
     }
 
-    return nonce;
+    return ctx.nonce;
 }
 
 /**

--- a/packages/gitbook/src/lib/gitbook-context.ts
+++ b/packages/gitbook/src/lib/gitbook-context.ts
@@ -1,0 +1,83 @@
+import { headers } from 'next/headers';
+
+import { DEFAULT_API_ENDPOINT } from './api';
+import { formatBasePath } from './links';
+
+export type GitBookContext = {
+    theme: string | null;
+    nonce: string | null;
+    visitorToken: string | null;
+    trackPageViews: boolean;
+    apiEndpoint: string;
+    apiToken: string | null;
+    apiTokenContextId: string | null;
+    customization: string | null;
+    host: string;
+    basePath: string;
+    protocol: string;
+    originBasePath: string;
+
+    // Content pointers
+    spaceId: string | null;
+    siteId: string | null;
+    organizationId: string | null;
+    siteSpaceId: string | null;
+    siteSectionId: string | null;
+    siteShareKey: string | null;
+    contentRevisionId: string | null;
+    changeRequestId: string | null;
+
+    // Indexation
+    searchIndexation: boolean;
+};
+
+/**
+ * Extract the gitbook context from the headers.
+ */
+export function getGitBookContextFromHeaders(headers: Headers): GitBookContext {
+    return {
+        theme: headers.get('x-gitbook-theme'),
+        nonce: headers.get('x-nonce'),
+        visitorToken: headers.get('x-gitbook-visitor-token'),
+        trackPageViews: headers.has('x-gitbook-track-page-views'),
+        apiEndpoint: headers.get('x-gitbook-api') ?? DEFAULT_API_ENDPOINT,
+        apiToken: headers.get('x-gitbook-token'),
+        apiTokenContextId: headers.get('x-gitbook-token-context'),
+        customization: headers.get('x-gitbook-customization'),
+        basePath: formatBasePath(headers.get('x-gitbook-basepath')),
+        host: headers.get('x-gitbook-host') ?? headers.get('host') ?? '',
+        protocol: headers.get('x-forwarded-proto') ?? 'https',
+        originBasePath: headers.get('x-gitbook-origin-basepath') ?? '/',
+        spaceId: headers.get('x-gitbook-content-space'),
+        siteId: headers.get('x-gitbook-content-site'),
+        organizationId: headers.get('x-gitbook-content-organization'),
+        siteSpaceId: headers.get('x-gitbook-content-site-space'),
+        siteSectionId: headers.get('x-gitbook-content-site-section'),
+        siteShareKey: headers.get('x-gitbook-content-site-share-key'),
+        contentRevisionId: headers.get('x-gitbook-content-revision'),
+        changeRequestId: headers.get('x-gitbook-content-changerequest'),
+        searchIndexation: headers.has('x-gitbook-search-indexation'),
+    };
+}
+
+export type IpAndUserAgent = {
+    ip: string;
+    userAgent: string;
+};
+
+/**
+ * Read the IP and User-Agent from the headers.
+ * This function can only be called at the top level of a component or route.
+ */
+export function getIpAndUserAgentFromHeaders(headers: Headers): IpAndUserAgent {
+    const ip =
+        headers.get('x-gitbook-ipv4') ??
+        headers.get('x-gitbook-ip') ??
+        headers.get('cf-pseudo-ipv4') ??
+        headers.get('cf-connecting-ip') ??
+        headers.get('x-forwarded-for') ??
+        '';
+    const userAgent = headers.get('user-agent') ?? '';
+
+    return { ip, userAgent };
+}

--- a/packages/gitbook/src/lib/pointer.ts
+++ b/packages/gitbook/src/lib/pointer.ts
@@ -1,18 +1,11 @@
-import { headers } from 'next/headers';
-
 import { SiteContentPointer, SpaceContentPointer } from './api';
+import { GitBookContext } from './gitbook-context';
 
 /**
  * Get the current site content pointer from the headers
  */
-export async function getSiteContentPointer(): Promise<SiteContentPointer> {
-    const headersList = await headers();
-    const spaceId = headersList.get('x-gitbook-content-space');
-    const siteId = headersList.get('x-gitbook-content-site');
-    const organizationId = headersList.get('x-gitbook-content-organization');
-    const siteSpaceId = headersList.get('x-gitbook-content-site-space');
-    const siteSectionId = headersList.get('x-gitbook-content-site-section');
-    const siteShareKey = headersList.get('x-gitbook-content-site-share-key');
+export function getSiteContentPointer(ctx: GitBookContext): SiteContentPointer {
+    const { siteId, spaceId, organizationId, siteSectionId, siteSpaceId, siteShareKey } = ctx;
 
     if (!spaceId || !siteId || !organizationId) {
         throw new Error(
@@ -27,8 +20,8 @@ export async function getSiteContentPointer(): Promise<SiteContentPointer> {
         siteSpaceId: siteSpaceId ?? undefined,
         siteShareKey: siteShareKey ?? undefined,
         organizationId,
-        revisionId: headersList.get('x-gitbook-content-revision') ?? undefined,
-        changeRequestId: headersList.get('x-gitbook-content-changerequest') ?? undefined,
+        revisionId: ctx.contentRevisionId ?? undefined,
+        changeRequestId: ctx.changeRequestId ?? undefined,
     };
 
     return pointer;
@@ -38,9 +31,8 @@ export async function getSiteContentPointer(): Promise<SiteContentPointer> {
  * Get the current space pointer from the headers. This should be used when rendering
  * the space in an isolated context (e.g. PDF generation).
  */
-export async function getSpacePointer(): Promise<SpaceContentPointer> {
-    const headersList = await headers();
-    const spaceId = headersList.get('x-gitbook-content-space');
+export function getSpacePointer(ctx: GitBookContext): SpaceContentPointer {
+    const spaceId = ctx.spaceId;
     if (!spaceId) {
         throw new Error(
             'getSpacePointer is called outside the scope of a request processed by the middleware',
@@ -49,8 +41,8 @@ export async function getSpacePointer(): Promise<SpaceContentPointer> {
 
     const pointer: SpaceContentPointer = {
         spaceId,
-        revisionId: headersList.get('x-gitbook-content-revision') ?? undefined,
-        changeRequestId: headersList.get('x-gitbook-content-changerequest') ?? undefined,
+        revisionId: ctx.contentRevisionId ?? undefined,
+        changeRequestId: ctx.changeRequestId ?? undefined,
     };
 
     return pointer;

--- a/packages/gitbook/src/lib/seo.ts
+++ b/packages/gitbook/src/lib/seo.ts
@@ -1,5 +1,4 @@
 import {
-    Collection,
     ContentVisibility,
     RevisionPageDocument,
     RevisionPageGroup,
@@ -7,7 +6,8 @@ import {
     SiteVisibility,
     Space,
 } from '@gitbook/api';
-import { headers } from 'next/headers';
+
+import { GitBookContext } from './gitbook-context';
 
 /**
  * Return true if a page is indexable in search.
@@ -31,21 +31,16 @@ export function isPageIndexable(
 /**
  * Return true if a space should be indexed by search engines.
  */
-export async function isSpaceIndexable({ space, site }: { space: Space; site: Site | null }) {
-    const headersList = await headers();
-
-    if (
-        process.env.GITBOOK_BLOCK_SEARCH_INDEXATION &&
-        !headersList.has('x-gitbook-search-indexation')
-    ) {
+export function isSpaceIndexable(
+    ctx: GitBookContext,
+    { space, site }: { space: Space; site: Site | null },
+) {
+    if (process.env.GITBOOK_BLOCK_SEARCH_INDEXATION && !ctx.searchIndexation) {
         return false;
     }
 
     // Prevent indexation of preview of revisions / change-requests
-    if (
-        headersList.get('x-gitbook-content-revision') ||
-        headersList.get('x-gitbook-content-changerequest')
-    ) {
+    if (ctx.contentRevisionId || ctx.changeRequestId) {
         return false;
     }
 

--- a/packages/gitbook/src/lib/tracking.ts
+++ b/packages/gitbook/src/lib/tracking.ts
@@ -1,15 +1,12 @@
-import { headers } from 'next/headers';
+import { GitBookContext } from './gitbook-context';
 
 /**
  * Return true if events should be tracked on the site.
  */
-export async function shouldTrackEvents(): Promise<boolean> {
-    const headersList = await headers();
-
+export function shouldTrackEvents(ctx: GitBookContext): boolean {
     if (
         process.env.NODE_ENV === 'development' ||
-        (process.env.GITBOOK_BLOCK_PAGE_VIEWS_TRACKING &&
-            !headersList.has('x-gitbook-track-page-views'))
+        (process.env.GITBOOK_BLOCK_PAGE_VIEWS_TRACKING && !ctx.trackPageViews)
     ) {
         return false;
     }

--- a/packages/gitbook/src/lib/visitor-token.ts
+++ b/packages/gitbook/src/lib/visitor-token.ts
@@ -91,15 +91,6 @@ export function normalizeVisitorAuthURL(url: URL): URL {
 }
 
 /**
- * Get the visitor token from the request context.
- */
-export async function getCurrentVisitorToken(): Promise<string | null> {
-    const headersList = await headers();
-    const visitorToken = headersList.get('x-gitbook-visitor-token');
-    return visitorToken;
-}
-
-/**
  * Get all possible basePaths for a given URL. This is used to find the visitor
  * authentication cookie token.
  * It returns the longest one first, and the shortest one last.


### PR DESCRIPTION
Headers can only be read in Server Components, we were reading it
everywhere. In this PR we introduce a context passed everywhere we need
to avoid reading them in wrong places.

Fix GITBOOK-OPEN-1WXE
Fix GITBOOK-OPEN-1WXD
Fix GITBOOK-OPEN-1WXC
Fix GITBOOK-OPEN-1WXB
Fix GITBOOK-OPEN-1WXA
Fix GITBOOK-OPEN-1WX9
Fix GITBOOK-OPEN-1WXF
Fix GITBOOK-OPEN-1WXW
Fix GITBOOK-OPEN-1WY0
Fix GITBOOK-OPEN-1WXX
Fix GITBOOK-OPEN-1WXY