### PR TITLE
Support deprecated and x-deprecated-sunset in OpenAPI spec

### DIFF
--- a/.changeset/swift-gorillas-juggle.md
+++ b/.changeset/swift-gorillas-juggle.md
@@ -1,0 +1,6 @@
+---
+'gitbook': patch
+'@gitbook/react-openapi': patch
+---
+
+Support deprecated and x-deprecated-sunset in OpenAPI spec

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -15,7 +15,7 @@
 }
 
 .openapi-summary {
-    @apply flex flex-row items-center gap-3;
+    @apply flex flex-col items-start justify-start gap-2;
 }
 
 .openapi-summary-title {
@@ -31,7 +31,7 @@
 }
 
 .openapi-deprecated-sunset-date {
-    @apply font-medium font-mono;
+    @apply font-semibold font-mono;
 }
 
 .openapi-description.openapi-markdown {

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -15,7 +15,23 @@
 }
 
 .openapi-summary {
+    @apply flex flex-row items-center gap-3;
+}
+
+.openapi-summary-title {
     @apply font-semibold text-xl;
+}
+
+.openapi-summary-title[data-deprecated='true'] {
+    @apply line-through;
+}
+
+.openapi-deprecated {
+    @apply py-0.5 px-1.5 min-w-[1.625rem] font-normal justify-center items-center ring-1 ring-inset ring-dark/1 bg-dark/[0.06] rounded-full dark:ring-light/1 dark:bg-light/1 dark:text-light text-sm leading-[calc(max(1.20em,1.25rem))] before:!content-none after:!content-none;
+}
+
+.openapi-deprecated-sunset-date {
+    @apply font-medium font-mono;
 }
 
 .openapi-description.openapi-markdown {
@@ -163,8 +179,16 @@
     @apply select-none flex gap-2.5 items-baseline text-sm;
 }
 
