### PR TITLE
Hotfix docs.radiantdrift.com crashing in production.

### DIFF
--- a/.changeset/loud-dodos-rhyme.md
+++ b/.changeset/loud-dodos-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Fix an issue where a response object using a special ref would crash the page.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ To run a local version of this project, please follow these simple steps.
 
 ### Prerequisites
 
--   Node.js (Version: >=18.x)
--   Bun (Version: >=1.2.0)
+-   Node.js (Version: >=20.6)
+  - Use nvm for easy Node management
+-   Bun (Version: >=1.2.1)
+  - We use a text-based lockfile which isn't supported below 1.2.1
 
 ### Set up
 

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -42,6 +42,11 @@ export function OpenAPIResponseExample(props: {
         .map((response) => {
             const responseObject = noReference(response[1]);
 
+            // TODO: unnecessary with https://github.com/GitbookIO/gitbook/pull/2780
+            if (!responseObject) {
+                return null;
+            }
+
             const schema = noReference(
                 (
                     responseObject.content?.['application/json'] ??


### PR DESCRIPTION
The underlying error is in our parser. We have another PR open for that: https://github.com/GitbookIO/gitbook/pull/2780

This PR will get the docs loading again in the meantime.
