### PR TITLE
Make tint color subtler when equal to primary color

### DIFF
--- a/.changeset/six-hotels-pay.md
+++ b/.changeset/six-hotels-pay.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Subtler tint color when based on the primary color, by mixing in some gray

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -146,8 +146,27 @@ function getTintMixColor(
     ratio?: { light?: number; dark?: number };
 } {
     if (!tintColor) {
+        // Mix in a bit of the primary colour into neutral, to match with primary nicely.
         return {
             color: primaryColor,
+            ratio: {
+                light: 0.2,
+                dark: 0.1,
+            },
+        };
+    }
+
+    if (tintColor === primaryColor) {
+        // Mix in neutral into the tint colour to offset it from the primary, and to make the effect less intense.
+        return {
+            color: {
+                light: DEFAULT_TINT_COLOR,
+                dark: DEFAULT_TINT_COLOR,
+            },
+            ratio: {
+                light: 0.4,
+                dark: 0.4,
+            },
         };
     }
 
@@ -157,8 +176,8 @@ function getTintMixColor(
             dark: tintColor.dark === primaryColor.dark ? DEFAULT_TINT_COLOR : undefined,
         },
         ratio: {
-            light: tintColor.light === primaryColor.light ? 0.4 : undefined, // Undefined to use mix's default ratio
-            dark: tintColor.dark === primaryColor.dark ? 0.4 : undefined, // Undefined to use mix's default ratio
+            light: tintColor.light === primaryColor.light ? 0.4 : 0.2,
+            dark: tintColor.dark === primaryColor.dark ? 0.4 : 0.2,
         },
     };
 }

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -11,7 +11,6 @@ import {
 } from '@gitbook/api';
 import { IconsProvider, IconStyle } from '@gitbook/icons';
 import assertNever from 'assert-never';
-import colors from 'tailwindcss/colors';
 
 import { fontNotoColorEmoji, fonts, ibmPlexMono } from '@/fonts';
 import { getSpaceLanguage } from '@/intl/server';
@@ -20,8 +19,10 @@ import {
     colorContrast,
     colorScale,
     type ColorScaleOptions,
+    DARK_BASE,
     DEFAULT_TINT_COLOR,
     hexToRgb,
+    LIGHT_BASE,
     shadesOfColor,
 } from '@/lib/colors';
 import { tcls } from '@/lib/tailwind';
