### PR TITLE
Fix URL resolution in Site Sections for Ask

### DIFF
--- a/.changeset/curvy-pets-brush.md
+++ b/.changeset/curvy-pets-brush.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix site section URL resolution in Ask AI sources

--- a/packages/gitbook/src/components/Search/SearchAskAnswer.tsx
+++ b/packages/gitbook/src/components/Search/SearchAskAnswer.tsx
@@ -52,7 +52,7 @@ export function SearchAskAnswer(props: { pointer: SiteContentPointer; query: str
                 query,
             });
 
-            const response = streamAskQuestion(organizationId, siteId, siteSpaceId ?? null, query);
+            const response = streamAskQuestion({ pointer, question: query });
             const stream = iterateStreamResponse(response);
 
             // When we pass in "ask" mode, the query could still be updated by the client

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -82,7 +82,7 @@ async function searchSiteContent(args: {
     ]);
     const siteStructure = siteData?.structure;
 
-    const siteSpaces = siteStructure ? getSiteStructureSiteSpaces(siteStructure) : null;
+    const siteSpaces = siteStructure ? extractSiteStructureSiteSpaces(siteStructure) : null;
 
     if (siteSpaces) {
         // We are searching all of this Site's content
@@ -160,7 +160,9 @@ export const streamAskQuestion = streamResponse(async function* ({
 }) {
     const { organizationId, siteId, siteSpaceId } = pointer;
     const [apiCtx, siteData] = await Promise.all([api.api(), api.getSiteData(pointer)]);
-    const siteSpaces = siteData?.structure ? getSiteStructureSiteSpaces(siteData.structure) : null;
+    const siteSpaces = siteData?.structure
+        ? extractSiteStructureSiteSpaces(siteData.structure)
+        : null;
 
     const stream = apiCtx.client.orgs.streamAskInSite(
         organizationId,
@@ -264,7 +266,7 @@ async function transformAnswer({
                     return null;
                 }
 
-                // Find the siteSpace in site spaces in case it is nested in a site section so we can resolve the URL appropriately
+                // Find the siteSpace in case it is nested in a site section so we can resolve the URL appropriately
                 const spaceURL = siteSpaces?.find(
                     (siteSpace) => siteSpace.space.id === source.space,
                 )?.urls.published;
@@ -368,7 +370,7 @@ async function getURLWithSections(path: string, spaceURL?: string) {
 /*
  * Gets all site spaces, in a site structure and overrides the title
  */
-function getSiteStructureSiteSpaces(siteStructure: SiteStructure) {
+function extractSiteStructureSiteSpaces(siteStructure: SiteStructure) {
     return siteStructure.type === 'siteSpaces'
         ? siteStructure.structure
         : getSiteStructureSections(siteStructure).reduce<SiteSpace[]>((prev, section) => {

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -265,16 +265,13 @@ async function transformAnswer({
                 }
 
                 // Find the siteSpace in site spaces in case it is nested in a site section so we can resolve the URL appropriately
-                const siteSpace = siteSpaces?.find(
+                const spaceURL = siteSpaces?.find(
                     (siteSpace) => siteSpace.space.id === source.space,
-                );
-
-                const spaceURL = siteSpace?.urls.published;
+                )?.urls.published;
 
                 const href = spaceURL
                     ? await getURLWithSections(page.page.path, spaceURL)
                     : await getPageHref(pages, page.page);
-                console.log('SPACE', source.space, spaceURL);
 
                 return {
                     id: source.page,

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -1,6 +1,13 @@
 'use server';
 
-import { RevisionPage, SearchAIAnswer, SearchPageResult, SiteSpace, Space } from '@gitbook/api';
+import {
+    RevisionPage,
+    SearchAIAnswer,
+    SearchPageResult,
+    SiteSpace,
+    SiteStructure,
+    Space,
+} from '@gitbook/api';
 import * as React from 'react';
 import { assert } from 'ts-essentials';
 
@@ -75,22 +82,7 @@ async function searchSiteContent(args: {
     ]);
     const siteStructure = siteData?.structure;
 
-    const siteSpaces = siteStructure
-        ? siteStructure.type === 'siteSpaces'
-            ? siteStructure.structure
-            : getSiteStructureSections(siteStructure).reduce<SiteSpace[]>((prev, section) => {
-                  const sectionSiteSpaces = section.siteSpaces.map((siteSpace) => ({
-                      ...siteSpace,
-                      space: {
-                          ...siteSpace.space,
-                          title: section.title || siteSpace.space.title,
-                      },
-                  }));
-
-                  prev.push(...sectionSiteSpaces);
-                  return prev;
-              }, [])
-        : null;
+    const siteSpaces = siteStructure ? getSiteStructureSiteSpaces(siteStructure) : null;
 
     if (siteSpaces) {
         // We are searching all of this Site's content
@@ -159,13 +151,17 @@ export async function searchSiteSpaceContent(
 /**
  * Server action to ask a question in a space.
  */
-export const streamAskQuestion = streamResponse(async function* (
-    organizationId: string,
-    siteId: string,
-    siteSpaceId: string | null,
-    question: string,
-) {
-    const apiCtx = await api.api();
+export const streamAskQuestion = streamResponse(async function* ({
+    pointer,
+    question,
+}: {
+    pointer: api.SiteContentPointer;
+    question: string;
+}) {
+    const { organizationId, siteId, siteSpaceId } = pointer;
+    const [apiCtx, siteData] = await Promise.all([api.api(), api.getSiteData(pointer)]);
+    const siteSpaces = siteData?.structure ? getSiteStructureSiteSpaces(siteData.structure) : null;
+
     const stream = apiCtx.client.orgs.streamAskInSite(
         organizationId,
         siteId,
@@ -222,7 +218,7 @@ export const streamAskQuestion = streamResponse(async function* (
                 return map;
             }, new Map<string, RevisionPage[]>());
         });
-        yield await transformAnswer(chunk.answer, pages);
+        yield await transformAnswer({ answer: chunk.answer, spacePages: pages, siteSpaces });
     }
 });
 
@@ -237,15 +233,19 @@ export const streamRecommendedQuestions = streamResponse(async function* (
     const stream = apiCtx.client.orgs.streamRecommendedQuestionsInSite(organizationId, siteId);
 
     for await (const chunk of stream) {
-        console.log('got question', chunk);
         yield chunk;
     }
 });
 
-async function transformAnswer(
-    answer: SearchAIAnswer,
-    spacePages: Map<string, RevisionPage[]>,
-): Promise<AskAnswerResult> {
+async function transformAnswer({
+    answer,
+    spacePages,
+    siteSpaces,
+}: {
+    answer: SearchAIAnswer;
+    spacePages: Map<string, RevisionPage[]>;
+    siteSpaces: SiteSpace[] | null;
+}): Promise<AskAnswerResult> {
     const sources = (
         await Promise.all(
             answer.sources.map(async (source) => {
@@ -264,10 +264,22 @@ async function transformAnswer(
                     return null;
                 }
 
+                // Find the siteSpace in site spaces in case it is nested in a site section so we can resolve the URL appropriately
+                const siteSpace = siteSpaces?.find(
+                    (siteSpace) => siteSpace.space.id === source.space,
+                );
+
+                const spaceURL = siteSpace?.urls.published;
+
+                const href = spaceURL
+                    ? await getURLWithSections(page.page.path, spaceURL)
+                    : await getPageHref(pages, page.page);
+                console.log('SPACE', source.space, spaceURL);
+
                 return {
                     id: source.page,
                     title: page.page.title,
-                    href: await getPageHref(pages, page.page),
+                    href,
                 };
             }),
         )
@@ -299,28 +311,12 @@ async function transformSectionsAndPage(args: {
 }): Promise<[ComputedPageResult, ComputedSectionResult[]]> {
     const { item, space, spaceURL } = args;
 
-    // Resolve a relative path to an absolute URL
-    // if the search result is relative to another space, we use the space URL
-    const getURL = async (path: string, spaceURL?: string) => {
-        if (spaceURL) {
-            if (!spaceURL.endsWith('/')) {
-                spaceURL += '/';
-            }
-            if (path.startsWith('/')) {
-                path = path.slice(1);
-            }
-            return spaceURL + path;
-        } else {
-            return getAbsoluteHref(path);
-        }
-    };
-
     const sections = await Promise.all(
         item.sections?.map<Promise<ComputedSectionResult>>(async (section) => ({
             type: 'section',
             id: item.id + '/' + section.id,
             title: section.title,
-            href: await getURL(section.path, spaceURL),
+            href: await getURLWithSections(section.path, spaceURL),
             body: section.body,
         })) ?? [],
     );
@@ -329,7 +325,7 @@ async function transformSectionsAndPage(args: {
         type: 'page',
         id: item.id,
         title: item.title,
-        href: await getURL(item.path, spaceURL),
+        href: await getURLWithSections(item.path, spaceURL),
         spaceTitle: space?.title,
     };
 
@@ -354,4 +350,40 @@ async function transformPageResult(item: SearchPageResult, space?: Space) {
     });
 
     return [page, ...sections];
+}
+
+// Resolve a relative path to an absolute URL
+// if the search result is relative to another space, we use the space URL
+async function getURLWithSections(path: string, spaceURL?: string) {
+    if (spaceURL) {
+        if (!spaceURL.endsWith('/')) {
+            spaceURL += '/';
+        }
+        if (path.startsWith('/')) {
+            path = path.slice(1);
+        }
+        return spaceURL + path;
+    } else {
+        return getAbsoluteHref(path);
+    }
+}
+
+/*
+ * Gets all site spaces, in a site structure and overrides the title
+ */
+function getSiteStructureSiteSpaces(siteStructure: SiteStructure) {
+    return siteStructure.type === 'siteSpaces'
+        ? siteStructure.structure
+        : getSiteStructureSections(siteStructure).reduce<SiteSpace[]>((prev, section) => {
+              const sectionSiteSpaces = section.siteSpaces.map((siteSpace) => ({
+                  ...siteSpace,
+                  space: {
+                      ...siteSpace.space,
+                      title: section.title || siteSpace.space.title,
+                  },
+              }));
+
+              prev.push(...sectionSiteSpaces);
+              return prev;
+          }, []);
 }


### PR DESCRIPTION
Fixes the resolution of URLs when sources, in Ask AI, are under a different site section.

This was a bug with site sections where we were not querying the site structure for information on which section a page belongs to in the Sources section of Ask AI (pictured below). This resulted in an issue where it would default to whatever current section the visitor happened to be in when asking and a 404.

This fixes it by querying the site structure and looking up the proper published url that includes the site section path.
Before it would resolve to something like this:
https://docs.gitbook.com/published-documentation/whats-the-difference-between-a-space-and-a-docs-site
Now it properly includes the section slug in the path:
https://docs.gitbook.com/help-center/published-documentation/publishing/whats-the-difference-between-a-space-and-a-docs-site

The sources section where the URL is fixed (in the Ask AI modal):
<img width="730" alt="Screenshot 2025-02-12 at 11 40 38" src="https://github.com/user-attachments/assets/3d6d1dc1-ae56-480a-94f9-82c49a6d55a7" />
