### PR TITLE
Header button styling

### DIFF
--- a/.changeset/tasty-cooks-kneel.md
+++ b/.changeset/tasty-cooks-kneel.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Improve styling of header buttons with shadows and high-contrast styles

--- a/packages/gitbook/src/components/Header/HeaderLink.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLink.tsx
@@ -129,7 +129,10 @@ function HeaderItemButton(
             size="medium"
             className={tcls(
                 {
-                    'button-primary': null,
+                    'button-primary':
+                        headerPreset != CustomizationHeaderPreset.Default &&
+                        `bg-header-link dark:bg-header-link hover:bg-header-link dark:hover:bg-header-link
+                        text-header-background dark:text-header-background hover:text-header-background dark:hover:text-header-background`,
                     'button-secondary': tcls(
                         headerPreset != CustomizationHeaderPreset.Default &&
                             `bg-header-link/2 dark:bg-header-link/2 hover:bg-header-link/3 dark:hover:bg-header-link/3 

--- a/packages/gitbook/src/components/Header/HeaderLink.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLink.tsx
@@ -129,19 +129,13 @@ function HeaderItemButton(
             size="medium"
             className={tcls(
                 {
-                    'button-primary':
-                        headerPreset === CustomizationHeaderPreset.Custom ||
-                        headerPreset === CustomizationHeaderPreset.Bold
-                            ? tcls(
-                                  'bg-header-link-500 hover:bg-text-header-link-300 text-header-button-text',
-                                  'dark:bg-header-link-500 dark:hover:bg-text-header-link-300 dark:text-header-button-text',
-                              )
-                            : null,
+                    'button-primary': null,
                     'button-secondary': tcls(
-                        'bg:transparent hover:bg-transparent',
-                        'dark:bg-transparent dark:hover:bg-transparent',
-                        'ring-header-link-500 hover:ring-header-link-300 text-header-link-500',
-                        'dark:ring-header-link-500 dark:hover:ring-header-link-300 dark:text-header-link-500',
+                        headerPreset != CustomizationHeaderPreset.Default &&
+                            `bg-header-link/2 dark:bg-header-link/2 hover:bg-header-link/3 dark:hover:bg-header-link/3 
+                            text-header-link dark:text-header-link hover:text-header-link dark:hover:text-header-link
+                            ring-header-link/4 dark:ring-header-link/4 hover:ring-header-link/5 dark:hover:ring-header-link/5
+                            contrast-more:ring-header-link contrast-more:bg-header-background contrast-more:text-header-link contrast-more:hover:ring-header-link`,
                     ),
                 }[linkStyle],
             )}
@@ -161,6 +155,7 @@ function getHeaderLinkClassName(props: { headerPreset: CustomizationHeaderPreset
         'flex items-center shrink',
         'hover:text-header-link-400 dark:hover:text-light',
         'min-w-0',
+        'contrast-more:underline',
 
         props.headerPreset === CustomizationHeaderPreset.Default
             ? ['text-dark/8', 'dark:text-light/8']

--- a/packages/gitbook/src/components/Header/HeaderLink.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLink.tsx
@@ -132,13 +132,15 @@ function HeaderItemButton(
                     'button-primary':
                         headerPreset != CustomizationHeaderPreset.Default &&
                         `bg-header-link dark:bg-header-link hover:bg-header-link dark:hover:bg-header-link
-                        text-header-background dark:text-header-background hover:text-header-background dark:hover:text-header-background`,
+                        text-header-background dark:text-header-background hover:text-header-background dark:hover:text-header-background
+                        shadow-none hover:shadow-none`,
                     'button-secondary': tcls(
                         headerPreset != CustomizationHeaderPreset.Default &&
                             `bg-header-link/2 dark:bg-header-link/2 hover:bg-header-link/3 dark:hover:bg-header-link/3 
                             text-header-link dark:text-header-link hover:text-header-link dark:hover:text-header-link
                             ring-header-link/4 dark:ring-header-link/4 hover:ring-header-link/5 dark:hover:ring-header-link/5
-                            contrast-more:ring-header-link contrast-more:bg-header-background contrast-more:text-header-link contrast-more:hover:ring-header-link`,
+                            contrast-more:ring-header-link contrast-more:bg-header-background contrast-more:text-header-link contrast-more:hover:ring-header-link
+                            shadow-none hover:shadow-none`,
                     ),
                 }[linkStyle],
             )}

--- a/packages/gitbook/src/components/Header/HeaderLinks.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinks.tsx
@@ -13,7 +13,7 @@ export async function HeaderLinks({ children }: HeaderLinksProps) {
         <div
             className={tcls(
                 styles.containerHeaderlinks,
-                'grow shrink flex justify-end items-center gap-x-6 lg:gap-x-8 min-w-9 z-20',
+                'grow shrink flex justify-end items-center gap-x-4 lg:gap-x-6 min-w-9 z-20',
             )}
         >
             {children}

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -27,27 +27,51 @@ export function Button({
         variant === 'primary'
             ? //PRIMARY
               [
-                  'bg-primary-600',
-                  'text-white',
-                  'ring-dark/2',
-                  'hover:bg-primary-500',
-                  'dark:ring-light/3',
-                  'dark:bg-primary-600',
-                  'dark:hover:bg-primary-700',
+                  'bg-primary',
+                  'text-light', // TODO: Move to 'text-contrast-primary' once contrast calculation works better
+                  'hover:text-light-1',
+                  'hover:bg-primary-600',
+
+                  'dark:bg-primary-400',
+                  'dark:text-contrast-primary-400',
+                  'dark:hover:bg-primary',
+
+                  //   'shadow-sm',
+                  //   'shadow-dark/4',
+                  //   'bg-primary-600',
+                  //   'text-white',
+                  //   'hover:bg-primary-500',
+                  //   'dark:ring-light/3',
+                  //   'dark:bg-primary-600',
+                  //   'dark:hover:bg-primary-700',
               ]
             : // SECONDARY
               [
-                  'bg-dark/2',
-                  'ring-dark/1',
-                  'hover:bg-dark/3',
-                  'dark:bg-light/2',
-                  'dark:ring-light/1',
-                  'dark:hover:bg-light/3',
+                  'bg-light-1',
+                  'text-dark/8',
+                  'hover:text-primary',
+                  'contrast-more:bg-light',
+                  'contrast-more:text-dark',
+                  'contrast-more:hover:ring-primary',
+
+                  'dark:bg-light/1',
+                  'dark:text-light/8',
+                  'contrast-more:dark:bg-dark',
+                  'contrast-more:dark:text-light',
+                  'dark:hover:bg-light/2',
+                  'dark:hover:text-light',
+                  // 'ring-dark/2',
+                  //   'bg-dark/1',
+                  //   'ring-transparent',
+                  //   'hover:bg-dark/3',
+                  //   'dark:bg-light/2',
+                  //   'dark:ring-light/1',
+                  //   'dark:hover:bg-light/3',
               ];
 
     const sizes = {
         default: ['text-base', 'px-4', 'py-2'],
-        medium: ['text-sm', 'px-3', 'py-1'],
+        medium: ['text-sm', 'px-3', 'py-1.5'],
         small: ['text-xs', 'px-3 py-2'],
     };
 
@@ -58,12 +82,32 @@ export function Button({
         'rounded-md',
         'straight-corners:rounded-none',
         'place-self-start',
+
         'ring-1',
-        'ring-inset',
+        'ring-dark/1',
+        'hover:ring-dark/2',
+        'dark:ring-light/2',
+        'dark:hover:ring-light/4',
+
+        'shadow-sm',
+        'shadow-dark/4',
+        'dark:shadow-dark/8',
+        'hover:shadow-md',
+        'active:shadow-none',
+
+        'contrast-more:ring-dark',
+        'contrast-more:hover:ring-2',
+        'contrast-more:hover:ring-dark',
+        'contrast-more:dark:ring-light',
+        'contrast-more:dark:hover:ring-light',
+
+        'hover:scale-105',
+        'active:scale-100',
+        'transition-all',
+
         'grow-0',
         'shrink-0',
         'truncate',
-        'transition-colors',
         variantClasses,
         sizeClasses,
         className,

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -32,8 +32,8 @@ export function Button({
                   'hover:text-light-1',
                   'hover:bg-primary-600',
 
-                  'dark:bg-primary-400',
-                  'dark:text-contrast-primary-400',
+                  'dark:bg-primary',
+                  'dark:text-contrast-primary',
                   'dark:hover:bg-primary',
               ]
             : // SECONDARY

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -35,15 +35,6 @@ export function Button({
                   'dark:bg-primary-400',
                   'dark:text-contrast-primary-400',
                   'dark:hover:bg-primary',
-
-                  //   'shadow-sm',
-                  //   'shadow-dark/4',
-                  //   'bg-primary-600',
-                  //   'text-white',
-                  //   'hover:bg-primary-500',
-                  //   'dark:ring-light/3',
-                  //   'dark:bg-primary-600',
-                  //   'dark:hover:bg-primary-700',
               ]
             : // SECONDARY
               [
@@ -60,13 +51,6 @@ export function Button({
                   'contrast-more:dark:text-light',
                   'dark:hover:bg-light/2',
                   'dark:hover:text-light',
-                  // 'ring-dark/2',
-                  //   'bg-dark/1',
-                  //   'ring-transparent',
-                  //   'hover:bg-dark/3',
-                  //   'dark:bg-light/2',
-                  //   'dark:ring-light/1',
-                  //   'dark:hover:bg-light/3',
               ];
 
     const sizes = {


### PR DESCRIPTION
Decreases the gap between header links and adds new styling for primary and secondary buttons, in line with new theming.

# Comparisons
(Before → After)

<img width="1538" alt="Screenshot 2025-01-14 at 14 16 06" src="https://github.com/user-attachments/assets/06595f90-379c-49db-bbb9-5d0ee8f730d5" />
<img width="1538" alt="Screenshot 2025-01-14 at 14 16 03" src="https://github.com/user-attachments/assets/0e768ec5-2e63-4937-92dc-76dd4fc81b11" />

<img width="1538" alt="Screenshot 2025-01-14 at 14 16 31" src="https://github.com/user-attachments/assets/3c68af99-a683-4151-9261-6f541fab1f2f" />
<img width="1538" alt="Screenshot 2025-01-14 at 14 28 32" src="https://github.com/user-attachments/assets/a993bf24-6a40-4bba-bc48-85d56d72b6ac" />

<img width="1538" alt="Screenshot 2025-01-14 at 14 16 39" src="https://github.com/user-attachments/assets/73ea258e-c0b8-4de7-a670-cb0e4da82f40" />
<img width="1538" alt="Screenshot 2025-01-14 at 14 16 42" src="https://github.com/user-attachments/assets/bfe990ec-eaaf-49d9-a652-af1ba04c7f77" />

<img width="1538" alt="Screenshot 2025-01-14 at 14 16 54" src="https://github.com/user-attachments/assets/bac6b257-72bd-4df0-9d13-be4aaeb568f5" />
<img width="1538" alt="Screenshot 2025-01-14 at 14 17 05" src="https://github.com/user-attachments/assets/731a1cbf-7691-4b71-8782-1c19acd30f81" />

<img width="1538" alt="Screenshot 2025-01-14 at 14 18 23" src="https://github.com/user-attachments/assets/ccc24aee-45c7-43f0-8225-73a29cdcc9a4" />
<img width="1538" alt="Screenshot 2025-01-14 at 14 36 32" src="https://github.com/user-attachments/assets/56f23124-e366-41c1-893c-def5425a5791" />
