### PR TITLE
Cache API spec for 24 hours, revalidated every 2 hours

### DIFF
--- a/.changeset/five-students-rescue.md
+++ b/.changeset/five-students-rescue.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Cache API spec for 24 hours, revalidated every 2 hours

--- a/packages/gitbook/src/lib/openapi.ts
+++ b/packages/gitbook/src/lib/openapi.ts
@@ -7,7 +7,7 @@ import {
     OpenAPIParseError,
 } from '@gitbook/react-openapi';
 
-import { cache, parseCacheResponse, noCacheFetchOptions, CacheFunctionOptions } from '@/lib/cache';
+import { cache, noCacheFetchOptions, CacheFunctionOptions } from '@/lib/cache';
 
 import { parseMarkdown } from './markdown';
 import { ResolvedContentRef } from './references';
@@ -68,7 +68,10 @@ const fetcher: OpenAPIFetcher = {
             const text = await response.text();
             const data = await parseOpenAPI({ url, value: text, parseMarkdown });
             return {
-                ...parseCacheResponse(response),
+                // Cache for 4 hours
+                ttl: 24 * 60 * 60,
+                // Revalidate every 2 hours
+                revalidateBefore: 22 * 60 * 60,
                 data,
             };
         },


### PR DESCRIPTION
As of today we fetch the API spec directly from an URL and we respect the cache headers from it. We should not because our system rely on this cache to be speed. So now we revalidate every 2 hours and keep a cache of 24 hours.

With our new system this will be solved because we will regenerate the cache only if the spec changes.