### PR TITLE
Fix an issue where a missing OpenAPI example would crash the page.

### DIFF
--- a/.changeset/smart-mayflies-cry.md
+++ b/.changeset/smart-mayflies-cry.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': minor
+---
+
+Fix an issue where a missing OpenAPI example would crash the page.

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -53,7 +53,9 @@ export function OpenAPISchemaProperty(
             typeof schema.example === 'number' ||
             typeof schema.example === 'boolean' ||
             (Array.isArray(schema.example) && schema.example.length > 0) ||
-            (typeof schema.example === 'object' && Object.keys(schema.example).length > 0)
+            (typeof schema.example === 'object' &&
+                schema.example !== null &&
+                Object.keys(schema.example).length > 0)
         );
     };
     return (


### PR DESCRIPTION
Because `typeof null` is object.
