### PR TITLE
Fix regression issue with page icons for multi-line titles

### DIFF
--- a/.changeset/large-ligers-nail.md
+++ b/.changeset/large-ligers-nail.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix regression issue with page icons for multi-line titles

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -73,7 +73,10 @@ export async function PageHeader(props: {
             )}
             {page.layout.title ? (
                 <h1 className={tcls('text-4xl', 'font-bold', 'flex', 'items-center', 'gap-4')}>
-                    <PageIcon page={page} style={['text-dark/6', 'dark:text-light/6', 'shrink-0']} />
+                    <PageIcon
+                        page={page}
+                        style={['text-dark/6', 'dark:text-light/6', 'shrink-0']}
+                    />
                     {page.title}
                 </h1>
             ) : null}

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -73,7 +73,7 @@ export async function PageHeader(props: {
             )}
             {page.layout.title ? (
                 <h1 className={tcls('text-4xl', 'font-bold', 'flex', 'items-center', 'gap-4')}>
-                    <PageIcon page={page} style={['text-dark/6', 'dark:text-light/6']} />
+                    <PageIcon page={page} style={['text-dark/6', 'dark:text-light/6', 'shrink-0']} />
                     {page.title}
                 </h1>
             ) : null}


### PR DESCRIPTION
Fixes RND-6018

![Screenshot 2025-01-21 at 16 51 43](https://github.com/user-attachments/assets/9a36b6bc-6320-4bb6-a87e-301b60add12a)

![Screenshot 2025-01-21 at 16 51 37](https://github.com/user-attachments/assets/6ca0582c-9758-425b-88f7-d74b72507179)