### PR TITLE
Separate cache for HTTP methods

### DIFF
--- a/.changeset/two-mirrors-move.md
+++ b/.changeset/two-mirrors-move.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix server actions cache compromised. Leading to some bugs on frontend.


### PR DESCRIPTION
Fix GITBOOK-OPEN-1WZE
Fix GITBOOK-OPEN-1WZF

Server actions use the same endpoint with a "POST" method. In Cloudflare, we serve the cache from the GET request.

In that PR I do two things:

- No cache on POST request
- Add "x-http-method" to be included in the cache key. See https://developers.cloudflare.com/cache/how-to/cache-keys/