### PR TITLE
Support non primitive examples in OpenAPI block

### DIFF
--- a/.changeset/stupid-points-chew.md
+++ b/.changeset/stupid-points-chew.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Support non primitive examples in OpenAPI block

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -176,7 +176,7 @@
 
 .openapi-schema-example,
 .openapi-schema-pattern {
-    @apply prose-sm mt-2 text-tint-strong;
+    @apply prose-sm mt-1 text-tint-strong;
 }
 
 /** Authentication */

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -51,7 +51,9 @@ export function OpenAPISchemaProperty(
         return (
             typeof schema.example === 'string' ||
             typeof schema.example === 'number' ||
-            typeof schema.example === 'boolean'
+            typeof schema.example === 'boolean' ||
+            (Array.isArray(schema.example) && schema.example.length > 0) ||
+            (typeof schema.example === 'object' && Object.keys(schema.example).length > 0)
         );
     };
     return (

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -102,9 +102,9 @@ export function OpenAPISchemaProperty(
                         />
                     ) : null}
                     {shouldDisplayExample(schema) ? (
-                        <span className="openapi-schema-example">
+                        <div className="openapi-schema-example">
                             Example: <code>{stringifyOpenAPI(schema.example)}</code>
-                        </span>
+                        </div>
                     ) : null}
                     {schema.pattern ? (
                         <div className="openapi-schema-pattern">


### PR DESCRIPTION
This PR adds support for Array and Object examples in an OpenAPI block

![CleanShot 2025-01-24 at 14 58 24@2x](https://github.com/user-attachments/assets/bbc43885-ffcd-4242-9ec8-62dfa524e65e)
![CleanShot 2025-01-24 at 14 58 17@2x](https://github.com/user-attachments/assets/7311fc7d-258c-4e44-aebd-184760d9f660)


### Spacing update preview

**Before:**
![CleanShot 2025-01-24 at 15 01 54@2x](https://github.com/user-attachments/assets/f4e65e27-fd81-4893-b463-ac9697e4136a)

**After:**
![CleanShot 2025-01-24 at 15 02 08@2x](https://github.com/user-attachments/assets/55023176-0e6b-43cc-82e7-92c79791e0dd)

