### PR TITLE
Restore borders on embed blocks with Captions

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Caption.tsx
+++ b/packages/gitbook/src/components/DocumentView/Caption.tsx
@@ -23,16 +23,16 @@ export function Caption(
         fit?: boolean;
         wrapperStyle?: ClassValue;
         block: DocumentBlockImage | DocumentBlockDrawing | DocumentBlockEmbed | DocumentBlockFile;
+        withBorder?: boolean;
     } & DocumentContextProps,
 ) {
-    const needsBorder = props.block.type === 'embed' || props.block.type === 'file';
-
     const {
         children,
         document,
         block,
         context,
         fit = false,
+        withBorder = false,
         wrapperStyle = [
             'relative',
             'overflow-hidden',
@@ -40,7 +40,7 @@ export function Caption(
             'after:absolute',
             'after:-inset-[0]',
             fit ? 'w-fit' : null,
-            needsBorder
+            withBorder
                 ? 'rounded straight-corners:rounded-none after:border-dark/2 after:border after:rounded straight-corners:after:rounded-none dark:after:border-light/1 dark:after:mix-blend-plus-lighter after:pointer-events-none'
                 : null,
         ],

--- a/packages/gitbook/src/components/DocumentView/Caption.tsx
+++ b/packages/gitbook/src/components/DocumentView/Caption.tsx
@@ -25,6 +25,8 @@ export function Caption(
         block: DocumentBlockImage | DocumentBlockDrawing | DocumentBlockEmbed | DocumentBlockFile;
     } & DocumentContextProps,
 ) {
+    const needsBorder = props.block.type === 'embed' || props.block.type === 'file';
+
     const {
         children,
         document,
@@ -37,9 +39,10 @@ export function Caption(
             'after:block',
             'after:absolute',
             'after:-inset-[0]',
-            'dark:after:mix-blend-plus-lighter',
-            'after:pointer-events-none',
             fit ? 'w-fit' : null,
+            needsBorder
+                ? 'rounded straight-corners:rounded-none after:border-dark/2 after:border after:rounded straight-corners:after:rounded-none dark:after:border-light/1 dark:after:mix-blend-plus-lighter after:pointer-events-none'
+                : null,
         ],
         style,
     } = props;

--- a/packages/gitbook/src/components/DocumentView/Embed.tsx
+++ b/packages/gitbook/src/components/DocumentView/Embed.tsx
@@ -22,7 +22,7 @@ export async function Embed(props: BlockProps<gitbookAPI.DocumentBlockEmbed>) {
         : getEmbedByUrl(block.data.url));
 
     return (
-        <Caption {...props}>
+        <Caption {...props} withBorder>
             {embed.type === 'rich' ? (
                 <>
                     <div

--- a/packages/gitbook/src/components/DocumentView/File.tsx
+++ b/packages/gitbook/src/components/DocumentView/File.tsx
@@ -21,7 +21,7 @@ export async function File(props: BlockProps<DocumentBlockFile>) {
     const contentType = getSimplifiedContentType(file.contentType);
 
     return (
-        <Caption {...props} wrapperStyle={[]}>
+        <Caption {...props}>
             <Link
                 href={file.downloadURL}
                 download={file.name}
@@ -34,13 +34,9 @@ export async function File(props: BlockProps<DocumentBlockFile>) {
                     'flex',
                     'flex-row',
                     'items-center',
-                    'border',
                     'px-5',
                     'py-3',
-                    'border-dark/3',
-                    'rounded-lg',
                     'hover:text-primary-600',
-                    'dark:border-light/3',
                     'dark:hover:text-primary-300',
                 )}
             >

--- a/packages/gitbook/src/components/DocumentView/File.tsx
+++ b/packages/gitbook/src/components/DocumentView/File.tsx
@@ -21,7 +21,7 @@ export async function File(props: BlockProps<DocumentBlockFile>) {
     const contentType = getSimplifiedContentType(file.contentType);
 
     return (
-        <Caption {...props}>
+        <Caption {...props} withBorder>
             <Link
                 href={file.downloadURL}
                 download={file.name}


### PR DESCRIPTION
Fixes oversight in commit 994eb. 
The Caption block wraps a couple other blocks to enable captions. In a prior PR the border on the Caption block was removed as we wanted it removed on images and drawings, as these can function as diagrams with white backgrounds, and a border adds more noise than utility then.

However, this also removed the border on the Embed block, which is an external link block. 

This PR:
- restores the bordering for Embed blocks
- also improves consistency by having the Files block adhere to the same bordering styles from Caption, it was using its own but these were a bit different

Before (url embed block & files block)
![CleanShot 2025-01-17 at 10 26 25@2x](https://github.com/user-attachments/assets/f5a702a2-1685-423a-ac80-9a1c6a700360)

After:

![CleanShot 2025-01-17 at 10 25 41@2x](https://github.com/user-attachments/assets/be679b13-7ebe-4c44-9b81-f09bba4968a2)
