### PR TITLE
Page outline positioning

### DIFF
--- a/.changeset/angry-years-notice.md
+++ b/.changeset/angry-years-notice.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+page outline on the right remains visible when scrolling, move mode toggler to PageAside

--- a/packages/gitbook/src/app/middleware/(site)/(content)/[[...pathname]]/page.tsx
+++ b/packages/gitbook/src/app/middleware/(site)/(content)/[[...pathname]]/page.tsx
@@ -86,20 +86,18 @@ export default async function Page(props: {
                 <PageCover as="full" page={page} cover={page.cover} context={contentRefContext} />
             ) : null}
             {/* We use a flex row reverse to render the aside first because the page is streamed. */}
-            <div className="flex flex-row-reverse justify-end">
-                {page.layout.outline ? (
-                    <PageAside
-                        space={space}
-                        site={site}
-                        customization={customization}
-                        page={page}
-                        document={document}
-                        withHeaderOffset={headerOffset}
-                        withFullPageCover={withFullPageCover}
-                        withPageFeedback={withPageFeedback}
-                        context={contentRefContext}
-                    />
-                ) : null}
+            <div className="flex flex-row-reverse justify-end grow">
+                <PageAside
+                    space={space}
+                    site={site}
+                    customization={customization}
+                    page={page}
+                    document={document}
+                    withHeaderOffset={headerOffset}
+                    withFullPageCover={withFullPageCover}
+                    withPageFeedback={withPageFeedback}
+                    context={contentRefContext}
+                />
                 <PageBody
                     space={space}
                     pointer={contentPointer}

