### PR TITLE
Change card layout depending on cover aspect ratio

### DIFF
--- a/.changeset/shy-books-tease.md
+++ b/.changeset/shy-books-tease.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Change card layout depending on cover aspect ratio

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -42,12 +42,17 @@ export async function RecordCard(
                 'rounded-[7px]',
                 'straight-corners:rounded-none',
                 'overflow-hidden',
-                '[&_.heading]:flip-heading-hash',
+                '[&_.heading>div:first-child]:hidden',
+                '[&_.heading>div]:text-[.8em]',
+                'md:[&_.heading>div]:text-[1em]',
                 '[&_.blocks:first-child_.heading:first-child_div]:mt-0', // Remove margin on first heading in card
 
-                cover
+                // On mobile, check if we can display the cover responsively or not:
+                // - If the file has a landscape aspect ratio, we display it normally
+                // - If the file is square or portrait, we display it left with 40% of the card width
+                cover?.file?.dimensions &&
+                    cover.file?.dimensions?.width / cover.file?.dimensions?.height <= 1
                     ? [
-                          // On mobile, the cover is displayed on the left with 40% of the width
                           'grid-cols-[40%,_1fr]',
                           'min-[432px]:grid-cols-none',
                           'min-[432px]:grid-rows-[auto,1fr]',

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -28,6 +28,10 @@ export async function RecordCard(
         : null;
     const target = targetRef ? await context.resolveContentRef(targetRef) : null;
 
+    const coverIsLandscape =
+        cover?.file?.dimensions &&
+        cover.file?.dimensions?.width / cover.file?.dimensions?.height > 1;
+
     const body = (
         <div
             className={tcls(
@@ -50,14 +54,13 @@ export async function RecordCard(
                 // On mobile, check if we can display the cover responsively or not:
                 // - If the file has a landscape aspect ratio, we display it normally
                 // - If the file is square or portrait, we display it left with 40% of the card width
-                cover?.file?.dimensions &&
-                    cover.file?.dimensions?.width / cover.file?.dimensions?.height <= 1
-                    ? [
+                coverIsLandscape
+                    ? 'grid-rows-[auto,1fr]'
+                    : [
                           'grid-cols-[40%,_1fr]',
                           'min-[432px]:grid-cols-none',
                           'min-[432px]:grid-rows-[auto,1fr]',
-                      ]
-                    : 'grid-rows-[auto,1fr]',
+                      ],
             )}
         >
             {cover ? (
@@ -79,8 +82,9 @@ export async function RecordCard(
                         'w-full',
                         'h-full',
                         'object-cover',
-                        'min-[432px]:h-auto',
-                        'min-[432px]:aspect-video',
+                        coverIsLandscape
+                            ? ['h-auto', 'aspect-video']
+                            : ['min-[432px]:h-auto', 'min-[432px]:aspect-video'],
                     )}
                     priority={isOffscreen ? 'lazy' : 'high'}
                     preload

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -57,7 +57,7 @@ export async function RecordCard(
                           'min-[432px]:grid-cols-none',
                           'min-[432px]:grid-rows-[auto,1fr]',
                       ]
-                    : null,
+                    : 'grid-rows-[auto,1fr]',
             )}
         >
             {cover ? (


### PR DESCRIPTION
Cards on GBO have a different aspect ratio on mobile vs desktop. This is sometimes welcome as it decreases the size of each card, but doesn't work with all images, especially when users upload a landscape image for the card they see in the editor.

Instead of always doing one of the two, we'll be a bit smarter about it and only show the alternative layout on mobile if the image actually lends itself to it.
- If the file has a landscape aspect ratio, we display it the same on mobile as on desktop: with the cover on top.
- If the file is square or portrait, we display the cover on the left with 40% of the card width.

## Before (and layout for square + portrait)
<img width="484" alt="Screenshot 2025-02-12 at 15 54 58" src="https://github.com/user-attachments/assets/51c0f2f9-cd6f-453b-a0e0-b22ed2eeac56" />

## After (layout for landscape)
<img width="484" alt="Screenshot 2025-02-12 at 15 55 03" src="https://github.com/user-attachments/assets/65cd4360-4a9c-4c64-a96f-55d5b53394a7" />
