### PR TITLE
Generate sitemap for all sections and spaces

### DIFF
--- a/.changeset/nervous-flowers-happen.md
+++ b/.changeset/nervous-flowers-happen.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Generate sitemap for all sections and spaces

--- a/packages/gitbook/src/app/middleware/(site)/(core)/sitemap-pages.xml/route.ts
+++ b/packages/gitbook/src/app/middleware/(site)/(core)/sitemap-pages.xml/route.ts
@@ -1,0 +1,100 @@
+import { RevisionPage, RevisionPageDocument, RevisionPageGroup } from '@gitbook/api';
+import jsontoxml from 'jsontoxml';
+
+import { getRevisionPages, getSpace } from '@/lib/api';
+import { getAbsoluteHref, getBasePath } from '@/lib/links';
+import { getPagePath } from '@/lib/pages';
+import { getSiteContentPointer } from '@/lib/pointer';
+import { isPageIndexable } from '@/lib/seo';
+
+export const runtime = 'edge';
+
+/**
+ * Generate a sitemap.xml for the current space.
+ */
+export async function GET() {
+    const pointer = await getSiteContentPointer();
+
+    const revisionId = await (async () => {
+        if (pointer.revisionId) {
+            return pointer.revisionId;
+        }
+        const space = await getSpace(pointer.spaceId, pointer.siteShareKey);
+        return space.revision;
+    })();
+
+    const rootPages = await getRevisionPages(pointer.spaceId, revisionId, { metadata: false });
+
+    const pages = flattenPages(rootPages, (page) => !page.hidden && isPageIndexable([], page));
+
+    const urls = await Promise.all(
+        pages.map(async ({ page, depth }) => {
+            // Decay priority with depth
+            const priority = Math.pow(2, -0.25 * depth);
+            // Normalize to keep 2 decimals
+            const normalizedPriority = Math.floor(100 * priority) / 100;
+            const lastModified = page.updatedAt || page.createdAt;
+
+            const url: { loc: string; priority: number; lastmod?: string } = {
+                priority: normalizedPriority,
+                loc: await getAbsoluteHref(getPagePath(rootPages, page), true),
+            };
+
+            if (lastModified) {
+                url.lastmod = new Date(lastModified).toISOString();
+            }
+
+            return { url };
+        }),
+    );
+
+    const xml = jsontoxml(
+        [
+            {
+                name: 'urlset',
+                children: urls,
+                attrs: {
+                    xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9',
+                },
+            },
+        ],
+        {
+            xmlHeader: true,
+            prettyPrint: true,
+        },
+    );
+
+    return new Response(xml, {
+        headers: {
+            'Content-Type': 'application/xml',
+        },
+    });
+}
+
+type FlatPageEntry = { page: RevisionPageDocument; depth: number };
+
+function flattenPages(
+    rootPags: RevisionPage[],
+    filter: (page: RevisionPageDocument | RevisionPageGroup) => boolean,
+): FlatPageEntry[] {
+    const flattenPage = (
+        page: RevisionPageDocument | RevisionPageGroup,
+        depth: number,
+    ): FlatPageEntry[] => {
+        const allowed = filter(page);
+        if (!allowed) {
+            return [];
+        }
+
+        return [
+            ...(page.type === 'document' ? [{ page, depth }] : []),
+            ...page.pages.flatMap((child) =>
+                child.type === 'document' ? flattenPage(child, depth + 1) : [],
+            ),
+        ];
+    };
+
+    return rootPags.flatMap((page) =>
+        page.type === 'group' || page.type === 'document' ? flattenPage(page, 0) : [],
+    );
+}

--- a/packages/gitbook/src/app/middleware/(site)/(core)/sitemap.xml/route.ts
+++ b/packages/gitbook/src/app/middleware/(site)/(core)/sitemap.xml/route.ts
@@ -1,12 +1,13 @@
-import { RevisionPage, RevisionPageDocument, RevisionPageGroup } from '@gitbook/api';
+import { SiteSection, SiteSpace, SiteStructure } from '@gitbook/api';
+import assertNever from 'assert-never';
 import jsontoxml from 'jsontoxml';
 import { NextRequest } from 'next/server';
 
-import { getSpaceContentData } from '@/lib/api';
+import { getPublishedContentSite } from '@/lib/api';
 import { getAbsoluteHref } from '@/lib/links';
