### PR TITLE
Fix OG image generation

### DIFF
--- a/.changeset/late-pots-remain.md
+++ b/.changeset/late-pots-remain.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix OG image generation for non-latin characters


### PR DESCRIPTION
When font loading fails (mostly when we use non-latin characters), we fallback to use the
default font.

It ensures OG image generation will always works correctly.

Fix GITBOOK-OPEN-1X0Y
