### PR TITLE
Fix card layout for cards without cover

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -54,13 +54,15 @@ export async function RecordCard(
                 // On mobile, check if we can display the cover responsively or not:
                 // - If the file has a landscape aspect ratio, we display it normally
                 // - If the file is square or portrait, we display it left with 40% of the card width
-                coverIsLandscape
-                    ? 'grid-rows-[auto,1fr]'
-                    : [
-                          'grid-cols-[40%,_1fr]',
-                          'min-[432px]:grid-cols-none',
-                          'min-[432px]:grid-rows-[auto,1fr]',
-                      ],
+                cover
+                    ? coverIsLandscape
+                        ? 'grid-rows-[auto,1fr]'
+                        : [
+                              'grid-cols-[40%,_1fr]',
+                              'min-[432px]:grid-cols-none',
+                              'min-[432px]:grid-rows-[auto,1fr]',
+                          ]
+                    : null,
             )}
         >
             {cover ? (


### PR DESCRIPTION
I accidentally broke card layouts without covers, here's a fix
<img width="543" alt="Screenshot 2025-02-13 at 14 30 11" src="https://github.com/user-attachments/assets/60526a27-197c-4aaa-a1b3-55b4383f7582" />
<img width="547" alt="Screenshot 2025-02-13 at 14 30 18" src="https://github.com/user-attachments/assets/5cc165c4-02c8-4741-8426-1f84f697fb7e" />
