### PR TITLE
Handle unresolved references in OpenAPI response'

### DIFF
--- a/packages/react-openapi/src/OpenAPIResponse.tsx
+++ b/packages/react-openapi/src/OpenAPIResponse.tsx
@@ -7,18 +7,6 @@ import { OpenAPIClientContext } from './types';
 import { InteractiveSection } from './InteractiveSection';
 import { Markdown } from './Markdown';
 
-const handleReferences = (
-    input: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined,
-): OpenAPIV3.SchemaObject => {
-    const isReference = checkIsReference(input);
-
-    if (isReference || input === undefined) {
-        return {};
-    }
-
-    return input;
-};
-
 /**
  * Display an interactive response body.
  */
@@ -81,4 +69,17 @@ export function OpenAPIResponse(props: {
             ) : null}
         </>
     );
+}
+
+function handleReferences(
+    input: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined,
+): OpenAPIV3.SchemaObject {
+    const isReference = checkIsReference(input);
+
+    if (isReference || input === undefined) {
+        // If we find a reference that wasn't resolved or needed to be resolved externally, do not try to render it
+        return {};
+    }
+
+    return input;
 }

--- a/packages/react-openapi/src/OpenAPIResponse.tsx
+++ b/packages/react-openapi/src/OpenAPIResponse.tsx
@@ -59,7 +59,7 @@ export function OpenAPIResponse(props: {
                             label: contentType,
                             body: (
                                 <OpenAPIRootSchema
-                                    schema={handleUnresolvedReference(mediaType.schema) ?? {}}
+                                    schema={handleUnresolvedReference(mediaType.schema)}
                                     context={context}
                                 />
                             ),

--- a/packages/react-openapi/src/OpenAPIResponse.tsx
+++ b/packages/react-openapi/src/OpenAPIResponse.tsx
@@ -77,7 +77,8 @@ function handleUnresolvedReference(
     const isReference = checkIsReference(input);
 
     if (isReference || input === undefined) {
-        // If we find a reference that wasn't resolved or needed to be resolved externally, do not try to render it
+        // If we find a reference that wasn't resolved or needed to be resolved externally, do not try to render it.
+        // Instead we render `any`
         return {};
     }
 

--- a/packages/react-openapi/src/OpenAPIResponse.tsx
+++ b/packages/react-openapi/src/OpenAPIResponse.tsx
@@ -59,7 +59,7 @@ export function OpenAPIResponse(props: {
                             label: contentType,
                             body: (
                                 <OpenAPIRootSchema
-                                    schema={handleReferences(mediaType.schema) ?? {}}
+                                    schema={handleUnresolvedReference(mediaType.schema) ?? {}}
                                     context={context}
                                 />
                             ),
@@ -71,7 +71,7 @@ export function OpenAPIResponse(props: {
     );
 }
 
-function handleReferences(
+function handleUnresolvedReference(
     input: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined,
 ): OpenAPIV3.SchemaObject {
     const isReference = checkIsReference(input);

--- a/packages/react-openapi/src/OpenAPIResponse.tsx
+++ b/packages/react-openapi/src/OpenAPIResponse.tsx
@@ -2,10 +2,22 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { OpenAPIV3 } from '@scalar/openapi-types';
 import { OpenAPIRootSchema, OpenAPISchemaProperties } from './OpenAPISchema';
-import { noReference } from './utils';
+import { checkIsReference, noReference } from './utils';
 import { OpenAPIClientContext } from './types';
 import { InteractiveSection } from './InteractiveSection';
 import { Markdown } from './Markdown';
+
+const handleReferences = (
+    input: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined,
+): OpenAPIV3.SchemaObject => {
+    const isReference = checkIsReference(input);
+
+    if (isReference || input === undefined) {
+        return {};
+    }
+
+    return input;
+};
 
 /**
  * Display an interactive response body.
@@ -59,7 +71,7 @@ export function OpenAPIResponse(props: {
                             label: contentType,
                             body: (
                                 <OpenAPIRootSchema
-                                    schema={noReference(mediaType.schema) ?? {}}
+                                    schema={handleReferences(mediaType.schema) ?? {}}
                                     context={context}
                                 />
                             ),

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -122,8 +122,8 @@ function handleUnresolvedReference(
     const isReference = checkIsReference(input?.value);
 
     if (isReference) {
-        // If we find a reference that wasn't resolved or needed to be resolved externally, don't try to render it
-        return null;
+        // If we find a reference that wasn't resolved or needed to be resolved externally, render out the URL
+        return { value: `See: ${input.value.$ref}` };
     }
 
     return input;

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -56,7 +56,7 @@ export function OpenAPIResponseExample(props: {
                 return null;
             }
 
-            const example: OpenAPIV3.ExampleObject | null = handleUnresolvedReference(
+            const example = handleUnresolvedReference(
                 (() => {
                     const { examples, example } = mediaTypeObject;
                     if (examples) {

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -116,12 +116,14 @@ export function OpenAPIResponseExample(props: {
     );
 }
 
-function handleUnresolvedReference(input: OpenAPIV3.ExampleObject | null): OpenAPIV3.ExampleObject {
+function handleUnresolvedReference(
+    input: OpenAPIV3.ExampleObject | null,
+): OpenAPIV3.ExampleObject | null {
     const isReference = checkIsReference(input?.value);
 
-    if (isReference || input === null) {
-        // If we find a reference that wasn't resolved or needed to be resolved externally, render an empty object
-        return { value: {} };
+    if (isReference) {
+        // If we find a reference that wasn't resolved or needed to be resolved externally, don't try to render it
+        return null;
     }
 
     return input;

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -3,7 +3,7 @@ import { InteractiveSection } from './InteractiveSection';
 import { OpenAPIOperationData } from './fetchOpenAPIOperation';
 import { generateSchemaExample } from './generateSchemaExample';
 import { OpenAPIContextProps } from './types';
-import { createStateKey, noReference } from './utils';
+import { checkIsReference, createStateKey, noReference } from './utils';
 import { stringifyOpenAPI } from './stringifyOpenAPI';
 import { OpenAPIV3 } from '@scalar/openapi-types';
 
@@ -56,7 +56,7 @@ export function OpenAPIResponseExample(props: {
                 return null;
             }
 
-            const example: OpenAPIV3.ExampleObject | null = noReference(
+            const example: OpenAPIV3.ExampleObject | null = handleUnresolvedReference(
                 (() => {
                     const { examples, example } = mediaTypeObject;
                     if (examples) {
@@ -114,4 +114,15 @@ export function OpenAPIResponseExample(props: {
             tabs={examples}
         />
     );
+}
+
+function handleUnresolvedReference(input: OpenAPIV3.ExampleObject | null): OpenAPIV3.ExampleObject {
+    const isReference = checkIsReference(input?.value);
+
+    if (isReference || input === null) {
+        // If we find a reference that wasn't resolved or needed to be resolved externally, render an empty object
+        return { value: {} };
+    }
+
+    return input;
 }

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -123,7 +123,7 @@ function handleUnresolvedReference(
 
     if (isReference) {
         // If we find a reference that wasn't resolved or needed to be resolved externally, render out the URL
-        return { value: `See: ${input.value.$ref}` };
+        return { value: input.value.$ref };
     }
 
     return input;


### PR DESCRIPTION
This handles unresolved references passed to the body in an OpenAPI response by returning an empty object instead of a crash.

Renders any for the type instead:

<img width="942" alt="Screenshot 2025-02-06 at 01 34 52" src="https://github.com/user-attachments/assets/d8278b41-fe61-4b07-92ea-ac70395ff352" />
