### PR TITLE
Tweak card background, better margins for card headings

### DIFF
--- a/.changeset/poor-carrots-taste.md
+++ b/.changeset/poor-carrots-taste.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Cards stand out slighly more on tinted and dark mode sites, and have better support for headings inside them

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -18,7 +18,10 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
     id = context.getId ? context.getId(id) : id;
 
     return (
-        <Tag id={id} className={tcls(textStyle.textSize, 'heading', 'group', 'relative', 'grid', style)}>
+        <Tag
+            id={id}
+            className={tcls(textStyle.textSize, 'heading', 'group', 'relative', 'grid', style)}
+        >
             <div
                 className={tcls(
                     'grid',

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -18,7 +18,7 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
     id = context.getId ? context.getId(id) : id;
 
     return (
-        <Tag id={id} className={tcls(textStyle.textSize, 'group', 'relative', 'grid', style)}>
+        <Tag id={id} className={tcls(textStyle.textSize, 'heading', 'group', 'relative', 'grid', style)}>
             <div
                 className={tcls(
                     'grid',

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -35,14 +35,17 @@ export async function RecordCard(
                 'z-0',
                 'relative',
                 'grid',
-                'bg-light',
+                'bg-light-1',
+                'dark:bg-dark-1',
                 'w-[calc(100%+2px)]',
                 'h-[calc(100%+2px)]',
                 'inset-[-1px]',
                 'rounded-[7px]',
                 'straight-corners:rounded-none',
                 'overflow-hidden',
-                'dark:bg-dark',
+                '[&_.heading]:flip-heading-hash',
+                '[&_.blocks:first-child_.heading:first-child_div]:mt-0', // Remove margin on first heading in card
+                
                 cover
                     ? [
                           // On mobile, the cover is displayed on the left with 40% of the width

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -45,7 +45,7 @@ export async function RecordCard(
                 'overflow-hidden',
                 '[&_.heading]:flip-heading-hash',
                 '[&_.blocks:first-child_.heading:first-child_div]:mt-0', // Remove margin on first heading in card
-                
+
                 cover
                     ? [
                           // On mobile, the cover is displayed on the left with 40% of the width

--- a/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
@@ -126,6 +126,7 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                     ancestorBlocks={[]}
                     nodes={fragment.nodes}
                     style={[
+                        'blocks',
                         'w-full',
                         'space-y-2',
                         'lg:space-y-3',


### PR DESCRIPTION
Cards stand out slightly more on tinted and dark mode sites, and have better support for headings inside them.

# Preview
## Background
#### Tinted (Before → After)
![Screenshot 2025-01-21 at 16 42 31](https://github.com/user-attachments/assets/4025cec7-7287-42a6-9417-50cc074728bc)
![Screenshot 2025-01-21 at 16 42 14](https://github.com/user-attachments/assets/1d78a9c4-eb56-41a6-a446-feb42236abfe)

#### Dark mode (Before → After)
![Screenshot 2025-01-21 at 16 42 48](https://github.com/user-attachments/assets/00367a12-c74a-4834-bdc4-2333fb091c55)
![Screenshot 2025-01-21 at 16 42 58](https://github.com/user-attachments/assets/c6b2dab2-06e2-4d7b-9da0-a18f73f01eed)

## Headings (Before → After)
![Screenshot 2025-01-21 at 16 43 55](https://github.com/user-attachments/assets/b9fd9701-cd0e-4999-be2b-a76fec178648)
![Screenshot 2025-01-21 at 16 43 45](https://github.com/user-attachments/assets/4087fa27-a319-4965-a4f7-c4f5712275fa)
