### PR TITLE
Fix icons generate script

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -31,7 +31,7 @@
         "react": "*"
     },
     "scripts": {
-        "generate": "node ./bin/gen-list.js",
+        "generate": "bun ./bin/gen-list.js",
         "build": "tsc",
         "typecheck": "tsc --noEmit",
         "dev": "tsc -w",


### PR DESCRIPTION
The `icons` package `generate` script was using node instead of bun. It was causing the script to fail since its using  [import.meta.resolve()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve)
which is supported on the project current node version. 

Better to stick to using the same tool, bun, for all scripts.