### PR TITLE
Fix server actions stability

### DIFF
--- a/.changeset/perfect-laws-pay.md
+++ b/.changeset/perfect-laws-pay.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix server actions stability leading to no results found sometimes on search

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
               run: bun run build:cloudflare
               env:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+                  NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
                   SENTRY_ORG: ${{ vars.SENTRY_ORG }}
                   SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
                   SENTRY_DSN: ${{ vars.SENTRY_DSN }}

--- a/packages/gitbook/next.config.js
+++ b/packages/gitbook/next.config.js
@@ -10,6 +10,7 @@ module.exports = withSentryConfig(
             GITBOOK_ASSETS_PREFIX: process.env.GITBOOK_ASSETS_PREFIX,
             GITBOOK_ICONS_URL: process.env.GITBOOK_ICONS_URL,
             GITBOOK_ICONS_TOKEN: process.env.GITBOOK_ICONS_TOKEN,
+            NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY,
         },
 
         webpack(config, { dev, webpack }) {

--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,8 @@
         },
         // Build the package for Cloudflare Pages
         "build:cloudflare": {
-            "dependsOn": ["^build", "generate"]
+            "dependsOn": ["^build", "generate"],
+            "env": ["NEXT_SERVER_ACTIONS_ENCRYPTION_KEY"]
         },
         // Check the package for type errors
         "typecheck": {


### PR DESCRIPTION
Add `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` to ensure server-actions are
stable across deployments.

Without that, when we deploy server-actions can randomly failed because
we have cache on HTML/JS bundles.

Related: https://github.com/vercel/next.js/discussions/73951, https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations#overwriting-encryption-keys-advanced