@@ -224,8 +225,8 @@ function generateHeaderTheme(customization: CustomizationSettings | SiteCustomiz
         case CustomizationHeaderPreset.Default: {
             return {
                 backgroundColor: {
-                    light: colors.white,
-                    dark: colors.black,
+                    light: LIGHT_BASE,
+                    dark: DARK_BASE,
                 },
                 linkColor: {
                     light: customization.styling.primaryColor.light,
@@ -242,11 +243,11 @@ function generateHeaderTheme(customization: CustomizationSettings | SiteCustomiz
                 linkColor: {
                     light: colorContrast(
                         tintColor?.light ?? customization.styling.primaryColor.light,
-                        [colors.white, colors.black],
+                        [LIGHT_BASE, DARK_BASE],
                     ),
                     dark: colorContrast(
                         tintColor?.dark ?? customization.styling.primaryColor.dark,
-                        [colors.white, colors.black],
+                        [LIGHT_BASE, DARK_BASE],
                     ),
                 },
             };
@@ -254,12 +255,12 @@ function generateHeaderTheme(customization: CustomizationSettings | SiteCustomiz
         case CustomizationHeaderPreset.Contrast: {
             return {
                 backgroundColor: {
-                    light: colors.black,
-                    dark: colors.white,
+                    light: DARK_BASE,
+                    dark: LIGHT_BASE,
                 },
                 linkColor: {
-                    light: colors.white,
-                    dark: colors.black,
+                    light: LIGHT_BASE,
+                    dark: DARK_BASE,
                 },
             };
         }
@@ -269,22 +270,20 @@ function generateHeaderTheme(customization: CustomizationSettings | SiteCustomiz
                     light:
                         customization.header.backgroundColor?.light ??
                         tintColor?.light ??
-                        colors.white,
+                        LIGHT_BASE,
                     dark:
-                        customization.header.backgroundColor?.dark ??
-                        tintColor?.dark ??
-                        colors.black,
+                        customization.header.backgroundColor?.dark ?? tintColor?.dark ?? DARK_BASE,
                 },
                 linkColor: {
                     light:
                         customization.header.linkColor?.light ??
                         (tintColor?.light &&
-                            colorContrast(tintColor.light, [colors.white, colors.black])) ??
+                            colorContrast(tintColor.light, [LIGHT_BASE, DARK_BASE])) ??
                         customization.styling.primaryColor.light,
                     dark:
                         customization.header.linkColor?.dark ??
                         (tintColor?.dark &&
-                            colorContrast(tintColor.dark, [colors.white, colors.black])) ??
+                            colorContrast(tintColor.dark, [LIGHT_BASE, DARK_BASE])) ??
                         customization.styling.primaryColor.dark,
                 },
             };

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -164,8 +164,8 @@ function getTintMixColor(
             dark: DEFAULT_TINT_COLOR,
         },
         ratio: {
-            light: tintColor.light === primaryColor.light ? 0.4 : 0,
-            dark: tintColor.dark === primaryColor.dark ? 0.4 : 0,
+            light: tintColor.light.toUpperCase() === primaryColor.light.toUpperCase() ? 0.4 : 0,
+            dark: tintColor.dark.toUpperCase() === primaryColor.dark.toUpperCase() ? 0.4 : 0,
         },
     };
 }

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -45,7 +45,7 @@ export async function CustomizationRootLayout(props: {
     const headerTheme = generateHeaderTheme(customization);
     const language = getSpaceLanguage(customization);
     const tintColor = getTintColor(customization);
-    const mixColor = getMixColor(customization.styling.primaryColor, tintColor);
+    const mixColor = getTintMixColor(customization.styling.primaryColor, tintColor);
     const sidebarStyles = getSidebarStyles(customization);
 
     return (
@@ -76,7 +76,7 @@ export async function CustomizationRootLayout(props: {
                 >{`
                     :root {
                         ${generateColorVariable('primary', customization.styling.primaryColor.light)}
-                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { mix: mixColor?.color.light, mixRatio: mixColor?.ratio?.light })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { mix: mixColor.color.light, mixRatio: mixColor.ratio?.light })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR)}
 
                         --header-background: ${hexToRgb(headerTheme.backgroundColor.light)};
@@ -85,7 +85,7 @@ export async function CustomizationRootLayout(props: {
 
                     .dark {
                         ${generateColorVariable('primary', customization.styling.primaryColor.dark, { darkMode: true })}
-                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, mix: mixColor?.color.light, mixRatio: mixColor?.ratio?.light })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, mix: mixColor?.color.dark, mixRatio: mixColor?.ratio?.dark })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR, { darkMode: true })}
 
                         --header-background: ${hexToRgb(headerTheme.backgroundColor.dark)};
@@ -138,15 +138,14 @@ function getTintColor(
     }
 }
 
-function getMixColor(
+function getTintMixColor(
     primaryColor: CustomizationThemedColor,
     tintColor: CustomizationTint['color'] | undefined,
-):
-    | {
-          color: { light: string | undefined; dark: string | undefined };
-          ratio?: { light: number; dark: number };
-      }
-    | undefined {
+): {
+    color: { light: string | undefined; dark: string | undefined };
+    ratio?: { light: number; dark: number };
+} {
+
     if (!tintColor) {
         return {
             color: primaryColor,

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -76,7 +76,7 @@ export async function CustomizationRootLayout(props: {
                 >{`
                     :root {
                         ${generateColorVariable('primary', customization.styling.primaryColor.light)}
-                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { mix: mixColor.color.light, mixRatio: mixColor.ratio?.light })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { mix: { color: mixColor.color.light, ratio: mixColor.ratio?.light } })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR)}
 
                         --header-background: ${hexToRgb(headerTheme.backgroundColor.light)};
@@ -85,7 +85,7 @@ export async function CustomizationRootLayout(props: {
 
                     .dark {
                         ${generateColorVariable('primary', customization.styling.primaryColor.dark, { darkMode: true })}
-                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, mix: mixColor?.color.dark, mixRatio: mixColor?.ratio?.dark })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, mix: { color: mixColor?.color.dark, ratio: mixColor?.ratio?.dark } })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR, { darkMode: true })}
 
                         --header-background: ${hexToRgb(headerTheme.backgroundColor.dark)};
