### PR TITLE
Fix breadcrumbs emoji display + add contrast styles

### DIFF
--- a/.changeset/two-beans-smell.md
+++ b/.changeset/two-beans-smell.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix breadcrumbs emoji display + add contrast styles

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -44,7 +44,7 @@ export async function PageHeader(props: {
                         >
                             <PageIcon
                                 page={breadcrumb}
-                                style={tcls('size-4', 'flex', 'items-center', 'justify-center', 'text-base', 'leading-none')}
+                                style="size-4 flex items-center justify-center text-base leading-none"
                             />
                             {breadcrumb.title}
                         </StyledLink>

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -37,12 +37,14 @@ export async function PageHeader(props: {
                                 'uppercase',
                                 'flex',
                                 'items-center',
-                                'gap-1',
+                                'gap-1.5',
+                                'contrast-more:underline',
+                                'contrast-more:decoration-current',
                             )}
                         >
                             <PageIcon
                                 page={breadcrumb}
-                                style={tcls('size-4', 'text-base', 'leading-none')}
+                                style={tcls('size-4', 'flex', 'items-center', 'justify-center', 'text-base', 'leading-none')}
                             />
                             {breadcrumb.title}
                         </StyledLink>


### PR DESCRIPTION
Fixes #RND-5956

Emojis display bigger on Safari vs other browsers. There doesn't seem to be much we can do about that, but we can at least accommodate their size a bit better in breadcrumbs.

# Fixed display
<img width="774" alt="Screenshot 2025-01-13 at 15 43 13" src="https://github.com/user-attachments/assets/75c94696-1403-44b2-b574-b53669d1f0e9" />


# Difference between Safari and Chrome
<img width="738" alt="Screenshot 2025-01-13 at 15 35 02" src="https://github.com/user-attachments/assets/aac5c575-546b-4eb1-9da5-320cd4378d7b" />
<img width="638" alt="Screenshot 2025-01-13 at 15 37 14" src="https://github.com/user-attachments/assets/cec28fff-5da2-4349-bca3-030ae3ec9531" />