### PR TITLE
Improvements to inline images in headings

### DIFF
--- a/.changeset/lazy-seas-drop.md
+++ b/.changeset/lazy-seas-drop.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Improvements to inline images in headings

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -64,7 +64,16 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
                     />
                 </a>
             </div>
-            <div className={tcls('grid-area-1-1', 'z-[1]', textStyle.marginTop)}>
+            <div
+                className={tcls(
+                    'grid-area-1-1',
+                    'z-[1]',
+                    'justify-self-start',
+                    'text-left',
+                    textStyle.lineHeight,
+                    textStyle.marginTop,
+                )}
+            >
                 <Inlines {...rest} context={context} nodes={block.nodes} ancestorInlines={[]} />
             </div>
         </Tag>

--- a/packages/gitbook/src/components/DocumentView/InlineImage.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineImage.tsx
@@ -48,7 +48,7 @@ export async function InlineImage(props: InlineProps<DocumentInlineImage>) {
                 }}
                 priority="lazy"
                 preload
-                style={[size === 'line' ? ['max-h-[1.1em]', 'h-[1.1em]', 'mb-[.1em]', 'w-auto'] : null]}
+                style={[size === 'line' ? ['max-h-[1lh]', 'h-[1lh]', 'w-auto'] : null]}
                 inline
                 zoom={!isInLink}
             />

--- a/packages/gitbook/src/components/DocumentView/InlineImage.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineImage.tsx
@@ -48,7 +48,7 @@ export async function InlineImage(props: InlineProps<DocumentInlineImage>) {
                 }}
                 priority="lazy"
                 preload
-                style={[size === 'line' ? ['max-h-[1em]', 'h-[1em]', 'mb-[.1em]', 'w-auto'] : null]}
+                style={[size === 'line' ? ['max-h-[1.1em]', 'h-[1.1em]', 'mb-[.1em]', 'w-auto'] : null]}
                 inline
                 zoom={!isInLink}
             />

--- a/packages/gitbook/src/components/DocumentView/InlineImage.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineImage.tsx
@@ -48,7 +48,7 @@ export async function InlineImage(props: InlineProps<DocumentInlineImage>) {
                 }}
                 priority="lazy"
                 preload
-                style={[size === 'line' ? ['max-h-[1lh]', 'h-[1lh]', 'w-auto'] : null]}
+                style={[size === 'line' ? ['max-h-[1.1em]', 'h-[1.1em]', 'w-auto'] : null]}
                 inline
                 zoom={!isInLink}
             />

--- a/packages/gitbook/src/components/DocumentView/InlineImage.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineImage.tsx
@@ -48,7 +48,7 @@ export async function InlineImage(props: InlineProps<DocumentInlineImage>) {
                 }}
                 priority="lazy"
                 preload
-                style={[size === 'line' ? ['max-h-[1.1em]', 'h-[1.1em]', 'w-auto'] : null]}
+                style={[size === 'line' ? ['max-h-[1em]', 'h-[1em]', 'mb-[.1em]', 'w-auto'] : null]}
                 inline
                 zoom={!isInLink}
             />


### PR DESCRIPTION
Fixes the following issues:
- Text with inline images in it unexpectedly gets centered
- Headings don't inherit the line height set on them
- Inline images set to `line` size are displayed a bit too big in relation to the line.