### PR TITLE
Fix default outline list styling

### DIFF
--- a/.changeset/eleven-eggs-ring.md
+++ b/.changeset/eleven-eggs-ring.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix default outline list styling

--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -53,11 +53,11 @@ export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
                         <AsideSectionHighlight
                             transition={springCurve}
                             className={tcls(
+                                'sidebar-list-default:hidden',
                                 section?.depth > 1
                                     ? [
                                           'sidebar-list-default:rounded-l-none',
                                           'sidebar-list-line:rounded-l-none',
-                                          'sidebar-list-default:border-l',
                                       ]
                                     : [
                                           'sidebar-list-default:ml-3',
@@ -112,6 +112,8 @@ export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
                                 'dark:hover:text-tint-400',
 
                                 'contrast-more:font-semibold',
+
+                                'sidebar-list-default:border-tint',
 
                                 'hover:bg-tint/3',
                                 'dark:hover:bg-tint-400/3',


### PR DESCRIPTION
# Before

https://github.com/user-attachments/assets/274d24b3-b8f4-413a-be7a-cd0a7c3f3649


# After

https://github.com/user-attachments/assets/102e9e23-7a2c-4859-920f-2d7548e6dad4