@@ -145,7 +145,6 @@ function getTintMixColor(
     color: { light: string | undefined; dark: string | undefined };
     ratio?: { light: number; dark: number };
 } {
-
     if (!tintColor) {
         return {
             color: primaryColor,
@@ -158,8 +157,8 @@ function getTintMixColor(
             dark: tintColor.dark === primaryColor.dark ? DEFAULT_TINT_COLOR : undefined,
         },
         ratio: {
-            light: 0.4,
-            dark: 0.4,
+            light: tintColor.light === primaryColor.light ? 0.4 : 0.2,
+            dark: tintColor.dark === primaryColor.dark ? 0.4 : 0.2,
         },
     };
 }

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -2,12 +2,12 @@ import {
     CustomizationCorners,
     CustomizationHeaderPreset,
     CustomizationIconsStyle,
-    CustomizationSettings,
+    type CustomizationSettings,
     CustomizationSidebarBackgroundStyle,
     CustomizationSidebarListStyle,
-    CustomizationThemedColor,
-    CustomizationTint,
-    SiteCustomizationSettings,
+    type CustomizationThemedColor,
+    type CustomizationTint,
+    type SiteCustomizationSettings,
 } from '@gitbook/api';
 import { IconsProvider, IconStyle } from '@gitbook/icons';
 import assertNever from 'assert-never';
@@ -19,6 +19,7 @@ import { getStaticFileURL } from '@/lib/assets';
 import {
     colorContrast,
     colorScale,
+    type ColorScaleOptions,
     DEFAULT_TINT_COLOR,
     hexToRgb,
     shadesOfColor,
@@ -58,8 +59,8 @@ export async function CustomizationRootLayout(props: {
                     ? ' straight-corners'
                     : '',
                 tintColor ? ' tint' : 'no-tint',
-                sidebarStyles.background && ' sidebar-' + sidebarStyles.background,
-                sidebarStyles.list && ' sidebar-list-' + sidebarStyles.list,
+                sidebarStyles.background && ` sidebar-${sidebarStyles.background}`,
+                sidebarStyles.list && ` sidebar-list-${sidebarStyles.list}`,
             )}
         >
             <head>
@@ -153,8 +154,8 @@ function getMixColor(
 
     return {
         color: {
-            light: tintColor.light == primaryColor.light ? DEFAULT_TINT_COLOR : undefined,
-            dark: tintColor.dark == primaryColor.dark ? DEFAULT_TINT_COLOR : undefined,
+            light: tintColor.light === primaryColor.light ? DEFAULT_TINT_COLOR : undefined,
+            dark: tintColor.dark === primaryColor.dark ? DEFAULT_TINT_COLOR : undefined,
         },
         ratio: {
             light: 0.4,
@@ -190,9 +191,8 @@ function generateColorVariable(
     {
         withContrast = true,
         ...options // Pass any options along to the colorScale() function
-    }: {
+    }: ColorScaleOptions & {
         withContrast?: boolean;
-        [key: string]: any;
     } = {},
 ) {
     const shades: Record<string, string> =

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -141,12 +141,10 @@ function getTintColor(
 function getTintMixColor(
     primaryColor: CustomizationThemedColor,
     tintColor: CustomizationTint['color'] | undefined,
-):
-    | {
-          color: CustomizationThemedColor;
-          ratio: { light: number; dark: number };
-      }
-    | undefined {
+): {
+    color: CustomizationThemedColor;
+    ratio: { light: number; dark: number };
+} {
     if (!tintColor) {
         // Mix in a bit of the primary colour into neutral, to match with primary nicely.
         return {
@@ -158,19 +156,18 @@ function getTintMixColor(
         };
     }
 
-    if (tintColor === primaryColor) {
-        // Mix in neutral into the tint colour to offset it from the primary, and to make the effect less intense.
-        return {
-            color: {
-                light: DEFAULT_TINT_COLOR,
-                dark: DEFAULT_TINT_COLOR,
-            },
-            ratio: {
-                light: 0.4,
-                dark: 0.4,
-            },
-        };
-    }
+    // Mix in neutral into the tint colour to offset it from the primary, and to make the effect less intense.
+    // If the tint colour differs from the primary colour, we use the tint colour fully without mixing.
+    return {
+        color: {
+            light: DEFAULT_TINT_COLOR,
+            dark: DEFAULT_TINT_COLOR,
+        },
+        ratio: {
+            light: tintColor.light === primaryColor.light ? 0.4 : 0,
+            dark: tintColor.dark === primaryColor.dark ? 0.4 : 0,
+        },
+    };
 }
 
 /**

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -76,7 +76,7 @@ export async function CustomizationRootLayout(props: {
                 >{`
                     :root {
                         ${generateColorVariable('primary', customization.styling.primaryColor.light)}
-                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { mix: { color: mixColor.color.light, ratio: mixColor.ratio?.light } })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { mix: mixColor && { color: mixColor.color.light, ratio: mixColor.ratio.light } })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR)}
 
                         --header-background: ${hexToRgb(headerTheme.backgroundColor.light)};
@@ -85,7 +85,7 @@ export async function CustomizationRootLayout(props: {
 
                     .dark {
                         ${generateColorVariable('primary', customization.styling.primaryColor.dark, { darkMode: true })}
-                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, mix: { color: mixColor?.color.dark, ratio: mixColor?.ratio?.dark } })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, mix: mixColor && { color: mixColor?.color.dark, ratio: mixColor.ratio.dark } })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR, { darkMode: true })}
 
                         --header-background: ${hexToRgb(headerTheme.backgroundColor.dark)};
@@ -141,10 +141,12 @@ function getTintColor(
 function getTintMixColor(
     primaryColor: CustomizationThemedColor,
     tintColor: CustomizationTint['color'] | undefined,
-): {
-    color: { light: string | undefined; dark: string | undefined };
-    ratio?: { light?: number; dark?: number };
-} {
+):
+    | {
+          color: CustomizationThemedColor;
+          ratio: { light: number; dark: number };
+      }
+    | undefined {
     if (!tintColor) {
         // Mix in a bit of the primary colour into neutral, to match with primary nicely.
         return {
@@ -169,17 +171,6 @@ function getTintMixColor(
             },
         };
     }
-
-    return {
-        color: {
-            light: tintColor.light === primaryColor.light ? DEFAULT_TINT_COLOR : undefined,
-            dark: tintColor.dark === primaryColor.dark ? DEFAULT_TINT_COLOR : undefined,
-        },
-        ratio: {
-            light: tintColor.light === primaryColor.light ? 0.4 : 0.2,
-            dark: tintColor.dark === primaryColor.dark ? 0.4 : 0.2,
-        },
-    };
 }
 
 /**

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -143,7 +143,7 @@ function getTintMixColor(
     tintColor: CustomizationTint['color'] | undefined,
 ): {
     color: { light: string | undefined; dark: string | undefined };
-    ratio?: { light: number; dark: number };
+    ratio?: { light?: number; dark?: number };
 } {
     if (!tintColor) {
         return {
@@ -157,8 +157,8 @@ function getTintMixColor(
             dark: tintColor.dark === primaryColor.dark ? DEFAULT_TINT_COLOR : undefined,
         },
         ratio: {
-            light: tintColor.light === primaryColor.light ? 0.4 : 0.2,
-            dark: tintColor.dark === primaryColor.dark ? 0.4 : 0.2,
+            light: tintColor.light === primaryColor.light ? 0.4 : undefined, // Undefined to use mix's default ratio
+            dark: tintColor.dark === primaryColor.dark ? 0.4 : undefined, // Undefined to use mix's default ratio
         },
     };
 }

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -6,8 +6,9 @@ type RGBColor = [number, number, number];
 type OKLABColor = { L: number; A: number; B: number };
 type OKLCHColor = { L: number; C: number; H: number };
 
-const dark = '#1d1d1d';
-const light = '#ffffff';
+export const DARK_BASE = '#1d1d1d';
+export const LIGHT_BASE = '#ffffff';
+export const DEFAULT_TINT_COLOR = '#787878';
 const D65 = [95.047, 100.0, 108.883]; // Reference white (D65)
 
 export enum ColorCategory {
@@ -138,8 +139,8 @@ export function shadesOfColor(hex: string, halfShades = false) {
         }
 
         const percentage = shadeIndex / 500;
-        const startColor = isDarkShade ? dark : baseColor;
-        const endColor = isDarkShade ? baseColor : light;
+        const startColor = isDarkShade ? DARK_BASE : baseColor;
+        const endColor = isDarkShade ? baseColor : LIGHT_BASE;
 
         result[key] = getColor(percentage, hexToRgbArray(startColor), hexToRgbArray(endColor));
     });
@@ -161,8 +162,8 @@ export function colorScale(
     hex: string,
     {
         darkMode = false,
-        background = darkMode ? dark : light,
-        foreground = darkMode ? light : dark,
+        background = darkMode ? DARK_BASE : LIGHT_BASE,
+        foreground = darkMode ? LIGHT_BASE : DARK_BASE,
         mix,
         mixRatio = 0.2,
     }: {
@@ -182,7 +183,7 @@ export function colorScale(
         // If defined, we mix in a (tiny) bit of the mix color with the base color.
         baseColor.L = mixColor.L * mixRatio + baseColor.L * (1 - mixRatio);
         baseColor.C = mixColor.C * mixRatio + baseColor.C * (1 - mixRatio);
-        baseColor.H = mixColor.H;
+        baseColor.H = mix === DEFAULT_TINT_COLOR ? baseColor.H : mixColor.H;
     }
 
     const mapping = darkMode ? colorMixMapping.dark : colorMixMapping.light;
@@ -382,7 +383,7 @@ export function dpsContrast(a: RGBColor, b: RGBColor) {
 export function colorContrast(background: string, foreground?: string[]) {
     const bg = hexToRgbArray(background);
     if (!foreground) {
-        foreground = [light, dark];
+        foreground = [LIGHT_BASE, DARK_BASE];
     }
 
     let best: { color?: RGBColor; contrast: number } = { color: undefined, contrast: 0 };

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -152,7 +152,7 @@ export type ColorScaleOptions = {
     /** If set to `true`, inverts the scale (so 1 is black instead of white) and uses `colorMixMapping.dark` with different mix ratios per step. */
     darkMode?: boolean;
 
-    /** Define a custom foreground color to use. If left undefined, the global `light`/`dark` values (in `colors.ts`) will be used. */
+    /** Define a custom background color to use. If left undefined, the global `light`/`dark` values (in `colors.ts`) will be used. */
     background?: string;
 
     /** Define a custom foreground color to use. If left undefined, the global `light`/`dark` values (in `colors.ts`) will be used. */

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -158,11 +158,13 @@ export type ColorScaleOptions = {
     /** Define a custom foreground color to use. If left undefined, the global `light`/`dark` values (in `colors.ts`) will be used. */
     foreground?: string;
 
-    /** If set to a hex code, this color will be additionally mixed into the generated scale according to `options.mixRatio`. */
-    mix?: string;
+    mix?: {
+        /** If set to a hex code, this color will be additionally mixed into the generated scale according to `options.mixRatio`. */
+        color?: string;
 
-    /** Define a custom mix ratio to mix the `mix` color with. If left undefined, the default `mixRatio` will be used. */
-    mixRatio?: number;
+        /** Define a custom mix ratio to mix the `mix` color with. If left undefined, the default ratio will be used. */
+        ratio?: number;
+    };
 };
 
 /**
@@ -176,20 +178,22 @@ export function colorScale(
         darkMode = false,
         background = darkMode ? DARK_BASE : LIGHT_BASE,
         foreground = darkMode ? LIGHT_BASE : DARK_BASE,
-        mix,
-        mixRatio = 0.2,
+        mix = {
+            color: undefined,
+            ratio: 0.2,
+        },
     }: ColorScaleOptions = {},
 ) {
     const baseColor = rgbToOklch(hexToRgbArray(hex));
-    const mixColor = mix ? rgbToOklch(hexToRgbArray(mix)) : null;
+    const mixColor = mix.color ? rgbToOklch(hexToRgbArray(mix.color)) : null;
     const foregroundColor = rgbToOklch(hexToRgbArray(foreground));
     const backgroundColor = rgbToOklch(hexToRgbArray(background));
 
-    if (mixColor) {
+    if (mixColor && mix.ratio) {
         // If defined, we mix in a (tiny) bit of the mix color with the base color.
-        baseColor.L = mixColor.L * mixRatio + baseColor.L * (1 - mixRatio);
-        baseColor.C = mixColor.C * mixRatio + baseColor.C * (1 - mixRatio);
-        baseColor.H = mix === DEFAULT_TINT_COLOR ? baseColor.H : mixColor.H;
+        baseColor.L = mixColor.L * mix.ratio + baseColor.L * (1 - mix.ratio);
+        baseColor.C = mixColor.C * mix.ratio + baseColor.C * (1 - mix.ratio);
+        baseColor.H = mix.color === DEFAULT_TINT_COLOR ? baseColor.H : mixColor.H;
     }
 
     const mapping = darkMode ? colorMixMapping.dark : colorMixMapping.light;

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -159,7 +159,7 @@ export type ColorScaleOptions = {
     foreground?: string;
 
     mix?: {
-        /** If set to a hex code, this color will be additionally mixed into the generated scale according to `options.mixRatio`. */
+        /** If set to a hex code, this color will be additionally mixed into the generated scale according to `mix.ratio`. */
         color?: string;
 
         /** Define a custom mix ratio to mix the `mix` color with. If left undefined, the default ratio will be used. */
@@ -179,7 +179,6 @@ export function colorScale(
         background = darkMode ? DARK_BASE : LIGHT_BASE,
         foreground = darkMode ? LIGHT_BASE : DARK_BASE,
         mix = {
-            color: undefined,
             ratio: 0.2,
         },
     }: ColorScaleOptions = {},

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -186,7 +186,7 @@ export function colorScale(
     const foregroundColor = rgbToOklch(hexToRgbArray(foreground));
     const backgroundColor = rgbToOklch(hexToRgbArray(background));
 
-    if (mixColor && mix?.ratio) {
+    if (mixColor && mix?.ratio && mix.ratio > 0) {
         // If defined, we mix in a (tiny) bit of the mix color with the base color.
         baseColor.L = mixColor.L * mix.ratio + baseColor.L * (1 - mix.ratio);
         baseColor.C = mixColor.C * mix.ratio + baseColor.C * (1 - mix.ratio);

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -160,10 +160,10 @@ export type ColorScaleOptions = {
 
     mix?: {
         /** If set to a hex code, this color will be additionally mixed into the generated scale according to `mix.ratio`. */
-        color?: string;
+        color: string;
 
         /** Define a custom mix ratio to mix the `mix` color with. If left undefined, the default ratio will be used. */
-        ratio?: number;
+        ratio: number;
     };
 };
 
@@ -178,17 +178,15 @@ export function colorScale(
         darkMode = false,
         background = darkMode ? DARK_BASE : LIGHT_BASE,
         foreground = darkMode ? LIGHT_BASE : DARK_BASE,
-        mix = {
-            ratio: 0.2,
-        },
+        mix,
     }: ColorScaleOptions = {},
 ) {
     const baseColor = rgbToOklch(hexToRgbArray(hex));
-    const mixColor = mix.color ? rgbToOklch(hexToRgbArray(mix.color)) : null;
+    const mixColor = mix?.color ? rgbToOklch(hexToRgbArray(mix.color)) : null;
     const foregroundColor = rgbToOklch(hexToRgbArray(foreground));
     const backgroundColor = rgbToOklch(hexToRgbArray(background));
 
-    if (mixColor && mix.ratio) {
+    if (mixColor && mix?.ratio) {
         // If defined, we mix in a (tiny) bit of the mix color with the base color.
         baseColor.L = mixColor.L * mix.ratio + baseColor.L * (1 - mix.ratio);
         baseColor.C = mixColor.C * mix.ratio + baseColor.C * (1 - mix.ratio);


### PR DESCRIPTION
The new tint colour system results in pretty intense looks when using the primary colour as the tint colour 1:1. To reduce this effect, we will add in 40% grey with the primary colour _when exactly equal to the primary colour._ This results in a more subtle tone.

When the tint colour is custom-set, we give control to the user and use the chosen colour exactly.