### PR TITLE
Only push scrolling down when Footer is present

### DIFF
--- a/.changeset/cold-cameras-work.md
+++ b/.changeset/cold-cameras-work.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Don't add extra page scroll when footer is not present

--- a/packages/gitbook/src/app/middleware/(site)/(content)/[[...pathname]]/not-found.tsx
+++ b/packages/gitbook/src/app/middleware/(site)/(content)/[[...pathname]]/not-found.tsx
@@ -22,7 +22,7 @@ export default async function NotFound() {
                 'items-center',
                 'justify-center',
                 'py-9',
-                'min-h-[calc(100vh-64px)] sm:min-h-fit',
+                'min-h-[calc(100vh-64px)] lg:min-h-fit',
             )}
         >
             <div className={tcls('max-w-80')}>

--- a/packages/gitbook/src/app/middleware/(site)/(content)/[[...pathname]]/not-found.tsx
+++ b/packages/gitbook/src/app/middleware/(site)/(content)/[[...pathname]]/not-found.tsx
@@ -15,7 +15,15 @@ export default async function NotFound() {
 
     return (
         <div
-            className={tcls('flex-1', 'flex', 'flex-row', 'items-center', 'justify-center', 'py-9')}
+            className={tcls(
+                'flex-1',
+                'flex',
+                'flex-row',
+                'items-center',
+                'justify-center',
+                'py-9',
+                'min-h-[calc(100vh-64px)] sm:min-h-fit',
+            )}
         >
             <div className={tcls('max-w-80')}>
                 <h2 className={tcls('text-2xl', 'font-semibold', 'mb-2')}>

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -78,6 +78,11 @@ export async function SpaceLayout(props: {
     const visitorAuthToken = await getCurrentVisitorToken();
     const enabled = await shouldTrackEvents();
 
+  const withFooter = customization.themes.toggeable ||
+            customization.footer.copyright ||
+            customization.footer.logo ||
+            customization.footer.groups?.length;
+
     return (
         <InsightsProvider
             enabled={enabled}
@@ -103,7 +108,7 @@ export async function SpaceLayout(props: {
                         CONTAINER_STYLE,
 
                         // Ensure the footer is display below the viewport even if the content is not enough
-                        `min-h-[calc(100vh-64px)]`,
+                        withFooter  && 'min-h-[calc(100vh-64px)]',
                         withTopHeader ? null : 'lg:min-h-screen',
                     )}
                 >
@@ -174,10 +179,7 @@ export async function SpaceLayout(props: {
                 </div>
             </div>
 
-            {customization.themes.toggeable ||
-            customization.footer.copyright ||
-            customization.footer.logo ||
-            customization.footer.groups?.length ? (
+            {withFooter ? (
                 <Footer space={space} context={contentRefContext} customization={customization} />
             ) : null}
 

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -78,10 +78,11 @@ export async function SpaceLayout(props: {
     const visitorAuthToken = await getCurrentVisitorToken();
     const enabled = await shouldTrackEvents();
 
-  const withFooter = customization.themes.toggeable ||
-            customization.footer.copyright ||
-            customization.footer.logo ||
-            customization.footer.groups?.length;
+    const withFooter =
+        customization.themes.toggeable ||
+        customization.footer.copyright ||
+        customization.footer.logo ||
+        customization.footer.groups?.length;
 
     return (
         <InsightsProvider
@@ -108,7 +109,7 @@ export async function SpaceLayout(props: {
                         CONTAINER_STYLE,
 
                         // Ensure the footer is display below the viewport even if the content is not enough
-                        withFooter  && 'min-h-[calc(100vh-64px)]',
+                        withFooter && 'min-h-[calc(100vh-64px)]',
                         withTopHeader ? null : 'lg:min-h-screen',
                     )}
                 >


### PR DESCRIPTION
This fixes vertical scrolling when there is no Footer below the content to see by conditionally adding the extra height. The screen was scrolling unnecessarily when the footer wasn't present. This makes sure that there is no scrolling when the footer is not present and the content does not go beyond the screen size.

Before:


https://github.com/user-attachments/assets/b00be21a-194b-4330-ad32-53eaeb0b6981

After:


https://github.com/user-attachments/assets/b7547106-1655-4087-b8a5-6615d8884ef1




