### PR TITLE
Load Scalar only when the button is pressed

### DIFF
--- a/.changeset/selfish-badgers-smile.md
+++ b/.changeset/selfish-badgers-smile.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Improve performances by loading Scalar API Client only when the button is clicked

--- a/packages/react-openapi/src/OpenAPICodeSample.tsx
+++ b/packages/react-openapi/src/OpenAPICodeSample.tsx
@@ -123,7 +123,11 @@ export function OpenAPICodeSample(props: {
             tabs={samples}
             overlay={
                 data['x-hideTryItPanel'] || data.operation['x-hideTryItPanel'] ? null : (
-                    <ScalarApiButton method={data.method} path={data.path} />
+                    <ScalarApiButton
+                        method={data.method}
+                        path={data.path}
+                        specUrl={context.specUrl}
+                    />
                 )
             }
         />

--- a/packages/react-openapi/src/OpenAPIOperation.tsx
+++ b/packages/react-openapi/src/OpenAPIOperation.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { ApiClientModalProvider } from '@scalar/api-client-react';
 
 import { OpenAPIOperationData } from './fetchOpenAPIOperation';
 import { Markdown } from './Markdown';
@@ -28,45 +27,40 @@ export function OpenAPIOperation(props: {
     };
 
     return (
-        <ApiClientModalProvider
-            configuration={{ spec: { url: context.specUrl } }}
-            initialRequest={{ path: data.path, method: data.method }}
-        >
-            <div className={classNames('openapi-operation', className)}>
-                <div className="openapi-intro">
-                    <h2 className="openapi-summary" id={context.id}>
-                        {operation.summary}
-                    </h2>
-                    {operation.description ? (
-                        <Markdown className="openapi-description" source={operation.description} />
-                    ) : null}
-                    <div className="openapi-target">
-                        <span
-                            className={classNames(
-                                'openapi-method',
-                                `openapi-method-${method.toLowerCase()}`,
-                            )}
-                        >
-                            {method.toUpperCase()}
-                        </span>
-                        <span className="openapi-url">
-                            <OpenAPIServerURL servers={servers} />
-                            {path}
-                        </span>
-                    </div>
+        <div className={classNames('openapi-operation', className)}>
+            <div className="openapi-intro">
+                <h2 className="openapi-summary" id={context.id}>
+                    {operation.summary}
+                </h2>
+                {operation.description ? (
+                    <Markdown className="openapi-description" source={operation.description} />
+                ) : null}
+                <div className="openapi-target">
+                    <span
+                        className={classNames(
+                            'openapi-method',
+                            `openapi-method-${method.toLowerCase()}`,
+                        )}
+                    >
+                        {method.toUpperCase()}
+                    </span>
+                    <span className="openapi-url">
+                        <OpenAPIServerURL servers={servers} />
+                        {path}
+                    </span>
                 </div>
-                <div className={classNames('openapi-columns')}>
-                    <div className={classNames('openapi-column-spec')}>
-                        <OpenAPISpec data={data} context={clientContext} />
-                    </div>
-                    <div className={classNames('openapi-column-preview')}>
-                        <div className={classNames('openapi-column-preview-body')}>
-                            <OpenAPICodeSample {...props} />
-                            <OpenAPIResponseExample {...props} />
-                        </div>
+            </div>
+            <div className={classNames('openapi-columns')}>
+                <div className={classNames('openapi-column-spec')}>
+                    <OpenAPISpec data={data} context={clientContext} />
+                </div>
+                <div className={classNames('openapi-column-preview')}>
+                    <div className={classNames('openapi-column-preview-body')}>
+                        <OpenAPICodeSample {...props} />
+                        <OpenAPIResponseExample {...props} />
                     </div>
                 </div>
             </div>
-        </ApiClientModalProvider>
+        </div>
     );
 }


### PR DESCRIPTION
Scalar client fetches the spec and parse it, in addition it loads CodeMirror that add listener to scroll etc.. Overall it degrades perf a lot for a client that is not displayed to the user.

Until the issues are fixed we load the client only when the button is pressed.