### PR TITLE
Flip card logic

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -30,7 +30,7 @@ export async function RecordCard(
 
     const coverIsSquareOrPortrait =
         cover?.file?.dimensions &&
-        cover.file?.dimensions?.width / cover.file?.dimensions?.height < 1;
+        cover.file?.dimensions?.width / cover.file?.dimensions?.height <= 1;
 
     const body = (
         <div

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -28,9 +28,9 @@ export async function RecordCard(
         : null;
     const target = targetRef ? await context.resolveContentRef(targetRef) : null;
 
-    const coverIsLandscape =
+    const coverIsSquareOrPortrait =
         cover?.file?.dimensions &&
-        cover.file?.dimensions?.width / cover.file?.dimensions?.height > 1;
+        cover.file?.dimensions?.width / cover.file?.dimensions?.height < 1;
 
     const body = (
         <div
@@ -54,15 +54,13 @@ export async function RecordCard(
                 // On mobile, check if we can display the cover responsively or not:
                 // - If the file has a landscape aspect ratio, we display it normally
                 // - If the file is square or portrait, we display it left with 40% of the card width
-                cover
-                    ? coverIsLandscape
-                        ? 'grid-rows-[auto,1fr]'
-                        : [
-                              'grid-cols-[40%,_1fr]',
-                              'min-[432px]:grid-cols-none',
-                              'min-[432px]:grid-rows-[auto,1fr]',
-                          ]
-                    : null,
+                coverIsSquareOrPortrait
+                    ? [
+                          'grid-cols-[40%,_1fr]',
+                          'min-[432px]:grid-cols-none',
+                          'min-[432px]:grid-rows-[auto,1fr]',
+                      ]
+                    : 'grid-rows-[auto,1fr]',
             )}
         >
             {cover ? (
@@ -84,9 +82,9 @@ export async function RecordCard(
                         'w-full',
                         'h-full',
                         'object-cover',
-                        coverIsLandscape
-                            ? ['h-auto', 'aspect-video']
-                            : ['min-[432px]:h-auto', 'min-[432px]:aspect-video'],
+                        coverIsSquareOrPortrait
+                            ? ['min-[432px]:h-auto', 'min-[432px]:aspect-video']
+                            : ['h-auto', 'aspect-video'],
                     )}
                     priority={isOffscreen ? 'lazy' : 'high'}
                     preload


### PR DESCRIPTION
From `coverIsLandscape` to the more specific `coverIsSquareOrPortrait`, which means our default can be more sensible. This fixes some bugs where `cover` values are `undefined`. Now we will only render the alternative card layout if we are certain we should, and we fall back to the normal layout.