+.openapi-schema-name .openapi-deprecated {
+    @apply text-xs;
+}
+
 .openapi-schema-propertyname {
     @apply select-all font-mono font-normal text-dark dark:text-light;
+}
+
+.openapi-schema-propertyname[data-deprecated='true'] {
+    @apply line-through opacity-9;
 }
 
 .openapi-schema-required {
@@ -377,6 +401,10 @@
     @apply flex-1 relative font-normal whitespace-nowrap overflow-x-auto font-mono text-dark dark:text-light;
     scrollbar-width: none;
     -ms-overflow-style: none;
+}
+
+.openapi-path-title[data-deprecated='true'] {
+    @apply line-through;
 }
 
 .openapi-path-title::-webkit-scrollbar {

--- a/packages/react-openapi/src/OpenAPIOperation.tsx
+++ b/packages/react-openapi/src/OpenAPIOperation.tsx
@@ -31,11 +31,22 @@ export function OpenAPIOperation(props: {
 
     return (
         <div className={classNames('openapi-operation', className)}>
-            <h2 className="openapi-summary" id={context.id}>
-                {operation.summary}
-            </h2>
+            <div className="openapi-summary" id={context.id}>
+                <h2 className="openapi-summary-title" data-deprecated={operation.deprecated}>
+                    {operation.summary}
+                </h2>
+                {operation.deprecated && <div className="openapi-deprecated">Deprecated</div>}
+            </div>
             <div className={classNames('openapi-columns')}>
                 <div className={classNames('openapi-column-spec')}>
+                    {operation['x-deprecated-sunset'] ? (
+                        <div className="openapi-deprecated-sunset openapi-description openapi-markdown">
+                            This operation is deprecated and will be sunset on{' '}
+                            <span className="openapi-deprecated-sunset-date">
+                                {operation['x-deprecated-sunset']}
+                            </span>
+                        </div>
+                    ) : null}
                     {trimmedDescription ? (
                         <div className="openapi-intro">
                             <Markdown className="openapi-description" source={trimmedDescription} />

--- a/packages/react-openapi/src/OpenAPIOperation.tsx
+++ b/packages/react-openapi/src/OpenAPIOperation.tsx
@@ -45,6 +45,7 @@ export function OpenAPIOperation(props: {
                             <span className="openapi-deprecated-sunset-date">
                                 {operation['x-deprecated-sunset']}
                             </span>
+                            {`.`}
                         </div>
                     ) : null}
                     {trimmedDescription ? (

--- a/packages/react-openapi/src/OpenAPIPath.tsx
+++ b/packages/react-openapi/src/OpenAPIPath.tsx
@@ -13,9 +13,8 @@ export function OpenAPIPath(props: {
     return (
         <div className="openapi-path">
             <div className={`openapi-method openapi-method-${method}`}>{method}</div>
-            <div className="openapi-path-title">
+            <div className="openapi-path-title" data-deprecated={data.operation.deprecated}>
                 <p>{formatPath(path)}</p>
-                {/* <button className="openapi-path-copy">Copy</button> */}
             </div>
             {data['x-hideTryItPanel'] || data.operation['x-hideTryItPanel'] ? null : (
                 <ScalarApiButton method={method} path={path} specUrl={specUrl} />

--- a/packages/react-openapi/src/OpenAPIResponse.tsx
+++ b/packages/react-openapi/src/OpenAPIResponse.tsx
@@ -43,7 +43,6 @@ export function OpenAPIResponse(props: {
                         properties={content.map(([contentType, mediaType]) => ({
                             propertyName: mediaType.schema?.title ?? '',
                             schema: noReference(mediaType.schema) ?? {},
-                            // required: mediaType.schema?.required,
                         }))}
                         context={context}
                     />

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -231,7 +231,16 @@ export function OpenAPISchemaPresentation(props: OpenAPISchemaPropertyEntry) {
                 type={getSchemaTitle(schema)}
                 propertyName={propertyName}
                 required={required}
+                deprecated={schema.deprecated}
             />
+            {schema['x-deprecated-sunset'] ? (
+                <div className="openapi-deprecated-sunset openapi-schema-description openapi-markdown">
+                    Sunsetting on{' '}
+                    <span className="openapi-deprecated-sunset-date">
+                        {schema['x-deprecated-sunset']}
+                    </span>
+                </div>
+            ) : null}
             {schema.description ? (
                 <Markdown source={schema.description} className="openapi-schema-description" />
             ) : null}
@@ -294,9 +303,6 @@ function getSchemaProperties(schema: OpenAPIV3.SchemaObject): null | OpenAPISche
         if (schema.properties) {
             Object.entries(schema.properties).forEach(([propertyName, rawPropertySchema]) => {
                 const propertySchema = noReference(rawPropertySchema);
-                if (propertySchema.deprecated) {
-                    return;
-                }
 
                 result.push({
                     propertyName,

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -235,7 +235,7 @@ export function OpenAPISchemaPresentation(props: OpenAPISchemaPropertyEntry) {
             />
             {schema['x-deprecated-sunset'] ? (
                 <div className="openapi-deprecated-sunset openapi-schema-description openapi-markdown">
-                    Sunsetting on{' '}
+                    Sunset date:{' '}
                     <span className="openapi-deprecated-sunset-date">
                         {schema['x-deprecated-sunset']}
                     </span>
@@ -246,7 +246,7 @@ export function OpenAPISchemaPresentation(props: OpenAPISchemaPropertyEntry) {
             ) : null}
             {shouldDisplayExample(schema) ? (
                 <div className="openapi-schema-example">
-                    Example{' '}
+                    Example:{' '}
                     <code>
                         {typeof schema.example === 'string'
                             ? schema.example
@@ -256,7 +256,7 @@ export function OpenAPISchemaPresentation(props: OpenAPISchemaPropertyEntry) {
             ) : null}
             {schema.pattern ? (
                 <div className="openapi-schema-pattern">
-                    Pattern <code>{schema.pattern}</code>
+                    Pattern: <code>{schema.pattern}</code>
                 </div>
             ) : null}
             {schema.enum && schema.enum.length > 0 ? (

--- a/packages/react-openapi/src/OpenAPISchemaName.tsx
+++ b/packages/react-openapi/src/OpenAPISchemaName.tsx
@@ -7,19 +7,28 @@ interface OpenAPISchemaNameProps {
     propertyName?: string | JSX.Element;
     required?: boolean;
     type?: string;
+    deprecated?: boolean;
 }
 
 export function OpenAPISchemaName(props: OpenAPISchemaNameProps): JSX.Element {
-    const { type, propertyName, required } = props;
+    const { type, propertyName, required, deprecated } = props;
 
     return (
         <div className={classNames('openapi-schema-name')}>
             {propertyName ? (
-                <span className={classNames('openapi-schema-propertyname')}>{propertyName}</span>
+                <span
+                    data-deprecated={deprecated}
+                    className={classNames('openapi-schema-propertyname')}
+                >
+                    {propertyName}
+                </span>
             ) : null}
             {type ? <span className={classNames('openapi-schema-type')}>{type}</span> : null}
             {required ? (
                 <span className={classNames('openapi-schema-required')}>required</span>
+            ) : null}
+            {deprecated ? (
+                <span className={classNames('openapi-deprecated')}>Deprecated</span>
             ) : null}
         </div>
     );

--- a/packages/react-openapi/src/OpenAPISpec.tsx
+++ b/packages/react-openapi/src/OpenAPISpec.tsx
@@ -46,6 +46,8 @@ export function OpenAPISpec(props: { data: OpenAPIOperationData; context: OpenAP
                                 // we use display it if the schema doesn't override it
                                 description: parameter.description,
                                 example: parameter.example,
+                                // Deprecated can be defined at the parameter level
+                                deprecated: parameter.deprecated,
                                 ...(noReference(parameter.schema) ?? {}),
                             },
                             required: parameter.required,


### PR DESCRIPTION
Support for `deprecated` and `x-deprecated-sunset` in an OpenAPI specification.

![CleanShot 2025-02-03 at 23 35 06@2x](https://github.com/user-attachments/assets/ac3e5961-0d28-4358-bbb6-25db48376ced)

![CleanShot 2025-02-03 at 23 35 15@2x](https://github.com/user-attachments/assets/2ec68924-5c77-4272-81c6-d956896b8836)