-import { getPagePath } from '@/lib/pages';
+import { joinPath } from '@/lib/paths';
 import { getSiteContentPointer } from '@/lib/pointer';
-import { isPageIndexable } from '@/lib/seo';
+import { filterOutNullable } from '@/lib/typescript';
 
 export const runtime = 'edge';
 
@@ -15,43 +16,24 @@ export const runtime = 'edge';
  */
 export async function GET(req: NextRequest) {
     const pointer = await getSiteContentPointer();
-    const { pages: rootPages } = await getSpaceContentData(pointer, pointer.siteShareKey);
+    const { structure: siteStructure } = await getPublishedContentSite({
+        organizationId: pointer.organizationId,
+        siteId: pointer.siteId,
+        siteShareKey: pointer.siteShareKey,
+    });
 
-    const pages = flattenPages(rootPages, (page) => !page.hidden && isPageIndexable([], page));
-    const urls = await Promise.all(
-        pages.map(async ({ page, depth }) => {
-            // Decay priority with depth
-            const priority = Math.pow(2, -0.25 * depth);
-            // Normalize to keep 2 decimals
-            const normalizedPriority = Math.floor(100 * priority) / 100;
-
-            const lastModified = page.updatedAt || page.createdAt;
-
-            return {
-                url: {
-                    loc: await getAbsoluteHref(getPagePath(rootPages, page), true),
-                    priority: normalizedPriority,
-                    ...(lastModified
-                        ? {
-                              // lastmod format is YYYY-MM-DD
-                              lastmod: new Date(lastModified).toISOString().split('T')[0],
-                          }
-                        : {}),
-                },
-            };
-        }),
-    );
+    const urls = await getUrlsFromSiteStructure(siteStructure);
 
     const xml = jsontoxml(
         [
             {
-                name: 'urlset',
-                children: urls,
+                name: 'sitemapindex',
+                children: urls.map((url) => ({
+                    name: 'sitemap',
+                    children: [{ name: 'loc', text: url }],
+                })),
                 attrs: {
-                    'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
                     xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9',
-                    'xsi:schemaLocation':
-                        'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
                 },
             },
         ],
@@ -68,30 +50,42 @@ export async function GET(req: NextRequest) {
     });
 }
 
-type FlatPageEntry = { page: RevisionPageDocument; depth: number };
+/**
+ * Get Sitemap URLs from site structure.
+ */
+async function getUrlsFromSiteStructure(siteStructure: SiteStructure): Promise<string[]> {
+    switch (siteStructure.type) {
+        case 'sections':
+            return getUrlsFromSiteSections(siteStructure.structure);
+        case 'siteSpaces':
+            return getUrlsFromSiteSpaces(siteStructure.structure);
+        default:
+            assertNever(siteStructure);
+    }
+}
 
