### PR TITLE
Fix an issue where search and Ask AI triggers unnecessary renders when in a Visitor Authenticated site.

### DIFF
--- a/.changeset/nice-spoons-double.md
+++ b/.changeset/nice-spoons-double.md
@@ -1,0 +1,5 @@
+---
+'gitbook': minor
+---
+
+Fix an issue where search and Ask AI triggers unnecessary renders when in a Visitor Authenticated site.


### PR DESCRIPTION
After investigating an issue with Visitor Auth causing root-level rerenders with @clairechabas, I was suspicious that cookies may be playing a part. 

I confirmed that the Visitor Auth cookie being set in middleware was the cause, and replicated the issue by setting a Hello World cookie even when on a public site (nothing to do with VA) and got the same behaviour. Some more digging led me to this: https://github.com/vercel/next.js/issues/50163. It's apparently a long-standing issue/technical limitation that we cannot set cookies inside a server action.

I'm removing the setting of cookies inside the action. I also cleaned up the cache controls for VA sites.
