### PR TITLE
Handle Errors from Unresolved Refs

### DIFF
--- a/.changeset/spicy-ravens-live.md
+++ b/.changeset/spicy-ravens-live.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Fix error on unresolvable refs by replacing with property name and any type

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -279,7 +279,9 @@ function getSchemaProperties(schema: OpenAPIV3.SchemaObject): null | OpenAPISche
         if (schema.properties) {
             Object.entries(schema.properties).forEach(([propertyName, rawPropertySchema]) => {
                 const isReference = checkIsReference(rawPropertySchema);
-                const propertySchema = isReference ? { propertyName } : rawPropertySchema;
+                const propertySchema: OpenAPIV3.SchemaObject = isReference
+                    ? { propertyName }
+                    : rawPropertySchema;
                 if (propertySchema.deprecated) {
                     return;
                 }

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -11,182 +11,182 @@ import { stringifyOpenAPI } from './stringifyOpenAPI';
 type CircularRefsIds = Map<OpenAPIV3.SchemaObject, string>;
 
 interface OpenAPISchemaPropertyEntry {
-    propertyName?: string;
-    required?: boolean;
-    schema: OpenAPIV3.SchemaObject;
+  propertyName?: string;
+  required?: boolean;
+  schema: OpenAPIV3.SchemaObject;
 }
 
 /**
  * Render a property of an OpenAPI schema.
  */
 export function OpenAPISchemaProperty(
-    props: OpenAPISchemaPropertyEntry & {
-        /** Set of objects already observed as parents */
-        circularRefs?: CircularRefsIds;
-        context: OpenAPIClientContext;
-        className?: string;
-    },
+  props: OpenAPISchemaPropertyEntry & {
+    /** Set of objects already observed as parents */
+    circularRefs?: CircularRefsIds;
+    context: OpenAPIClientContext;
+    className?: string;
+  },
 ) {
-    const {
-        propertyName,
-        required,
-        schema,
-        circularRefs: parentCircularRefs = new Map<OpenAPIV3.SchemaObject, string>(),
-        context,
-        className,
-    } = props;
+  const {
+    propertyName,
+    required,
+    schema,
+    circularRefs: parentCircularRefs = new Map<OpenAPIV3.SchemaObject, string>(),
+    context,
+    className,
+  } = props;
 
-    const id = useId();
+  const id = useId();
 
-    const parentCircularRef = parentCircularRefs.get(schema);
-    const circularRefs = new Map(parentCircularRefs).set(schema, id);
+  const parentCircularRef = parentCircularRefs.get(schema);
+  const circularRefs = new Map(parentCircularRefs).set(schema, id);
 
-    // Avoid recursing infinitely, and instead render a link to the parent schema
-    const properties = parentCircularRef ? null : getSchemaProperties(schema);
-    const alternatives = parentCircularRef
-        ? null
-        : getSchemaAlternatives(schema, new Set(circularRefs.keys()));
+  // Avoid recursing infinitely, and instead render a link to the parent schema
+  const properties = parentCircularRef ? null : getSchemaProperties(schema);
+  const alternatives = parentCircularRef
+    ? null
+    : getSchemaAlternatives(schema, new Set(circularRefs.keys()));
 
-    const shouldDisplayExample = (schema: OpenAPIV3.SchemaObject): boolean => {
-        return (
-            typeof schema.example === 'string' ||
-            typeof schema.example === 'number' ||
-            typeof schema.example === 'boolean' ||
-            (Array.isArray(schema.example) && schema.example.length > 0) ||
-            (typeof schema.example === 'object' &&
-                schema.example !== null &&
-                Object.keys(schema.example).length > 0)
-        );
-    };
+  const shouldDisplayExample = (schema: OpenAPIV3.SchemaObject): boolean => {
     return (
-        <InteractiveSection
-            id={id}
-            className={classNames('openapi-schema', className)}
-            toggeable={!!properties || !!alternatives}
-            defaultOpened={!!context.defaultInteractiveOpened}
-            toggleOpenIcon={context.icons.chevronRight}
-            toggleCloseIcon={context.icons.chevronDown}
-            tabs={alternatives?.[0].map((alternative, index) => ({
-                key: `${index}`,
-                label: getSchemaTitle(alternative, alternatives[1]),
-                body: circularRefs.has(alternative) ? (
-                    <OpenAPISchemaCircularRef
-                        id={circularRefs.get(alternative)!}
-                        schema={alternative}
-                    />
-                ) : (
-                    <OpenAPISchemaAlternative
-                        schema={alternative}
-                        circularRefs={circularRefs}
-                        context={context}
-                    />
-                ),
-            }))}
-            header={
-                <div className={classNames('openapi-schema-presentation')}>
-                    <div className={classNames('openapi-schema-name')}>
-                        {propertyName ? (
-                            <span className={classNames('openapi-schema-propertyname')}>
-                                {propertyName}
-                            </span>
-                        ) : null}
-                        {required ? (
-                            <span className={classNames('openapi-schema-required')}>*</span>
-                        ) : null}
-                        <span className={classNames('openapi-schema-type')}>
-                            {getSchemaTitle(schema)}
-                        </span>
-                    </div>
-                    {schema.description ? (
-                        <Markdown
-                            source={schema.description}
-                            className="openapi-schema-description"
-                        />
-                    ) : null}
-                    {shouldDisplayExample(schema) ? (
-                        <div className="openapi-schema-example">
-                            Example: <code>{stringifyOpenAPI(schema.example)}</code>
-                        </div>
-                    ) : null}
-                    {schema.pattern ? (
-                        <div className="openapi-schema-pattern">
-                            Pattern: <code>{schema.pattern}</code>
-                        </div>
-                    ) : null}
-                </div>
-            }
-        >
-            {(properties && properties.length > 0) ||
-            (schema.enum && schema.enum.length > 0) ||
-            parentCircularRef ? (
-                <>
-                    {properties?.length ? (
-                        <OpenAPISchemaProperties
-                            properties={properties}
-                            circularRefs={circularRefs}
-                            context={context}
-                        />
-                    ) : null}
-                    {schema.enum && schema.enum.length > 0 ? (
-                        <OpenAPISchemaEnum enumValues={schema.enum} />
-                    ) : null}
-                    {parentCircularRef ? (
-                        <OpenAPISchemaCircularRef id={parentCircularRef} schema={schema} />
-                    ) : null}
-                </>
-            ) : null}
-        </InteractiveSection>
+      typeof schema.example === 'string' ||
+      typeof schema.example === 'number' ||
+      typeof schema.example === 'boolean' ||
+      (Array.isArray(schema.example) && schema.example.length > 0) ||
+      (typeof schema.example === 'object' &&
+        schema.example !== null &&
+        Object.keys(schema.example).length > 0)
     );
+  };
+  return (
+    <InteractiveSection
+      id={id}
+      className={classNames('openapi-schema', className)}
+      toggeable={!!properties || !!alternatives}
+      defaultOpened={!!context.defaultInteractiveOpened}
+      toggleOpenIcon={context.icons.chevronRight}
+      toggleCloseIcon={context.icons.chevronDown}
+      tabs={alternatives?.[0].map((alternative, index) => ({
+        key: `${index}`,
+        label: getSchemaTitle(alternative, alternatives[1]),
+        body: circularRefs.has(alternative) ? (
+          <OpenAPISchemaCircularRef
+            id={circularRefs.get(alternative)!}
+            schema={alternative}
+          />
+        ) : (
+          <OpenAPISchemaAlternative
+            schema={alternative}
+            circularRefs={circularRefs}
+            context={context}
+          />
+        ),
+      }))}
+      header={
+        <div className={classNames('openapi-schema-presentation')}>
+          <div className={classNames('openapi-schema-name')}>
+            {propertyName ? (
+              <span className={classNames('openapi-schema-propertyname')}>
+                {propertyName}
+              </span>
+            ) : null}
+            {required ? (
+              <span className={classNames('openapi-schema-required')}>*</span>
+            ) : null}
+            <span className={classNames('openapi-schema-type')}>
+              {getSchemaTitle(schema)}
+            </span>
+          </div>
+          {schema.description ? (
+            <Markdown
+              source={schema.description}
+              className="openapi-schema-description"
+            />
+          ) : null}
+          {shouldDisplayExample(schema) ? (
+            <div className="openapi-schema-example">
+              Example: <code>{stringifyOpenAPI(schema.example)}</code>
+            </div>
+          ) : null}
+          {schema.pattern ? (
+            <div className="openapi-schema-pattern">
+              Pattern: <code>{schema.pattern}</code>
+            </div>
+          ) : null}
+        </div>
+      }
+    >
+      {(properties && properties.length > 0) ||
+        (schema.enum && schema.enum.length > 0) ||
+        parentCircularRef ? (
+        <>
+          {properties?.length ? (
+            <OpenAPISchemaProperties
+              properties={properties}
+              circularRefs={circularRefs}
+              context={context}
+            />
+          ) : null}
+          {schema.enum && schema.enum.length > 0 ? (
+            <OpenAPISchemaEnum enumValues={schema.enum} />
+          ) : null}
+          {parentCircularRef ? (
+            <OpenAPISchemaCircularRef id={parentCircularRef} schema={schema} />
+          ) : null}
+        </>
+      ) : null}
+    </InteractiveSection>
+  );
 }
 
 /**
  * Render a set of properties of an OpenAPI schema.
  */
 export function OpenAPISchemaProperties(props: {
-    id?: string;
-    properties: OpenAPISchemaPropertyEntry[];
-    circularRefs?: CircularRefsIds;
-    context: OpenAPIClientContext;
+  id?: string;
+  properties: OpenAPISchemaPropertyEntry[];
+  circularRefs?: CircularRefsIds;
+  context: OpenAPIClientContext;
 }) {
-    const { id, properties, circularRefs, context } = props;
+  const { id, properties, circularRefs, context } = props;
 
-    if (!properties.length) {
-        return null;
-    }
+  if (!properties.length) {
+    return null;
+  }
 
-    return (
-        <div id={id} className={classNames('openapi-schema-properties')}>
-            {properties.map((property) => (
-                <OpenAPISchemaProperty
-                    key={property.propertyName}
-                    circularRefs={circularRefs}
-                    {...property}
-                    context={context}
-                />
-            ))}
-        </div>
-    );
+  return (
+    <div id={id} className={classNames('openapi-schema-properties')}>
+      {properties.map((property) => (
+        <OpenAPISchemaProperty
+          key={property.propertyName}
+          circularRefs={circularRefs}
+          {...property}
+          context={context}
+        />
+      ))}
+    </div>
+  );
 }
 
 /**
  * Render a root schema (such as the request body or response body).
  */
 export function OpenAPIRootSchema(props: {
-    schema: OpenAPIV3.SchemaObject;
-    context: OpenAPIClientContext;
+  schema: OpenAPIV3.SchemaObject;
+  context: OpenAPIClientContext;
 }) {
-    const { schema, context } = props;
+  const { schema, context } = props;
 
-    // Avoid recursing infinitely, and instead render a link to the parent schema
-    const properties = getSchemaProperties(schema);
+  // Avoid recursing infinitely, and instead render a link to the parent schema
+  const properties = getSchemaProperties(schema);
 
-    if (properties && properties.length > 0) {
-        return <OpenAPISchemaProperties properties={properties} context={context} />;
-    }
+  if (properties && properties.length > 0) {
+    return <OpenAPISchemaProperties properties={properties} context={context} />;
+  }
 
-    return (
-        <OpenAPISchemaProperty schema={schema} context={context} className="openapi-schema-root" />
-    );
+  return (
+    <OpenAPISchemaProperty schema={schema} context={context} className="openapi-schema-root" />
+  );
 }
 
 /**
@@ -195,212 +195,217 @@ export function OpenAPIRootSchema(props: {
  * for primitives, it renders the schema itself.
  */
 function OpenAPISchemaAlternative(props: {
-    schema: OpenAPIV3.SchemaObject;
-    circularRefs?: CircularRefsIds;
-    context: OpenAPIClientContext;
+  schema: OpenAPIV3.SchemaObject;
+  circularRefs?: CircularRefsIds;
+  context: OpenAPIClientContext;
 }) {
-    const { schema, circularRefs, context } = props;
-    const id = useId();
-    const subProperties = getSchemaProperties(schema);
+  const { schema, circularRefs, context } = props;
+  const id = useId();
+  const subProperties = getSchemaProperties(schema);
 
-    return (
-        <OpenAPISchemaProperties
-            id={id}
-            properties={subProperties ?? [{ schema }]}
-            circularRefs={subProperties ? new Map(circularRefs).set(schema, id) : circularRefs}
-            context={context}
-        />
-    );
+  return (
+    <OpenAPISchemaProperties
+      id={id}
+      properties={subProperties ?? [{ schema }]}
+      circularRefs={subProperties ? new Map(circularRefs).set(schema, id) : circularRefs}
+      context={context}
+    />
+  );
 }
 
 /**
  * Render a circular reference to a schema.
  */
 function OpenAPISchemaCircularRef(props: { id: string; schema: OpenAPIV3.SchemaObject }) {
-    const { id, schema } = props;
+  const { id, schema } = props;
 
-    return (
-        <div className="openapi-schema-circular">
-            Circular reference to <a href={`#${id}`}>{getSchemaTitle(schema)}</a>{' '}
-            <span className="openapi-schema-circular-glyph">↩</span>
-        </div>
-    );
+  return (
+    <div className="openapi-schema-circular">
+      Circular reference to <a href={`#${id}`}>{getSchemaTitle(schema)}</a>{' '}
+      <span className="openapi-schema-circular-glyph">↩</span>
+    </div>
+  );
 }
 
 /**
  * Render the enum value for a schema.
  */
 export function OpenAPISchemaEnum(props: { enumValues: any[] }) {
-    const { enumValues } = props;
+  const { enumValues } = props;
 
-    return (
-        <div className="openapi-schema-enum">
-            {enumValues.map((value, index) => (
-                <span key={index} className="openapi-schema-enum-value">{`${value}`}</span>
-            ))}
-        </div>
-    );
+  return (
+    <div className="openapi-schema-enum">
+      {enumValues.map((value, index) => (
+        <span key={index} className="openapi-schema-enum-value">{`${value}`}</span>
+      ))}
+    </div>
+  );
 }
 
 /**
  * Get the sub-properties of a schema.
  */
 function getSchemaProperties(schema: OpenAPIV3.SchemaObject): null | OpenAPISchemaPropertyEntry[] {
-    if (schema.allOf) {
-        return schema.allOf.reduce((acc, subSchema) => {
-            const properties = getSchemaProperties(noReference(subSchema)) ?? [
-                {
-                    schema: noReference(subSchema),
-                },
-            ];
-            return [...acc, ...properties];
-        }, [] as OpenAPISchemaPropertyEntry[]);
+  if (schema.allOf) {
+    return schema.allOf.reduce((acc, subSchema) => {
+      const properties = getSchemaProperties(noReference(subSchema)) ?? [
+        {
+          schema: noReference(subSchema),
+        },
+      ];
+      return [...acc, ...properties];
+    }, [] as OpenAPISchemaPropertyEntry[]);
+  }
+
+  // check array AND schema.items as this is sometimes null despite what the type indicates
+  if (schema.type === 'array' && !!schema.items) {
+    const items = noReference(schema.items);
+    const itemProperties = getSchemaProperties(items);
+    if (itemProperties) {
+      return itemProperties;
     }
 
-    // check array AND schema.items as this is sometimes null despite what the type indicates
-    if (schema.type === 'array' && !!schema.items) {
-        const items = noReference(schema.items);
-        const itemProperties = getSchemaProperties(items);
-        if (itemProperties) {
-            return itemProperties;
-        }
+    return [
+      {
+        propertyName: 'items',
+        schema: items,
+      },
+    ];
+  }
 
-        return [
-            {
-                propertyName: 'items',
-                schema: items,
-            },
-        ];
+  if (schema.type === 'object' || schema.properties) {
+    const result: OpenAPISchemaPropertyEntry[] = [];
+
+    if (schema.properties) {
+      Object.entries(schema.properties).forEach(([propertyName, rawPropertySchema]) => {
+        try {
+          const propertySchema = noReference(rawPropertySchema);
+          if (propertySchema.deprecated) {
+            return;
+          }
+
+          result.push({
+            propertyName,
+            required: Array.isArray(schema.required)
+              ? schema.required.includes(propertyName)
+              : undefined,
+            schema: propertySchema,
+          });
+        } catch (e) {
+          // handle any errors that might come from noReference
+          return;
+        }
+      });
     }
 
-    if (schema.type === 'object' || schema.properties) {
-        const result: OpenAPISchemaPropertyEntry[] = [];
+    if (schema.additionalProperties) {
+      const additionalProperties = noReference(schema.additionalProperties);
 
-        if (schema.properties) {
-            Object.entries(schema.properties).forEach(([propertyName, rawPropertySchema]) => {
-                const propertySchema = noReference(rawPropertySchema);
-                if (propertySchema.deprecated) {
-                    return;
-                }
-
-                result.push({
-                    propertyName,
-                    required: Array.isArray(schema.required)
-                        ? schema.required.includes(propertyName)
-                        : undefined,
-                    schema: propertySchema,
-                });
-            });
-        }
-
-        if (schema.additionalProperties) {
-            const additionalProperties = noReference(schema.additionalProperties);
-
-            result.push({
-                propertyName: 'Other properties',
-                schema: additionalProperties === true ? {} : additionalProperties,
-            });
-        }
-
-        return result;
+      result.push({
+        propertyName: 'Other properties',
+        schema: additionalProperties === true ? {} : additionalProperties,
+      });
     }
 
-    return null;
+    return result;
+  }
+
+  return null;
 }
 
 /**
  * Get the alternatives to display for a schema.
  */
 export function getSchemaAlternatives(
-    schema: OpenAPIV3.SchemaObject,
-    ancestors: Set<OpenAPIV3.SchemaObject> = new Set(),
+  schema: OpenAPIV3.SchemaObject,
+  ancestors: Set<OpenAPIV3.SchemaObject> = new Set(),
 ): null | [OpenAPIV3.SchemaObject[], OpenAPIV3.DiscriminatorObject | undefined] {
-    const downAncestors = new Set(ancestors).add(schema);
+  const downAncestors = new Set(ancestors).add(schema);
 
-    if (schema.anyOf) {
-        return [
-            flattenAlternatives('anyOf', schema.anyOf.map(noReference), downAncestors),
-            noReference(schema.discriminator),
-        ];
-    }
+  if (schema.anyOf) {
+    return [
+      flattenAlternatives('anyOf', schema.anyOf.map(noReference), downAncestors),
+      noReference(schema.discriminator),
+    ];
+  }
 
-    if (schema.oneOf) {
-        return [
-            flattenAlternatives('oneOf', schema.oneOf.map(noReference), downAncestors),
-            noReference(schema.discriminator),
-        ];
-    }
+  if (schema.oneOf) {
+    return [
+      flattenAlternatives('oneOf', schema.oneOf.map(noReference), downAncestors),
+      noReference(schema.discriminator),
+    ];
+  }
 
-    if (schema.allOf) {
-        // allOf is managed in `getSchemaProperties`
-        return null;
-    }
-
+  if (schema.allOf) {
+    // allOf is managed in `getSchemaProperties`
     return null;
+  }
+
+  return null;
 }
 
 function flattenAlternatives(
-    alternativeType: 'oneOf' | 'allOf' | 'anyOf',
-    alternatives: OpenAPIV3.SchemaObject[],
-    ancestors: Set<OpenAPIV3.SchemaObject>,
+  alternativeType: 'oneOf' | 'allOf' | 'anyOf',
+  alternatives: OpenAPIV3.SchemaObject[],
+  ancestors: Set<OpenAPIV3.SchemaObject>,
 ): OpenAPIV3.SchemaObject[] {
-    return alternatives.reduce((acc, alternative) => {
-        if (!!alternative[alternativeType] && !ancestors.has(alternative)) {
-            return [...acc, ...(getSchemaAlternatives(alternative, ancestors)?.[0] || [])];
-        }
+  return alternatives.reduce((acc, alternative) => {
+    if (!!alternative[alternativeType] && !ancestors.has(alternative)) {
+      return [...acc, ...(getSchemaAlternatives(alternative, ancestors)?.[0] || [])];
+    }
 
-        return [...acc, alternative];
-    }, [] as OpenAPIV3.SchemaObject[]);
+    return [...acc, alternative];
+  }, [] as OpenAPIV3.SchemaObject[]);
 }
 
 function getSchemaTitle(
-    schema: OpenAPIV3.SchemaObject,
+  schema: OpenAPIV3.SchemaObject,
 
-    /** If the title is inferred in a oneOf with discriminator, we can use it to optimize the title */
-    discriminator?: OpenAPIV3.DiscriminatorObject,
+  /** If the title is inferred in a oneOf with discriminator, we can use it to optimize the title */
+  discriminator?: OpenAPIV3.DiscriminatorObject,
 ): string {
-    if (schema.title) {
-        // If the schema has a title, use it
-        return schema.title;
+  if (schema.title) {
+    // If the schema has a title, use it
+    return schema.title;
+  }
+
+  // Try using the discriminator
+  if (discriminator?.propertyName && schema.properties) {
+    const discriminatorProperty = noReference(schema.properties[discriminator.propertyName]);
+    if (discriminatorProperty) {
+      if (discriminatorProperty.enum) {
+        return discriminatorProperty.enum.map((value) => value.toString()).join(' | ');
+      }
     }
+  }
 
-    // Try using the discriminator
-    if (discriminator?.propertyName && schema.properties) {
-        const discriminatorProperty = noReference(schema.properties[discriminator.propertyName]);
-        if (discriminatorProperty) {
-            if (discriminatorProperty.enum) {
-                return discriminatorProperty.enum.map((value) => value.toString()).join(' | ');
-            }
-        }
+  // Otherwise try to infer a nice title
+  let type = 'any';
+
+  if (schema.enum) {
+    type = 'enum';
+    // check array AND schema.items as this is sometimes null despite what the type indicates
+  } else if (schema.type === 'array' && !!schema.items) {
+    type = `array of ${getSchemaTitle(noReference(schema.items))}`;
+  } else if (schema.type || schema.properties) {
+    type = schema.type ?? 'object';
+
+    if (schema.format) {
+      type += ` (${schema.format})`;
     }
+  } else if ('anyOf' in schema) {
+    type = 'any of';
+  } else if ('oneOf' in schema) {
+    type = 'one of';
+  } else if ('allOf' in schema) {
+    type = 'all of';
+  } else if ('not' in schema) {
+    type = 'not';
+  }
 
-    // Otherwise try to infer a nice title
-    let type = 'any';
+  if (schema.nullable) {
+    type = `nullable ${type}`;
+  }
 
-    if (schema.enum) {
-        type = 'enum';
-        // check array AND schema.items as this is sometimes null despite what the type indicates
-    } else if (schema.type === 'array' && !!schema.items) {
-        type = `array of ${getSchemaTitle(noReference(schema.items))}`;
-    } else if (schema.type || schema.properties) {
-        type = schema.type ?? 'object';
-
-        if (schema.format) {
-            type += ` (${schema.format})`;
-        }
-    } else if ('anyOf' in schema) {
-        type = 'any of';
-    } else if ('oneOf' in schema) {
-        type = 'one of';
-    } else if ('allOf' in schema) {
-        type = 'all of';
-    } else if ('not' in schema) {
-        type = 'not';
-    }
-
-    if (schema.nullable) {
-        type = `nullable ${type}`;
-    }
-
-    return type;
+  return type;
 }

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -11,182 +11,182 @@ import { stringifyOpenAPI } from './stringifyOpenAPI';
 type CircularRefsIds = Map<OpenAPIV3.SchemaObject, string>;
 
 interface OpenAPISchemaPropertyEntry {
-  propertyName?: string;
-  required?: boolean;
-  schema: OpenAPIV3.SchemaObject;
+    propertyName?: string;
+    required?: boolean;
+    schema: OpenAPIV3.SchemaObject;
 }
 
 /**
  * Render a property of an OpenAPI schema.
  */
 export function OpenAPISchemaProperty(
-  props: OpenAPISchemaPropertyEntry & {
-    /** Set of objects already observed as parents */
-    circularRefs?: CircularRefsIds;
-    context: OpenAPIClientContext;
-    className?: string;
-  },
+    props: OpenAPISchemaPropertyEntry & {
+        /** Set of objects already observed as parents */
+        circularRefs?: CircularRefsIds;
+        context: OpenAPIClientContext;
+        className?: string;
+    },
 ) {
-  const {
-    propertyName,
-    required,
-    schema,
-    circularRefs: parentCircularRefs = new Map<OpenAPIV3.SchemaObject, string>(),
-    context,
-    className,
-  } = props;
+    const {
+        propertyName,
+        required,
+        schema,
+        circularRefs: parentCircularRefs = new Map<OpenAPIV3.SchemaObject, string>(),
+        context,
+        className,
+    } = props;
 
-  const id = useId();
+    const id = useId();
 
-  const parentCircularRef = parentCircularRefs.get(schema);
-  const circularRefs = new Map(parentCircularRefs).set(schema, id);
+    const parentCircularRef = parentCircularRefs.get(schema);
+    const circularRefs = new Map(parentCircularRefs).set(schema, id);
 
-  // Avoid recursing infinitely, and instead render a link to the parent schema
-  const properties = parentCircularRef ? null : getSchemaProperties(schema);
-  const alternatives = parentCircularRef
-    ? null
-    : getSchemaAlternatives(schema, new Set(circularRefs.keys()));
+    // Avoid recursing infinitely, and instead render a link to the parent schema
+    const properties = parentCircularRef ? null : getSchemaProperties(schema);
+    const alternatives = parentCircularRef
+        ? null
+        : getSchemaAlternatives(schema, new Set(circularRefs.keys()));
 
-  const shouldDisplayExample = (schema: OpenAPIV3.SchemaObject): boolean => {
+    const shouldDisplayExample = (schema: OpenAPIV3.SchemaObject): boolean => {
+        return (
+            typeof schema.example === 'string' ||
+            typeof schema.example === 'number' ||
+            typeof schema.example === 'boolean' ||
+            (Array.isArray(schema.example) && schema.example.length > 0) ||
+            (typeof schema.example === 'object' &&
+                schema.example !== null &&
+                Object.keys(schema.example).length > 0)
+        );
+    };
     return (
-      typeof schema.example === 'string' ||
-      typeof schema.example === 'number' ||
-      typeof schema.example === 'boolean' ||
-      (Array.isArray(schema.example) && schema.example.length > 0) ||
-      (typeof schema.example === 'object' &&
-        schema.example !== null &&
-        Object.keys(schema.example).length > 0)
+        <InteractiveSection
+            id={id}
+            className={classNames('openapi-schema', className)}
+            toggeable={!!properties || !!alternatives}
+            defaultOpened={!!context.defaultInteractiveOpened}
+            toggleOpenIcon={context.icons.chevronRight}
+            toggleCloseIcon={context.icons.chevronDown}
+            tabs={alternatives?.[0].map((alternative, index) => ({
+                key: `${index}`,
+                label: getSchemaTitle(alternative, alternatives[1]),
+                body: circularRefs.has(alternative) ? (
+                    <OpenAPISchemaCircularRef
+                        id={circularRefs.get(alternative)!}
+                        schema={alternative}
+                    />
+                ) : (
+                    <OpenAPISchemaAlternative
+                        schema={alternative}
+                        circularRefs={circularRefs}
+                        context={context}
+                    />
+                ),
+            }))}
+            header={
+                <div className={classNames('openapi-schema-presentation')}>
+                    <div className={classNames('openapi-schema-name')}>
+                        {propertyName ? (
+                            <span className={classNames('openapi-schema-propertyname')}>
+                                {propertyName}
+                            </span>
+                        ) : null}
+                        {required ? (
+                            <span className={classNames('openapi-schema-required')}>*</span>
+                        ) : null}
+                        <span className={classNames('openapi-schema-type')}>
+                            {getSchemaTitle(schema)}
+                        </span>
+                    </div>
+                    {schema.description ? (
+                        <Markdown
+                            source={schema.description}
+                            className="openapi-schema-description"
+                        />
+                    ) : null}
+                    {shouldDisplayExample(schema) ? (
+                        <div className="openapi-schema-example">
+                            Example: <code>{stringifyOpenAPI(schema.example)}</code>
+                        </div>
+                    ) : null}
+                    {schema.pattern ? (
+                        <div className="openapi-schema-pattern">
+                            Pattern: <code>{schema.pattern}</code>
+                        </div>
+                    ) : null}
+                </div>
+            }
+        >
+            {(properties && properties.length > 0) ||
+            (schema.enum && schema.enum.length > 0) ||
+            parentCircularRef ? (
+                <>
+                    {properties?.length ? (
+                        <OpenAPISchemaProperties
+                            properties={properties}
+                            circularRefs={circularRefs}
+                            context={context}
+                        />
+                    ) : null}
+                    {schema.enum && schema.enum.length > 0 ? (
+                        <OpenAPISchemaEnum enumValues={schema.enum} />
+                    ) : null}
+                    {parentCircularRef ? (
+                        <OpenAPISchemaCircularRef id={parentCircularRef} schema={schema} />
+                    ) : null}
+                </>
+            ) : null}
+        </InteractiveSection>
     );
-  };
-  return (
-    <InteractiveSection
-      id={id}
-      className={classNames('openapi-schema', className)}
-      toggeable={!!properties || !!alternatives}
-      defaultOpened={!!context.defaultInteractiveOpened}
-      toggleOpenIcon={context.icons.chevronRight}
-      toggleCloseIcon={context.icons.chevronDown}
-      tabs={alternatives?.[0].map((alternative, index) => ({
-        key: `${index}`,
-        label: getSchemaTitle(alternative, alternatives[1]),
-        body: circularRefs.has(alternative) ? (
-          <OpenAPISchemaCircularRef
-            id={circularRefs.get(alternative)!}
-            schema={alternative}
-          />
-        ) : (
-          <OpenAPISchemaAlternative
-            schema={alternative}
-            circularRefs={circularRefs}
-            context={context}
-          />
-        ),
-      }))}
-      header={
-        <div className={classNames('openapi-schema-presentation')}>
-          <div className={classNames('openapi-schema-name')}>
-            {propertyName ? (
-              <span className={classNames('openapi-schema-propertyname')}>
-                {propertyName}
-              </span>
-            ) : null}
-            {required ? (
-              <span className={classNames('openapi-schema-required')}>*</span>
-            ) : null}
-            <span className={classNames('openapi-schema-type')}>
-              {getSchemaTitle(schema)}
-            </span>
-          </div>
-          {schema.description ? (
-            <Markdown
-              source={schema.description}
-              className="openapi-schema-description"
-            />
-          ) : null}
-          {shouldDisplayExample(schema) ? (
-            <div className="openapi-schema-example">
-              Example: <code>{stringifyOpenAPI(schema.example)}</code>
-            </div>
-          ) : null}
-          {schema.pattern ? (
-            <div className="openapi-schema-pattern">
-              Pattern: <code>{schema.pattern}</code>
-            </div>
-          ) : null}
-        </div>
-      }
-    >
-      {(properties && properties.length > 0) ||
-        (schema.enum && schema.enum.length > 0) ||
-        parentCircularRef ? (
-        <>
-          {properties?.length ? (
-            <OpenAPISchemaProperties
-              properties={properties}
-              circularRefs={circularRefs}
-              context={context}
-            />
-          ) : null}
-          {schema.enum && schema.enum.length > 0 ? (
-            <OpenAPISchemaEnum enumValues={schema.enum} />
-          ) : null}
-          {parentCircularRef ? (
-            <OpenAPISchemaCircularRef id={parentCircularRef} schema={schema} />
-          ) : null}
-        </>
-      ) : null}
-    </InteractiveSection>
-  );
 }
 
 /**
  * Render a set of properties of an OpenAPI schema.
  */
 export function OpenAPISchemaProperties(props: {
-  id?: string;
-  properties: OpenAPISchemaPropertyEntry[];
-  circularRefs?: CircularRefsIds;
-  context: OpenAPIClientContext;
+    id?: string;
+    properties: OpenAPISchemaPropertyEntry[];
+    circularRefs?: CircularRefsIds;
+    context: OpenAPIClientContext;
 }) {
-  const { id, properties, circularRefs, context } = props;
+    const { id, properties, circularRefs, context } = props;
 
-  if (!properties.length) {
-    return null;
-  }
+    if (!properties.length) {
+        return null;
+    }
 
-  return (
-    <div id={id} className={classNames('openapi-schema-properties')}>
-      {properties.map((property) => (
-        <OpenAPISchemaProperty
-          key={property.propertyName}
-          circularRefs={circularRefs}
-          {...property}
-          context={context}
-        />
-      ))}
-    </div>
-  );
+    return (
+        <div id={id} className={classNames('openapi-schema-properties')}>
+            {properties.map((property) => (
+                <OpenAPISchemaProperty
+                    key={property.propertyName}
+                    circularRefs={circularRefs}
+                    {...property}
+                    context={context}
+                />
+            ))}
+        </div>
+    );
 }
 
 /**
  * Render a root schema (such as the request body or response body).
  */
 export function OpenAPIRootSchema(props: {
-  schema: OpenAPIV3.SchemaObject;
-  context: OpenAPIClientContext;
+    schema: OpenAPIV3.SchemaObject;
+    context: OpenAPIClientContext;
 }) {
-  const { schema, context } = props;
+    const { schema, context } = props;
 
-  // Avoid recursing infinitely, and instead render a link to the parent schema
-  const properties = getSchemaProperties(schema);
+    // Avoid recursing infinitely, and instead render a link to the parent schema
+    const properties = getSchemaProperties(schema);
 
-  if (properties && properties.length > 0) {
-    return <OpenAPISchemaProperties properties={properties} context={context} />;
-  }
+    if (properties && properties.length > 0) {
+        return <OpenAPISchemaProperties properties={properties} context={context} />;
+    }
 
-  return (
-    <OpenAPISchemaProperty schema={schema} context={context} className="openapi-schema-root" />
-  );
+    return (
+        <OpenAPISchemaProperty schema={schema} context={context} className="openapi-schema-root" />
+    );
 }
 
 /**
@@ -195,217 +195,225 @@ export function OpenAPIRootSchema(props: {
  * for primitives, it renders the schema itself.
  */
 function OpenAPISchemaAlternative(props: {
-  schema: OpenAPIV3.SchemaObject;
-  circularRefs?: CircularRefsIds;
-  context: OpenAPIClientContext;
+    schema: OpenAPIV3.SchemaObject;
+    circularRefs?: CircularRefsIds;
+    context: OpenAPIClientContext;
 }) {
-  const { schema, circularRefs, context } = props;
-  const id = useId();
-  const subProperties = getSchemaProperties(schema);
+    const { schema, circularRefs, context } = props;
+    const id = useId();
+    const subProperties = getSchemaProperties(schema);
 
-  return (
-    <OpenAPISchemaProperties
-      id={id}
-      properties={subProperties ?? [{ schema }]}
-      circularRefs={subProperties ? new Map(circularRefs).set(schema, id) : circularRefs}
-      context={context}
-    />
-  );
+    return (
+        <OpenAPISchemaProperties
+            id={id}
+            properties={subProperties ?? [{ schema }]}
+            circularRefs={subProperties ? new Map(circularRefs).set(schema, id) : circularRefs}
+            context={context}
+        />
+    );
 }
 
 /**
  * Render a circular reference to a schema.
  */
 function OpenAPISchemaCircularRef(props: { id: string; schema: OpenAPIV3.SchemaObject }) {
-  const { id, schema } = props;
+    const { id, schema } = props;
 
-  return (
-    <div className="openapi-schema-circular">
-      Circular reference to <a href={`#${id}`}>{getSchemaTitle(schema)}</a>{' '}
-      <span className="openapi-schema-circular-glyph">↩</span>
-    </div>
-  );
+    return (
+        <div className="openapi-schema-circular">
+            Circular reference to <a href={`#${id}`}>{getSchemaTitle(schema)}</a>{' '}
+            <span className="openapi-schema-circular-glyph">↩</span>
+        </div>
+    );
 }
 
 /**
  * Render the enum value for a schema.
  */
 export function OpenAPISchemaEnum(props: { enumValues: any[] }) {
-  const { enumValues } = props;
+    const { enumValues } = props;
 
-  return (
-    <div className="openapi-schema-enum">
-      {enumValues.map((value, index) => (
-        <span key={index} className="openapi-schema-enum-value">{`${value}`}</span>
-      ))}
-    </div>
-  );
+    return (
+        <div className="openapi-schema-enum">
+            {enumValues.map((value, index) => (
+                <span key={index} className="openapi-schema-enum-value">{`${value}`}</span>
+            ))}
+        </div>
+    );
 }
 
 /**
  * Get the sub-properties of a schema.
  */
 function getSchemaProperties(schema: OpenAPIV3.SchemaObject): null | OpenAPISchemaPropertyEntry[] {
-  if (schema.allOf) {
-    return schema.allOf.reduce((acc, subSchema) => {
-      const properties = getSchemaProperties(noReference(subSchema)) ?? [
-        {
-          schema: noReference(subSchema),
-        },
-      ];
-      return [...acc, ...properties];
-    }, [] as OpenAPISchemaPropertyEntry[]);
-  }
-
-  // check array AND schema.items as this is sometimes null despite what the type indicates
-  if (schema.type === 'array' && !!schema.items) {
-    const items = noReference(schema.items);
-    const itemProperties = getSchemaProperties(items);
-    if (itemProperties) {
-      return itemProperties;
+    if (schema.allOf) {
+        return schema.allOf.reduce((acc, subSchema) => {
+            const properties = getSchemaProperties(noReference(subSchema)) ?? [
+                {
+                    schema: noReference(subSchema),
+                },
+            ];
+            return [...acc, ...properties];
+        }, [] as OpenAPISchemaPropertyEntry[]);
     }
 
-    return [
-      {
-        propertyName: 'items',
-        schema: items,
-      },
-    ];
-  }
-
-  if (schema.type === 'object' || schema.properties) {
-    const result: OpenAPISchemaPropertyEntry[] = [];
-
-    if (schema.properties) {
-      Object.entries(schema.properties).forEach(([propertyName, rawPropertySchema]) => {
-        try {
-          const propertySchema = noReference(rawPropertySchema);
-          if (propertySchema.deprecated) {
-            return;
-          }
-
-          result.push({
-            propertyName,
-            required: Array.isArray(schema.required)
-              ? schema.required.includes(propertyName)
-              : undefined,
-            schema: propertySchema,
-          });
-        } catch (e) {
-          // handle any errors that might come from noReference
-          return;
+    // check array AND schema.items as this is sometimes null despite what the type indicates
+    if (schema.type === 'array' && !!schema.items) {
+        const items = noReference(schema.items);
+        const itemProperties = getSchemaProperties(items);
+        if (itemProperties) {
+            return itemProperties;
         }
-      });
+
+        return [
+            {
+                propertyName: 'items',
+                schema: items,
+            },
+        ];
     }
 
-    if (schema.additionalProperties) {
-      const additionalProperties = noReference(schema.additionalProperties);
+    if (schema.type === 'object' || schema.properties) {
+        const result: OpenAPISchemaPropertyEntry[] = [];
 
-      result.push({
-        propertyName: 'Other properties',
-        schema: additionalProperties === true ? {} : additionalProperties,
-      });
+        if (schema.properties) {
+            Object.entries(schema.properties).forEach(([propertyName, rawPropertySchema]) => {
+                try {
+                    const propertySchema = noReference(rawPropertySchema);
+                    if (propertySchema.deprecated) {
+                        return;
+                    }
+
+                    result.push({
+                        propertyName,
+                        required: Array.isArray(schema.required)
+                            ? schema.required.includes(propertyName)
+                            : undefined,
+                        schema: propertySchema,
+                    });
+                } catch (e) {
+                    // handle any errors that might come from noReference and display as "any" type
+                    result.push({
+                        propertyName,
+                        required: Array.isArray(schema.required)
+                            ? schema.required.includes(propertyName)
+                            : undefined,
+                        schema: { propertyName },
+                    });
+
+                    return;
+                }
+            });
+        }
+
+        if (schema.additionalProperties) {
+            const additionalProperties = noReference(schema.additionalProperties);
+
+            result.push({
+                propertyName: 'Other properties',
+                schema: additionalProperties === true ? {} : additionalProperties,
+            });
+        }
+
+        return result;
     }
 
-    return result;
-  }
-
-  return null;
+    return null;
 }
 
 /**
  * Get the alternatives to display for a schema.
  */
 export function getSchemaAlternatives(
-  schema: OpenAPIV3.SchemaObject,
-  ancestors: Set<OpenAPIV3.SchemaObject> = new Set(),
+    schema: OpenAPIV3.SchemaObject,
+    ancestors: Set<OpenAPIV3.SchemaObject> = new Set(),
 ): null | [OpenAPIV3.SchemaObject[], OpenAPIV3.DiscriminatorObject | undefined] {
-  const downAncestors = new Set(ancestors).add(schema);
+    const downAncestors = new Set(ancestors).add(schema);
 
-  if (schema.anyOf) {
-    return [
-      flattenAlternatives('anyOf', schema.anyOf.map(noReference), downAncestors),
-      noReference(schema.discriminator),
-    ];
-  }
+    if (schema.anyOf) {
+        return [
+            flattenAlternatives('anyOf', schema.anyOf.map(noReference), downAncestors),
+            noReference(schema.discriminator),
+        ];
+    }
 
-  if (schema.oneOf) {
-    return [
-      flattenAlternatives('oneOf', schema.oneOf.map(noReference), downAncestors),
-      noReference(schema.discriminator),
-    ];
-  }
+    if (schema.oneOf) {
+        return [
+            flattenAlternatives('oneOf', schema.oneOf.map(noReference), downAncestors),
+            noReference(schema.discriminator),
+        ];
+    }
 
-  if (schema.allOf) {
-    // allOf is managed in `getSchemaProperties`
+    if (schema.allOf) {
+        // allOf is managed in `getSchemaProperties`
+        return null;
+    }
+
     return null;
-  }
-
-  return null;
 }
 
 function flattenAlternatives(
-  alternativeType: 'oneOf' | 'allOf' | 'anyOf',
-  alternatives: OpenAPIV3.SchemaObject[],
-  ancestors: Set<OpenAPIV3.SchemaObject>,
+    alternativeType: 'oneOf' | 'allOf' | 'anyOf',
+    alternatives: OpenAPIV3.SchemaObject[],
+    ancestors: Set<OpenAPIV3.SchemaObject>,
 ): OpenAPIV3.SchemaObject[] {
-  return alternatives.reduce((acc, alternative) => {
-    if (!!alternative[alternativeType] && !ancestors.has(alternative)) {
-      return [...acc, ...(getSchemaAlternatives(alternative, ancestors)?.[0] || [])];
-    }
+    return alternatives.reduce((acc, alternative) => {
+        if (!!alternative[alternativeType] && !ancestors.has(alternative)) {
+            return [...acc, ...(getSchemaAlternatives(alternative, ancestors)?.[0] || [])];
+        }
 
-    return [...acc, alternative];
-  }, [] as OpenAPIV3.SchemaObject[]);
+        return [...acc, alternative];
+    }, [] as OpenAPIV3.SchemaObject[]);
 }
 
 function getSchemaTitle(
-  schema: OpenAPIV3.SchemaObject,
+    schema: OpenAPIV3.SchemaObject,
 
-  /** If the title is inferred in a oneOf with discriminator, we can use it to optimize the title */
-  discriminator?: OpenAPIV3.DiscriminatorObject,
+    /** If the title is inferred in a oneOf with discriminator, we can use it to optimize the title */
+    discriminator?: OpenAPIV3.DiscriminatorObject,
 ): string {
-  if (schema.title) {
-    // If the schema has a title, use it
-    return schema.title;
-  }
-
-  // Try using the discriminator
-  if (discriminator?.propertyName && schema.properties) {
-    const discriminatorProperty = noReference(schema.properties[discriminator.propertyName]);
-    if (discriminatorProperty) {
-      if (discriminatorProperty.enum) {
-        return discriminatorProperty.enum.map((value) => value.toString()).join(' | ');
-      }
+    if (schema.title) {
+        // If the schema has a title, use it
+        return schema.title;
     }
-  }
 
-  // Otherwise try to infer a nice title
-  let type = 'any';
-
-  if (schema.enum) {
-    type = 'enum';
-    // check array AND schema.items as this is sometimes null despite what the type indicates
-  } else if (schema.type === 'array' && !!schema.items) {
-    type = `array of ${getSchemaTitle(noReference(schema.items))}`;
-  } else if (schema.type || schema.properties) {
-    type = schema.type ?? 'object';
-
-    if (schema.format) {
-      type += ` (${schema.format})`;
+    // Try using the discriminator
+    if (discriminator?.propertyName && schema.properties) {
+        const discriminatorProperty = noReference(schema.properties[discriminator.propertyName]);
+        if (discriminatorProperty) {
+            if (discriminatorProperty.enum) {
+                return discriminatorProperty.enum.map((value) => value.toString()).join(' | ');
+            }
+        }
     }
-  } else if ('anyOf' in schema) {
-    type = 'any of';
-  } else if ('oneOf' in schema) {
-    type = 'one of';
-  } else if ('allOf' in schema) {
-    type = 'all of';
-  } else if ('not' in schema) {
-    type = 'not';
-  }
 
-  if (schema.nullable) {
-    type = `nullable ${type}`;
-  }
+    // Otherwise try to infer a nice title
+    let type = 'any';
 
-  return type;
+    if (schema.enum) {
+        type = 'enum';
+        // check array AND schema.items as this is sometimes null despite what the type indicates
+    } else if (schema.type === 'array' && !!schema.items) {
+        type = `array of ${getSchemaTitle(noReference(schema.items))}`;
+    } else if (schema.type || schema.properties) {
+        type = schema.type ?? 'object';
+
+        if (schema.format) {
+            type += ` (${schema.format})`;
+        }
+    } else if ('anyOf' in schema) {
+        type = 'any of';
+    } else if ('oneOf' in schema) {
+        type = 'one of';
+    } else if ('allOf' in schema) {
+        type = 'all of';
+    } else if ('not' in schema) {
+        type = 'not';
+    }
+
+    if (schema.nullable) {
+        type = `nullable ${type}`;
+    }
+
+    return type;
 }

--- a/packages/react-openapi/src/utils.ts
+++ b/packages/react-openapi/src/utils.ts
@@ -8,7 +8,7 @@ export function noReference<T>(input: T | OpenAPIV3.ReferenceObject): T {
     return input;
 }
 
-function checkIsReference(input: unknown): input is OpenAPIV3.ReferenceObject {
+export function checkIsReference(input: unknown): input is OpenAPIV3.ReferenceObject {
     return typeof input === 'object' && !!input && '$ref' in input;
 }
 


### PR DESCRIPTION
This catches errors from erroneous OpenAPI specs that contain unresolvable $refs. It returns the property name instead along with an undefined type to continue allowing the components to be rendered with the property.

Before this `operator` property was not shown at all (and resulted in a crash). This makes the property show as `any` instead like so:
<img width="586" alt="Screenshot 2025-02-05 at 09 49 17" src="https://github.com/user-attachments/assets/a236b4fb-f055-4650-98c2-d7a89346f20b" />