-function flattenPages(
-    rootPags: RevisionPage[],
-    filter: (page: RevisionPageDocument | RevisionPageGroup) => boolean,
-): FlatPageEntry[] {
-    const flattenPage = (
-        page: RevisionPageDocument | RevisionPageGroup,
-        depth: number,
-    ): FlatPageEntry[] => {
-        const allowed = filter(page);
-        if (!allowed) {
-            return [];
-        }
-
-        return [
-            ...(page.type === 'document' ? [{ page, depth }] : []),
-            ...page.pages.flatMap((child) =>
-                child.type === 'document' ? flattenPage(child, depth + 1) : [],
-            ),
-        ];
-    };
-
-    return rootPags.flatMap((page) =>
-        page.type === 'group' || page.type === 'document' ? flattenPage(page, 0) : [],
+/**
+ * Get Sitemap URLs from site sections.
+ */
+async function getUrlsFromSiteSections(siteSections: SiteSection[]): Promise<string[]> {
+    const urls = await Promise.all(
+        siteSections.map(async (siteSection) => getUrlsFromSiteSpaces(siteSection.siteSpaces), []),
     );
+    return urls.flat();
+}
+
+/**
+ * Get Sitemap URLs from site spaces.
+ */
+async function getUrlsFromSiteSpaces(siteSpaces: SiteSpace[]): Promise<string[]> {
+    const urls = await Promise.all(
+        siteSpaces.map(async (siteSpace) => {
+            if (!siteSpace.urls.published) {
+                return null;
+            }
+            const url = new URL(siteSpace.urls.published);
+            return getAbsoluteHref(joinPath(url.pathname, 'sitemap-pages.xml'), true);
+        }, []),
+    );
+    return urls.filter(filterOutNullable);
 }

--- a/packages/gitbook/src/lib/paths.ts
+++ b/packages/gitbook/src/lib/paths.ts
@@ -1,0 +1,3 @@
+export function joinPath(...parts: string[]): string {
+    return parts.join('/').replace(/\/+/g, '/');
+}

--- a/packages/gitbook/src/lib/pointer.ts
+++ b/packages/gitbook/src/lib/pointer.ts
@@ -1,3 +1,4 @@
+import { SiteStructure } from '@gitbook/api';
 import { headers } from 'next/headers';
 import { assert } from 'ts-essentials';
 
@@ -39,6 +40,33 @@ export async function getSiteContentPointer(): Promise<SiteContentPointer> {
     };
 
     return pointer;
+}
+
+/**
+ * Check if the pointer is the root one.
+ * Meaning we are on the default section / space.
+ */
+export function checkIsRootPointer(
+    pointer: SiteContentPointer,
+    siteStructure: SiteStructure,
+): boolean {
+    switch (siteStructure.type) {
+        case 'sections': {
+            return siteStructure.structure.some(
+                (structure) =>
+                    structure.default &&
+                    structure.id === pointer.siteSectionId &&
+                    structure.siteSpaces.some(
+                        (siteSpace) => siteSpace.default && siteSpace.id === pointer.siteSpaceId,
+                    ),
+            );
+        }
+        case 'siteSpaces': {
+            return siteStructure.structure.some(
+                (siteSpace) => siteSpace.default && siteSpace.id === pointer.siteSpaceId,
+            );
+        }
+    }
 }
 
 /**

--- a/packages/gitbook/src/lib/sitemap.ts
+++ b/packages/gitbook/src/lib/sitemap.ts
@@ -1,0 +1,41 @@
+import { RevisionPage, RevisionPageDocument, RevisionPageGroup } from '@gitbook/api';
+
+import { isPageIndexable } from './seo';
+
+export type FlatPageEntry = { page: RevisionPageDocument; depth: number };
+
+/**
+ * Flatten all the pages in a revision.
+ */
+function flattenPages(
+    rootPages: RevisionPage[],
+    filter: (page: RevisionPageDocument | RevisionPageGroup) => boolean,
+): FlatPageEntry[] {
+    const flattenPage = (
+        page: RevisionPageDocument | RevisionPageGroup,
+        depth: number,
+    ): FlatPageEntry[] => {
+        const allowed = filter(page);
+        if (!allowed) {
+            return [];
+        }
+
+        return [
+            ...(page.type === 'document' ? [{ page, depth }] : []),
+            ...page.pages.flatMap((child) =>
+                child.type === 'document' ? flattenPage(child, depth + 1) : [],
+            ),
+        ];
+    };
+
+    return rootPages.flatMap((page) =>
+        page.type === 'group' || page.type === 'document' ? flattenPage(page, 0) : [],
+    );
+}
+
+/**
+ * Get all indexable pages from a revision in a flat list.
+ */
+export function getIndexablePages(rootPages: RevisionPage[]) {
+    return flattenPages(rootPages, (page) => !page.hidden && isPageIndexable([], page));
+}

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -31,6 +31,7 @@ import {
     normalizeVisitorAuthURL,
 } from '@/lib/visitor-token';
 
+import { joinPath } from './lib/paths';
 import { waitUntil } from './lib/waitUntil';
 
 export const config = {
@@ -874,10 +875,6 @@ function getDefaultAPIToken(apiEndpoint: string): string | undefined {
     }
 
     return defaultToken;
-}
-
-function joinPath(...parts: string[]): string {
-    return parts.join('/').replace(/\/+/g, '/');
 }
 
 function stripBasePath(pathname: string, basePath: string): string {


### PR DESCRIPTION
Currently the sitemap does not include all site links. With this new approach we include all the links in the site by having a root site map and one site map per section and site space.

I also simplified the site space markup:

- Remove useless attributes
- Use a more precise lastmod (ISO format is supported)


**Example**

- https://pr2767.gitbook-open.pages.dev/docs.gitbook.com/sitemap.xml