--- a/packages/gitbook/src/components/Footer/Footer.tsx
+++ b/packages/gitbook/src/components/Footer/Footer.tsx
@@ -20,115 +20,113 @@ export function Footer(props: {
     const { context, customization } = props;
 
     return (
-        <footer className="border-t border-tint-subtle scroll-nojump">
-            <div
-                className={tcls(
-                    CONTAINER_STYLE,
-                    'py-8',
-                    'gap-12',
-                    'flex',
-                    'flex-wrap',
-                    'items-start',
-                )}
-            >
-                {/* Footer Logo */}
-                <div className="shrink sm:basis-72 page-no-toc:lg:basis-56 mr-auto order-1 empty:hidden empty:lg:block page-no-toc:empty:lg:hidden page-no-toc:empty:xl:block">
-                    {customization.footer.logo ? (
-                        <Image
-                            alt="Logo"
-                            sources={{
-                                light: {
-                                    src: customization.footer.logo.light,
-                                },
-                                dark: customization.footer.logo.dark
-                                    ? {
-                                          src: customization.footer.logo.dark,
-                                      }
-                                    : null,
-                            }}
-                            priority="lazy"
-                            style={[
-                                'w-auto',
-                                'max-w-40',
-                                'lg:max-w-64',
-                                'max-h-12',
-                                'object-contain',
-                                'object-left',
-                                'rounded',
-                                'straight-corners:rounded-sm',
-                            ]}
-                            sizes={[
-                                {
-                                    width: 320,
-                                },
-                            ]}
-                        />
-                    ) : null}
-                </div>
-
-                {/* Mode Switcher */}
-                <div
-                    className={tcls(
-                        'ml-auto',
-                        'order-2 lg:order-4',
-                        customization.footer.groups?.length < 3 &&
-                            customization.footer.logo == undefined &&
-                            'sm:order-4',
-                        'xl:basis-56',
-                    )}
-                >
-                    {customization.themes.toggeable ? (
-                        <div className="flex items-center justify-end">
-                            <React.Suspense fallback={null}>
-                                <ThemeToggler />
-                            </React.Suspense>
-                        </div>
-                    ) : null}
-                </div>
-
-                {/* Navigation Groups (split into equal columns) */}
-                {customization.footer.groups?.length > 0 ? (
+        <>
+            <hr className="border-t border-tint-subtle" />
+            <div className="scroll-nojump">
+                <footer className={tcls(CONTAINER_STYLE, 'px-4', 'mx-auto', 'flex', 'gap-12')}>
+                    <div className="hidden lg:block basis-72 page-no-toc:hidden" />
                     <div
                         className={tcls(
-                            'flex flex-col sm:flex-row mx-auto grow lg:max-w-3xl gap-10 sm:gap-6 order-3',
-                            'w-full lg:w-auto',
-                            customization.footer.groups?.length < 3 &&
-                                customization.footer.logo == undefined &&
-                                'sm:w-auto',
+                            'py-8',
+                            'gap-12',
+                            'flex',
+                            'flex-wrap',
+                            'items-start',
+                            'w-full',
+                            'flex-1',
+                            'max-w-3xl',
+                            'page-full-width:max-w-none',
+                            'mx-auto',
                         )}
                     >
-                        {partition(customization.footer.groups, FOOTER_COLUMNS).map(
-                            (column, columnIndex) => (
-                                <div key={columnIndex} className="flex w-full flex-col gap-10">
-                                    {column.map((group, groupIndex) => (
-                                        <FooterLinksGroup
-                                            key={groupIndex}
-                                            group={group}
-                                            context={context}
-                                        />
-                                    ))}
-                                </div>
-                            ),
-                        )}
-                    </div>
-                ) : null}
+                        {/* Footer Logo */}
+                        {customization.footer.logo ? (
+                            <Image
+                                alt="Logo"
+                                sources={{
+                                    light: {
+                                        src: customization.footer.logo.light,
+                                    },
+                                    dark: customization.footer.logo.dark
+                                        ? {
+                                              src: customization.footer.logo.dark,
+                                          }
+                                        : null,
+                                }}
+                                priority="lazy"
+                                style={[
+                                    'w-auto',
+                                    'max-w-40',
+                                    'lg:max-w-64',
+                                    'max-h-12',
+                                    'object-contain',
+                                    'object-left',
+                                    'rounded',
+                                    'straight-corners:rounded-sm',
+                                    'order-1',
+                                ]}
+                                sizes={[
+                                    {
+                                        width: 320,
+                                    },
+                                ]}
+                            />
+                        ) : null}
 
-                {/* Legal */}
-                <div
-                    className={tcls(
-                        'mx-auto w-full grow text-xs text-tint items-center text-center order-4 flex flex-col gap-2 empty:hidden',
-                        customization.footer.groups.length == 0 &&
-                            'order-2 lg:flex-1 lg:w-auto lg:items-start lg:max-w-3xl self-center lg:text-start',
-                        customization.footer.groups.length == 0 &&
-                            customization.footer.logo == undefined &&
-                            'sm:w-auto sm:flex-1 sm:items-start sm:max-w-3xl sm:text-start',
-                    )}
-                >
-                    {customization.footer.copyright ? (
-                        <p>{customization.footer.copyright}</p>
-                    ) : null}
-                </div>
+                        {/* Mode Switcher */}
+                        {customization.themes.toggeable ? (
+                            <div className="flex items-center justify-end ml-auto order-2 xl:hidden">
+                                <React.Suspense fallback={null}>
+                                    <ThemeToggler />
+                                </React.Suspense>
+                            </div>
+                        ) : null}
+
+                        {/* Navigation Groups (split into equal columns) */}
+                        {customization.footer.groups?.length > 0 ? (
+                            <div
+                                className={tcls(
+                                    'flex flex-col sm:flex-row mx-auto grow gap-10 sm:gap-6 order-3 w-full',
+                                    !customization.footer.logo &&
+                                        customization.footer.groups.length < 2 &&
+                                        'sm:order-1 sm:flex-1 sm:w-auto sm:items-start sm:max-w-3xl self-center sm:text-start',
+                                )}
+                            >
+                                {partition(customization.footer.groups, FOOTER_COLUMNS).map(
+                                    (column, columnIndex) => (
+                                        <div
+                                            key={columnIndex}
+                                            className="flex w-full flex-col gap-10"
+                                        >
+                                            {column.map((group, groupIndex) => (
+                                                <FooterLinksGroup
+                                                    key={groupIndex}
+                                                    group={group}
+                                                    context={context}
+                                                />
+                                            ))}
+                                        </div>
+                                    ),
+                                )}
+                            </div>
+                        ) : null}
+
+                        {/* Legal */}
+                        <div
+                            className={tcls(
+                                'mx-auto w-full grow text-xs text-tint items-center text-center order-4 flex flex-col gap-2 empty:hidden',
+                                customization.footer.groups.length == 0 &&
+                                    'sm:order-1 sm:flex-1 sm:w-auto sm:items-start sm:max-w-3xl self-center sm:text-start',
+                            )}
+                        >
+                            {customization.footer.copyright ? (
+                                <p>{customization.footer.copyright}</p>
+                            ) : null}
+                        </div>
+                    </div>
+                    <div className="hidden lg:block xl:basis-56 page-no-toc:hidden" />
+                </footer>
             </div>
-        </footer>
+        </>
     );
 }

--- a/packages/gitbook/src/components/Footer/Footer.tsx
+++ b/packages/gitbook/src/components/Footer/Footer.tsx
@@ -23,7 +23,22 @@ export function Footer(props: {
         <>
             <hr className="border-t border-tint-subtle" />
             <div className="scroll-nojump">
-                <footer className={tcls(CONTAINER_STYLE, 'px-4', 'mx-auto', 'flex', 'gap-12')}>
+                <footer
+                    className={tcls(
+                        CONTAINER_STYLE,
+                        'px-4',
+                        'mx-auto',
+                        'flex',
+                        'gap-12',
+                        // If the footer only contains a mode toggle, we only show it on smaller screens
+                        customization.themes.toggeable &&
+                            !customization.footer.copyright &&
+                            !customization.footer.logo &&
+                            customization.footer.groups?.length == 0
+                            ? 'xl:hidden'
+                            : null,
+                    )}
+                >
                     <div className="hidden lg:block basis-72 page-no-toc:hidden" />
                     <div
                         className={tcls(

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -149,7 +149,7 @@ export async function PageAside(props: {
                     </div>
                     <div
                         className={tcls(
-                            'overflow-auto',
+                            'overflow-y-auto',
                             'overflow-x-visible',
 
                             'flex',

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -155,6 +155,7 @@ export async function PageAside(props: {
                             'flex',
                             'flex-col',
                             'shrink',
+                            'pb-12',
 
                             'sticky',
                             topOffset,
@@ -243,10 +244,15 @@ export async function PageAside(props: {
                     </div>
                 </>
             ) : null}
-            <div className="mb-4 mt-auto flex flex-col page-api-block:xl:max-2xl:mb-0 page-api-block:xl:max-2xl:hidden page-api-block:xl:max-2xl:group-hover/aside:flex">
+            <div
+                className={tcls(
+                    'pb-4 sticky bottom-0 bg-tint-base [html.tint.sidebar-filled_&]:bg-tint-subtle z-10 mt-auto flex flex-col page-api-block:xl:max-2xl:pb-0 page-api-block:xl:max-2xl:hidden page-api-block:xl:max-2xl:group-hover/aside:flex',
+                    'page-api-block:xl:max-2xl:bg-transparent',
+                )}
+            >
                 {/* Mode Switcher */}
                 {customization.themes.toggeable ? (
-                    <div className="flex items-center justify-end">
+                    <div className="flex items-center justify-end mt-4">
                         <React.Suspense fallback={null}>
                             <ThemeToggler />
                         </React.Suspense>

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -22,17 +22,30 @@ import { getPDFUrlSearchParams } from '@/lib/urls';
 import { ScrollSectionsList } from './ScrollSectionsList';
 import { Ad } from '../Ads';
 import { PageFeedbackForm } from '../PageFeedback';
+import { ThemeToggler } from '../ThemeToggler';
 
 function getTopOffset(props: { sectionsHeader: boolean; topHeader: boolean }) {
     if (props.topHeader && props.sectionsHeader) {
-        return 'lg:top-[6.75rem] lg:max-h-[calc(100vh_-_6.75rem)]';
+        return 'lg:top-[6.75rem]';
     }
 
     if (props.topHeader) {
-        return 'lg:top-16 lg:max-h-[calc(100vh_-_4rem)]';
+        return 'lg:top-16';
     }
 
-    return 'lg:top-0 lg:max-h-screen';
+    return 'lg:top-0';
+}
+
+function getMaxHeight(props: { sectionsHeader: boolean; topHeader: boolean }) {
+    if (props.topHeader && props.sectionsHeader) {
+        return 'lg:max-h-[calc(100vh_-_6.75rem)]';
+    }
+
+    if (props.topHeader) {
+        return 'lg:max-h-[calc(100vh_-_4rem)]';
+    }
+
+    return 'lg:max-h-screen';
 }
 
 /**
@@ -62,6 +75,7 @@ export async function PageAside(props: {
     const language = getSpaceLanguage(customization);
 
     const topOffset = getTopOffset(withHeaderOffset);
+    const maxHeight = getMaxHeight(withHeaderOffset);
     const pdfHref = await getAbsoluteHref(
         `~gitbook/pdf?${getPDFUrlSearchParams({
             page: page.id,
@@ -78,11 +92,13 @@ export async function PageAside(props: {
                 'basis-56',
                 'grow-0',
                 'shrink-0',
-                'sticky',
                 'break-anywhere', // To prevent long words in headings from breaking the layout
 
                 'text-tint',
                 'contrast-more:text-tint-strong',
+                'sticky',
+                topOffset,
+                maxHeight,
 
                 // When in api page mode, we display it as an overlay on non-large resolutions
                 'page-api-block:xl:max-2xl:z-10',
@@ -100,135 +116,153 @@ export async function PageAside(props: {
                 'page-api-block:xl:max-2xl:rounded-md',
                 'page-api-block:xl:max-2xl:h-auto',
                 'page-api-block:xl:max-2xl:my-8',
-
-                topOffset,
+                'page-api-block:p-2',
             )}
         >
-            <div
-                className={tcls(
-                    'hidden',
-                    'page-api-block:xl:max-2xl:flex',
-                    'text-xs',
-                    'tracking-wide',
-                    'font-semibold',
-                    'uppercase',
+            {page.layout.outline ? (
+                <>
+                    <div
+                        className={tcls(
+                            'hidden',
+                            'page-api-block:xl:max-2xl:flex',
+                            'text-xs',
+                            'tracking-wide',
+                            'font-semibold',
+                            'uppercase',
 
-                    'flex-row',
-                    'items-center',
-                    'gap-2',
-                    'p-2',
-                )}
-            >
-                <Icon icon="block-quote" className={tcls('size-3')} />
-                {t(language, 'on_this_page')}
-                <Icon
-                    icon="chevron-down"
-                    className={tcls(
-                        'size-3',
-                        'opacity-6',
-                        'ml-auto',
-                        'page-api-block:xl:max-2xl:group-hover/aside:hidden',
-                    )}
+                            'flex-row',
+                            'items-center',
+                            'gap-2',
+                        )}
+                    >
+                        <Icon icon="block-quote" className={tcls('size-3')} />
+                        {t(language, 'on_this_page')}
+                        <Icon
+                            icon="chevron-down"
+                            className={tcls(
+                                'size-3',
+                                'opacity-6',
+                                'ml-auto',
+                                'page-api-block:xl:max-2xl:group-hover/aside:hidden',
+                            )}
+                        />
+                    </div>
+                    <div
+                        className={tcls(
+                            'overflow-auto',
+                            'overflow-x-visible',
+
+                            'flex',
+                            'flex-col',
+                            'shrink',
+
+                            'sticky',
+                            topOffset,
+
+                            'gap-6',
+                            'pt-8',
+
+                            'page-api-block:xl:max-2xl:py-0',
+                            // Hide it for api page, until hovered
+                            'page-api-block:xl:max-2xl:hidden',
+                            'page-api-block:xl:max-2xl:group-hover/aside:flex',
+                        )}
+                    >
+                        {document ? (
+                            <React.Suspense fallback={null}>
+                                <PageAsideSections document={document} context={context} />
+                            </React.Suspense>
+                        ) : null}
+                        <div
+                            className={tcls(
+                                'flex',
+                                'flex-col',
+                                'gap-3',
+                                'sidebar-list-default:px-3',
+                                'border-t',
+                                'first:border-none',
+                                'border-tint-subtle',
+                                'py-4',
+                                'first:pt-0',
+                                'page-api-block:xl:max-2xl:px-3',
+                                'empty:hidden',
+                            )}
+                        >
+                            {withPageFeedback ? (
+                                <React.Suspense fallback={null}>
+                                    <PageFeedbackForm pageId={page.id} className={tcls('mt-2')} />
+                                </React.Suspense>
+                            ) : null}
+                            {customization.git.showEditLink && space.gitSync?.url && page.git ? (
+                                <div>
+                                    <a
+                                        href={urlJoin(space.gitSync.url, page.git.path)}
+                                        className={tcls(
+                                            'flex',
+                                            'flex-row',
+                                            'items-center',
+                                            'text-sm',
+                                            'hover:text-tint-strong',
+                                            'py-2',
+                                        )}
+                                    >
+                                        <Icon
+                                            icon={
+                                                space.gitSync.installationProvider === 'gitlab'
+                                                    ? 'gitlab'
+                                                    : 'github'
+                                            }
+                                            className={tcls('size-4', 'mr-1.5')}
+                                        />
+                                        {t(language, 'edit_on_git', getGitSyncName(space))}
+                                    </a>
+                                </div>
+                            ) : null}
+                            {customization.pdf.enabled ? (
+                                <div>
+                                    <a
+                                        href={pdfHref}
+                                        className={tcls(
+                                            'flex',
+                                            'flex-row',
+                                            'items-center',
+                                            'text-sm',
+                                            'hover:text-tint-strong',
+                                            'py-2',
+                                        )}
+                                    >
+                                        <Icon
+                                            icon="file-pdf"
+                                            className={tcls('size-4', 'mr-1.5')}
+                                        />
+                                        {t(language, 'pdf_download')}
+                                    </a>
+                                </div>
+                            ) : null}
+                        </div>
+                    </div>
+                </>
+            ) : null}
+            <div className="mb-4 mt-auto flex flex-col page-api-block:xl:max-2xl:mb-0 page-api-block:xl:max-2xl:hidden page-api-block:xl:max-2xl:group-hover/aside:flex">
+                {/* Mode Switcher */}
+                {customization.themes.toggeable ? (
+                    <div className="flex items-center justify-end">
+                        <React.Suspense fallback={null}>
+                            <ThemeToggler />
+                        </React.Suspense>
+                    </div>
+                ) : null}
+                <Ad
+                    zoneId={
+                        site?.ads && site.ads.status === SiteAdsStatus.Live ? site.ads.zoneId : null
+                    }
+                    placement={SiteInsightsAdPlacement.Aside}
+                    spaceId={space.id}
+                    siteAdsStatus={site?.ads && site.ads.status ? site.ads.status : undefined}
+                    ignore={process.env.NODE_ENV !== 'production'}
+                    style={site?.ads ? 'mt-4' : undefined}
                 />
             </div>
-            <div
-                className={tcls(
-                    'overflow-auto',
-                    'overflow-x-visible',
-                    'flex-1',
-                    'flex',
-                    'flex-col',
-                    'gap-6',
-                    'py-8',
-                    '[&::-webkit-scrollbar]:bg-transparent',
-                    '[&::-webkit-scrollbar-thumb]:bg-transparent',
-
-                    'page-api-block:xl:max-2xl:py-0',
-                    // Hide it for api page, until hovered
-                    'page-api-block:xl:max-2xl:hidden',
-                    'page-api-block:xl:max-2xl:group-hover/aside:flex',
-                )}
-            >
-                {document ? (
-                    <React.Suspense fallback={null}>
-                        <PageAsideSections document={document} context={context} />
-                    </React.Suspense>
-                ) : null}
-                <div
-                    className={tcls(
-                        'flex',
-                        'flex-col',
-                        'gap-3',
-                        'sidebar-list-default:px-3',
-                        'border-t',
-                        'first:border-none',
-                        'border-tint-subtle',
-                        'py-4',
-                        'first:pt-0',
-                        'page-api-block:xl:max-2xl:px-3',
-                        'empty:hidden',
-                    )}
-                >
-                    {withPageFeedback ? (
-                        <React.Suspense fallback={null}>
-                            <PageFeedbackForm pageId={page.id} className={tcls('mt-2')} />
-                        </React.Suspense>
-                    ) : null}
-                    {customization.git.showEditLink && space.gitSync?.url && page.git ? (
-                        <div>
-                            <a
-                                href={urlJoin(space.gitSync.url, page.git.path)}
-                                className={tcls(
-                                    'flex',
-                                    'flex-row',
-                                    'items-center',
-                                    'text-sm',
-                                    'hover:text-tint-strong',
-                                    'py-2',
-                                )}
-                            >
-                                <Icon
-                                    icon={
-                                        space.gitSync.installationProvider === 'gitlab'
-                                            ? 'gitlab'
-                                            : 'github'
-                                    }
-                                    className={tcls('size-4', 'mr-1.5')}
-                                />
-                                {t(language, 'edit_on_git', getGitSyncName(space))}
-                            </a>
-                        </div>
-                    ) : null}
-                    {customization.pdf.enabled ? (
-                        <div>
-                            <a
-                                href={pdfHref}
-                                className={tcls(
-                                    'flex',
-                                    'flex-row',
-                                    'items-center',
-                                    'text-sm',
-                                    'hover:text-tint-strong',
-                                    'py-2',
-                                )}
-                            >
-                                <Icon icon="file-pdf" className={tcls('size-4', 'mr-1.5')} />
-                                {t(language, 'pdf_download')}
-                            </a>
-                        </div>
-                    ) : null}
-                </div>
-            </div>
-            <Ad
-                zoneId={
-                    site?.ads && site.ads.status === SiteAdsStatus.Live ? site.ads.zoneId : null
-                }
-                placement={SiteInsightsAdPlacement.Aside}
-                spaceId={space.id}
-                siteAdsStatus={site?.ads && site.ads.status ? site.ads.status : undefined}
-                ignore={process.env.NODE_ENV !== 'production'}
-                style={tcls(site?.ads && site.ads.status === SiteAdsStatus.Live && ['mb-4'])}
-            />
         </aside>
     );
 }

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -68,7 +68,6 @@ export function PageBody(props: {
                         'page-api-block:max-w-[1654px]',
                         'page-api-block:mx-auto',
 
-                        page.layout.outline ? null : 'xl:mr-56',
                         page.layout.tableOfContents ? null : 'xl:ml-56',
                     ) +
                     (asFullWidth ? ' page-full-width' : '') +

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -94,87 +94,86 @@ export async function SpaceLayout(props: {
                 context={contentRefContext}
                 customization={customization}
             />
-            <div className={tcls('scroll-nojump')}>
-                <div
-                    className={tcls(
-                        'flex',
-                        'flex-col',
-                        'lg:flex-row',
-                        CONTAINER_STYLE,
+            <div
+                className={tcls(
+                    'flex',
+                    'flex-col',
+                    'lg:flex-row',
+                    CONTAINER_STYLE,
 
-                        // Ensure the footer is display below the viewport even if the content is not enough
-                        `min-h-[calc(100vh-64px)]`,
-                        withTopHeader ? null : 'lg:min-h-screen',
-                    )}
-                >
-                    <TableOfContents
-                        space={space}
-                        customization={customization}
-                        content={content}
-                        pages={pages}
-                        ancestors={ancestors}
-                        context={contentRefContext}
-                        header={
-                            withTopHeader ? null : (
-                                <div
-                                    className={tcls(
-                                        'hidden',
-                                        'pr-4',
-                                        'lg:flex',
-                                        'flex-grow-0',
-                                        'flex-wrap',
-                                        'dark:shadow-light/1',
-                                    )}
-                                >
-                                    <HeaderLogo
-                                        site={site}
-                                        space={space}
-                                        customization={customization}
-                                    />
+                    // Ensure the footer is display below the viewport even if the content is not enough
+                    `min-h-[calc(100vh-64px)]`,
+                    withTopHeader ? null : 'lg:min-h-screen',
+                )}
+            >
+                <TableOfContents
+                    space={space}
+                    customization={customization}
+                    content={content}
+                    pages={pages}
+                    ancestors={ancestors}
+                    context={contentRefContext}
+                    header={
+                        withTopHeader ? null : (
+                            <div
+                                className={tcls(
+                                    'hidden',
+                                    'pr-4',
+                                    'lg:flex',
+                                    'flex-grow-0',
+                                    'flex-wrap',
+                                    'dark:shadow-light/1',
+                                )}
+                            >
+                                <HeaderLogo
+                                    site={site}
+                                    space={space}
+                                    customization={customization}
+                                />
+                            </div>
+                        )
+                    }
+                    innerHeader={
+                        // displays the search button and/or the space dropdown in the ToC according to the header/variant settings. E.g if there is no header, the search button will be displayed in the ToC.
+                        <>
+                            {!withTopHeader && (
+                                <div className={tcls('hidden', 'lg:block')}>
+                                    <React.Suspense fallback={null}>
+                                        <SearchButton>
+                                            <span className={tcls('flex-1')}>
+                                                {t(
+                                                    getSpaceLanguage(customization),
+                                                    customization.aiSearch.enabled
+                                                        ? 'search_or_ask'
+                                                        : 'search',
+                                                )}
+                                            </span>
+                                        </SearchButton>
+                                    </React.Suspense>
                                 </div>
-                            )
-                        }
-                        innerHeader={
-                            // displays the search button and/or the space dropdown in the ToC according to the header/variant settings. E.g if there is no header, the search button will be displayed in the ToC.
-                            <>
-                                {!withTopHeader && (
-                                    <div className={tcls('hidden', 'lg:block')}>
-                                        <React.Suspense fallback={null}>
-                                            <SearchButton>
-                                                <span className={tcls('flex-1')}>
-                                                    {t(
-                                                        getSpaceLanguage(customization),
-                                                        customization.aiSearch.enabled
-                                                            ? 'search_or_ask'
-                                                            : 'search',
-                                                    )}
-                                                </span>
-                                            </SearchButton>
-                                        </React.Suspense>
-                                    </div>
-                                )}
-                                {!withTopHeader && withSections && sections && (
-                                    <SiteSectionList
-                                        className={tcls('hidden', 'lg:block')}
-                                        sections={sections}
-                                    />
-                                )}
-                                {withVariants && (
-                                    <SpacesDropdown
-                                        space={space}
-                                        spaces={spaces}
-                                        className={tcls('w-full')}
-                                    />
-                                )}
-                            </>
-                        }
-                        headerOffset={headerOffset}
-                    />
-                    <div className={tcls('flex-1', 'flex', 'flex-col')}>{children}</div>
-                </div>
+                            )}
+                            {!withTopHeader && withSections && sections && (
+                                <SiteSectionList
+                                    className={tcls('hidden', 'lg:block')}
+                                    sections={sections}
+                                />
+                            )}
+                            {withVariants && (
+                                <SpacesDropdown
+                                    space={space}
+                                    spaces={spaces}
+                                    className={tcls('w-full')}
+                                />
+                            )}
+                        </>
+                    }
+                    headerOffset={headerOffset}
+                />
+                <div className={tcls('flex-1', 'flex', 'flex-col')}>{children}</div>
             </div>
 
-            {customization.footer.copyright ||
+            {customization.themes.toggeable ||
+            customization.footer.copyright ||
             customization.footer.logo ||
             customization.footer.groups?.length ? (
                 <Footer space={space} context={contentRefContext} customization={customization} />

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -174,8 +174,7 @@ export async function SpaceLayout(props: {
                 </div>
             </div>
 
-            {customization.themes.toggeable ||
-            customization.footer.copyright ||
+            {customization.footer.copyright ||
             customization.footer.logo ||
             customization.footer.groups?.length ? (
                 <Footer space={space} context={contentRefContext} customization={customization} />

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -120,7 +120,7 @@ export async function SpaceLayout(props: {
                                     'hidden',
                                     'pr-4',
                                     'lg:flex',
-                                    'flex-grow-0',
+                                    'grow-0',
                                     'flex-wrap',
                                     'dark:shadow-light/1',
                                 )}


### PR DESCRIPTION
Fixes RND-6068, RND-5185, and an alignment issue with Ads.

# Outline stickiness and mode toggle
- Outline now stays in view as much as possible
- Mode toggle is displayed in outline sidebar, eliminating the need for a footer if it only contains a mode toggle
- Mode toggle is now available on pages without an outline view, like landing pages
<img width="1800" alt="Screenshot 2025-02-04 at 12 08 55" src="https://github.com/user-attachments/assets/9a824511-4910-4247-85a7-4c88d6136c44" />
<img width="1800" alt="Screenshot 2025-02-04 at 12 09 26" src="https://github.com/user-attachments/assets/7ba4bdab-18b7-431b-b0a6-8451bf58dac5" />

# Ad alignment
- Ad blocks now always display at the bottom of the view, together with mode toggle (if enabled)
<img width="1800" alt="Screenshot 2025-02-04 at 12 11 04" src="https://github.com/user-attachments/assets/21bfa7ec-ad14-4218-9ad3-e068f8c2e4c0" />
<img width="1800" alt="Screenshot 2025-02-04 at 12 11 18" src="https://github.com/user-attachments/assets/fe40dbe4-9621-4dca-bde6-83a2111e5ad9" />

- Mode toggle (and ad) are always in view, even when the page outline starts underneath the page cover
<img width="1800" alt="Screenshot 2025-02-04 at 12 16 14" src="https://github.com/user-attachments/assets/0496d88e-3f54-48d6-9b3e-c0a597af9ec8" />
<img width="1800" alt="Screenshot 2025-02-04 at 12 17 34" src="https://github.com/user-attachments/assets/2fa3ab41-b22a-4a16-9a89-0da8c812f777" />

# Footer tweaks
- Footer has been tweaked to rely less on the left and right columns. In the future we might make the sidebars sticky to prevent scrolling it up altogether.
<img width="1800" alt="Screenshot 2025-02-04 at 12 19 54" src="https://github.com/user-attachments/assets/8badd8bc-b3f4-46d9-b85a-9254bb80d077" />
<img width="1800" alt="Screenshot 2025-02-04 at 12 19 49" src="https://github.com/user-attachments/assets/18308c20-109a-4edd-a292-5cc846e0ab8b" />
