### PR TITLE
Update hint block

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -24,6 +24,7 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
         >
             <div
                 className={tcls(
+                    'hash',
                     'grid',
                     'grid-area-1-1',
                     'relative',
@@ -41,20 +42,14 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
                 <a
                     href={`#${id}`}
                     aria-label="Direct link to heading"
-                    className={tcls(
-                        'inline-flex',
-                        'h-full',
-                        'items-start',
-                        'dark:shadow-none',
-                        'dark:ring-0',
-                        textStyle.lineHeight,
-                    )}
+                    className={tcls('inline-flex', 'h-full', 'items-start', textStyle.lineHeight)}
                 >
                     <Icon
                         icon="hashtag"
                         className={tcls(
                             'w-3.5',
-                            'h-[1lh]',
+                            'h-[1em]',
+                            'mt-px',
                             'transition-colors',
                             'text-transparent',
                             'group-hover:text-tint-subtle',

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -1,54 +1,87 @@
-import { DocumentBlockHint } from '@gitbook/api';
+import { DocumentBlockHeading, DocumentBlockHint } from '@gitbook/api';
 import { Icon, IconName } from '@gitbook/icons';
 import React from 'react';
 
 import { ClassValue, tcls } from '@/lib/tailwind';
 
-import { BlockProps } from './Block';
+import { Block, BlockProps } from './Block';
 import { Blocks } from './Blocks';
+import { Heading } from './Heading';
 import { getBlockTextStyle } from './spacing';
+
+const headingTypes = new Set<DocumentBlockHeading['type']>();
 
 export function Hint(props: BlockProps<DocumentBlockHint>) {
     const { block, style, ancestorBlocks, ...contextProps } = props;
     const hintStyle = HINT_STYLES[block.data.style] ?? HINT_STYLES.info;
     const firstLine = getBlockTextStyle(block.nodes[0]);
 
+    const firstNode = block.nodes[0];
+    const hasHeading = ['heading-1', 'heading-2', 'heading-3'].includes(block.nodes[0].type);
+
     return (
         <div
             className={tcls(
                 'hint',
-                'p-4',
                 'transition-colors',
                 'rounded-md',
+                hasHeading ? 'rounded-l' : null,
                 'straight-corners:rounded-none',
+                'overflow-hidden',
+                hasHeading ? ['border-l-2', hintStyle.containerWithHeader] : hintStyle.container,
+
                 'text-sm',
-                hintStyle.style,
+
+                'grid',
+                'grid-cols-[auto_1fr]',
+                hasHeading ? 'grid-rows-[auto_auto]' : '',
+
                 style,
             )}
         >
-            <div className={tcls('flex', 'flex-row')}>
+            <div
+                className={tcls(
+                    'py-3',
+                    'pl-3',
+                    hasHeading ? hintStyle.header : null,
+                    hintStyle.iconColor,
+                )}
+            >
                 <Icon
                     icon={hintStyle.icon}
-                    className={tcls(
-                        'size-4',
-                        'mr-3',
-                        'mt-0.5',
-                        firstLine.lineHeight,
-                        hintStyle.iconColor,
-                    )}
-                />
-                <Blocks
-                    {...contextProps}
-                    ancestorBlocks={[...ancestorBlocks, block]}
-                    nodes={block.nodes}
-                    blockStyle={tcls(
-                        hintStyle.bodyColor,
-                        // render hash icon on the other side of the heading
-                        'flip-heading-hash',
-                    )}
-                    style={['flex-1', 'space-y-4', '[&_.hint]:border', '[&_pre]:border']}
+                    className={tcls('size-[1.2em]', 'mt-0.5', firstLine.lineHeight)}
                 />
             </div>
+            {hasHeading ? (
+                <Block
+                    style={tcls(
+                        'text-[1em] *:mt-0 p-3 flip-heading-hash',
+                        hasHeading ? hintStyle.header : null,
+                    )}
+                    ancestorBlocks={[...ancestorBlocks, block]}
+                    {...contextProps}
+                    block={firstNode}
+                />
+            ) : null}
+            <Blocks
+                {...contextProps}
+                ancestorBlocks={[...ancestorBlocks, block]}
+                nodes={hasHeading ? block.nodes.slice(1) : block.nodes}
+                blockStyle={tcls(
+                    hintStyle.body,
+                    // render hash icon on the other side of the heading
+                    'flip-heading-hash',
+                )}
+                style={[
+                    'p-3',
+                    '-row-end-1',
+                    '-col-end-1',
+                    'space-y-4',
+                    '[&_.hint]:border',
+                    '[&_pre]:border',
+                    '[&_pre]:border-neutral',
+                ]}
+            />
         </div>
     );
 }
@@ -56,89 +89,67 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
 const HINT_STYLES: {
     [style in DocumentBlockHint['data']['style']]: {
         icon: IconName;
-        iconColor: ClassValue;
-        bodyColor: ClassValue;
-        style: ClassValue;
+        iconColor?: ClassValue;
+        body?: ClassValue;
+        header?: ClassValue;
+        container?: ClassValue;
+        containerWithHeader?: ClassValue;
     };
 } = {
     info: {
         icon: 'circle-info',
-        iconColor: ['text-blue-500', 'dark:text-blue-400'],
-        bodyColor: [
-            'text-blue-950',
-            'dark:text-blue-50',
-            '[&_a]:text-blue-800',
-            '[&_a:hover]:text-blue-900',
-            'dark:[&_a]:text-blue-400',
-            'dark:[&_a:hover]:text-blue-300',
-            '[&_.can-override-bg]:bg-blue-500/3',
-            '[&_.can-override-text]:text-blue-800',
-            'dark:[&_.can-override-text]:text-blue-400',
-            'decoration-blue-800/6',
-            'dark:decoration-blue-400/6',
+        iconColor: 'text-info-subtle',
+        header: 'bg-info-active',
+        body: [
+            '[&_.can-override-bg]:bg-neutral-active',
+            '[&_.can-override-text]:text-neutral-strong',
         ],
-        style: [
-            'bg-tint',
-            'print-mode:!bg-tint',
-            'theme-muted:bg-tint-base',
-            'theme-bold-tint:bg-tint-base',
-            'theme-gradient:bg-tint-12/1',
-            'border-tint',
-            '[&_.can-override-bg]:bg-tint-active',
-            '[&_.can-override-text]:text-tint-strong',
-        ],
+        container: 'bg-neutral theme-gradient:bg-neutral-12/1 border-neutral',
+        containerWithHeader: 'border-info-solid bg-neutral-subtle theme-gradient:bg-neutral-12/1',
     },
     warning: {
         icon: 'circle-exclamation',
-        iconColor: ['text-amber-500', 'dark:text-orange-400'], // Darker shades of orange-* mismatch with lighter shades, so in light mode we use amber text on top of orange bg.
-        bodyColor: [
-            'text-orange-950',
-            'dark:text-orange-50',
-            '[&_a]:text-orange-800',
-            '[&_a:hover]:text-orange-900',
-            'dark:[&_a]:text-orange-400',
-            'dark:[&_a:hover]:text-orange-300',
-            '[&_.can-override-bg]:bg-orange-500/3',
-            '[&_.can-override-text]:text-orange-800',
-            'dark:[&_.can-override-text]:text-orange-400',
-            'decoration-orange-800/6',
-            'dark:decoration-orange-400/6',
+        iconColor: 'text-warning-subtle',
+        header: 'bg-warning-active',
+        body: [
+            // 'text-warning-strong',
+            '[&_a]:text-warning',
+            '[&_a:hover]:text-warning-strong',
+            '[&_.can-override-bg]:bg-warning-active',
+            '[&_.can-override-text]:text-warning-strong',
+            'decoration-warning/6',
         ],
-        style: ['bg-orange-500/2', 'border-orange-500/4'],
+        container: 'bg-warning border-warning',
+        containerWithHeader: 'border-warning-solid bg-warning-subtle',
     },
     danger: {
         icon: 'triangle-exclamation',
-        iconColor: ['text-red-500', 'dark:text-red-400'],
-        bodyColor: [
-            'text-red-950',
-            'dark:text-red-50',
-            '[&_a]:text-red-800',
-            '[&_a:hover]:text-red-900',
-            'dark:[&_a]:text-red-400',
-            'dark:[&_a:hover]:text-red-300',
-            '[&_.can-override-bg]:bg-red-500/3',
-            '[&_.can-override-text]:text-red-400',
-            'decoration-red-800/6',
-            'dark:decoration-red-400/6',
+        iconColor: 'text-danger-subtle',
+        header: 'bg-danger-active',
+        body: [
+            // 'text-danger-strong',
+            '[&_a]:text-danger',
+            '[&_a:hover]:text-danger-strong',
+            '[&_.can-override-bg]:bg-danger-active',
+            '[&_.can-override-text]:text-danger-strong',
+            'decoration-danger/6',
         ],
-        style: ['bg-red-500/2', 'border-red-500/4'],
+        container: 'bg-danger border-danger',
+        containerWithHeader: 'border-danger-solid bg-danger-subtle',
     },
     success: {
         icon: 'circle-check',
-        iconColor: ['text-green-500', 'dark:text-green-400'],
-        bodyColor: [
-            'text-green-950',
-            'dark:text-green-50',
-            '[&_a]:text-green-800',
-            '[&_a:hover]:text-green-900',
-            'dark:[&_a]:text-green-400',
-            'dark:[&_a:hover]:text-green-300',
-            '[&_.can-override-bg]:bg-green-500/3',
-            '[&_.can-override-text]:text-green-800',
-            'dark:[&_.can-override-text]:text-green-400',
-            'decoration-green-800/6',
-            'dark:decoration-green-400/6',
+        iconColor: 'text-success-subtle',
+        header: 'bg-success-active',
+        body: [
+            // 'text-success-strong',
+            '[&_a]:text-success',
+            '[&_a:hover]:text-success-strong',
+            '[&_.can-override-bg]:bg-success-active',
+            '[&_.can-override-text]:text-success-strong',
+            'decoration-success/6',
         ],
-        style: ['bg-green-500/2', 'border-green-500/4'],
+        container: 'bg-success border-success',
+        containerWithHeader: 'border-success-solid bg-success-subtle',
     },
 };

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -21,6 +21,7 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
                 'transition-colors',
                 'rounded-md',
                 'straight-corners:rounded-none',
+                'text-sm',
                 hintStyle.style,
                 style,
             )}
@@ -29,8 +30,8 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
                 <Icon
                     icon={hintStyle.icon}
                     className={tcls(
-                        'size-5',
-                        'mr-4',
+                        'size-4',
+                        'mr-3',
                         'mt-0.5',
                         firstLine.lineHeight,
                         hintStyle.iconColor,
@@ -62,8 +63,20 @@ const HINT_STYLES: {
 } = {
     info: {
         icon: 'circle-info',
-        iconColor: ['text-primary'],
-        bodyColor: ['[&_a]:text-primary', '[&_a:hover]:text-primary-strong'],
+        iconColor: ['text-blue-500', 'dark:text-blue-400'],
+        bodyColor: [
+            'text-blue-950',
+            'dark:text-blue-50',
+            '[&_a]:text-blue-800',
+            '[&_a:hover]:text-blue-900',
+            'dark:[&_a]:text-blue-400',
+            'dark:[&_a:hover]:text-blue-300',
+            '[&_.can-override-bg]:bg-blue-500/3',
+            '[&_.can-override-text]:text-blue-800',
+            'dark:[&_.can-override-text]:text-blue-400',
+            'decoration-blue-800/6',
+            'dark:decoration-blue-400/6',
+        ],
         style: [
             'bg-tint',
             'print-mode:!bg-tint',

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -18,7 +18,11 @@ import {
     colorContrast,
     colorScale,
     type ColorScaleOptions,
+    DEFAULT_DANGER_COLOR,
+    DEFAULT_INFO_COLOR,
+    DEFAULT_SUCCESS_COLOR,
     DEFAULT_TINT_COLOR,
+    DEFAULT_WARNING_COLOR,
     hexToRgb,
 } from '@/lib/colors';
 import { tcls } from '@/lib/tailwind';
@@ -85,6 +89,11 @@ export async function CustomizationRootLayout(props: {
                             )
                         };
                         --header-link: ${hexToRgb(customization.header.linkColor?.light ?? colorContrast(tintColor?.light ?? customization.styling.primaryColor.light))};
+
+                        ${generateColorVariable('info', DEFAULT_INFO_COLOR)}
+                        ${generateColorVariable('warning', DEFAULT_WARNING_COLOR)}
+                        ${generateColorVariable('danger', DEFAULT_DANGER_COLOR)}
+                        ${generateColorVariable('success', DEFAULT_SUCCESS_COLOR)}
                     }
 
                     .dark {
@@ -94,6 +103,11 @@ export async function CustomizationRootLayout(props: {
 
                         --header-background: ${hexToRgb(customization.header.backgroundColor?.dark ?? tintColor?.dark ?? customization.styling.primaryColor.dark)};
                         --header-link: ${hexToRgb(customization.header.linkColor?.dark ?? colorContrast(tintColor?.dark ?? customization.styling.primaryColor.dark))};
+
+                        ${generateColorVariable('info', DEFAULT_INFO_COLOR, { darkMode: true })}
+                        ${generateColorVariable('warning', DEFAULT_WARNING_COLOR, { darkMode: true })}
+                        ${generateColorVariable('danger', DEFAULT_DANGER_COLOR, { darkMode: true })}
+                        ${generateColorVariable('success', DEFAULT_SUCCESS_COLOR, { darkMode: true })}
                     }
                 `}</style>
             </head>

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -8,7 +8,13 @@ type OKLCHColor = { L: number; C: number; H: number };
 
 export const DARK_BASE = '#1d1d1d';
 export const LIGHT_BASE = '#ffffff';
+
 export const DEFAULT_TINT_COLOR = '#787878';
+export const DEFAULT_INFO_COLOR = '#346DDB';
+export const DEFAULT_WARNING_COLOR = '#FF6900';
+export const DEFAULT_DANGER_COLOR = '#FB2C36';
+export const DEFAULT_SUCCESS_COLOR = '#00C950';
+
 const D65 = [95.047, 100.0, 108.883]; // Reference white (D65)
 
 export enum ColorCategory {

--- a/packages/gitbook/tailwind.config.ts
+++ b/packages/gitbook/tailwind.config.ts
@@ -8,6 +8,8 @@ import { ColorCategory, hexToRgb, scale, shadesOfColor } from './src/lib/colors'
 export const shades = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900];
 export const opacities = [0, 4, 8, 12, 16, 24, 40, 64, 72, 88, 96, 100];
 
+export const semanticColors = ['info', 'warning', 'danger', 'success'];
+
 /**
  * Generate a Tailwind color shades from a variable.
  */
@@ -100,6 +102,18 @@ const config: Config = {
 
                 'header-background': 'rgb(var(--header-background))',
                 'header-link': 'rgb(var(--header-link))',
+
+                // Add each semantic color
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [color, generateVarShades(color)]),
+                ),
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [
+                        `contrast-${color}`,
+                        generateVarShades(`contrast-${color}`),
+                    ]),
+                ),
+
                 yellow: generateShades('#f4e28d'),
                 teal: generateShades('#3f89a1'),
                 pomegranate: generateShades('#f25b3a'),
@@ -127,6 +141,17 @@ const config: Config = {
                     ColorCategory.components,
                     ColorCategory.accents,
                 ]),
+                // Semantic colors
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [
+                        color,
+                        generateVarShades(color, [
+                            ColorCategory.backgrounds,
+                            ColorCategory.components,
+                            ColorCategory.accents,
+                        ]),
+                    ]),
+                ),
             },
             gradientColorStops: {
                 primary: generateVarShades('primary', [
@@ -144,26 +169,71 @@ const config: Config = {
                     ColorCategory.components,
                     ColorCategory.accents,
                 ]),
+                // Semantic colors
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [
+                        color,
+                        generateVarShades(color, [
+                            ColorCategory.backgrounds,
+                            ColorCategory.components,
+                            ColorCategory.accents,
+                        ]),
+                    ]),
+                ),
             },
             borderColor: {
-                primary: generateVarShades('primary', [ColorCategory.borders]),
-                tint: generateVarShades('tint', [ColorCategory.borders]),
-                neutral: generateVarShades('neutral', [ColorCategory.borders]),
+                primary: generateVarShades('primary', [
+                    ColorCategory.borders,
+                    ColorCategory.accents,
+                ]),
+                tint: generateVarShades('tint', [ColorCategory.borders, ColorCategory.accents]),
+                neutral: generateVarShades('neutral', [
+                    ColorCategory.borders,
+                    ColorCategory.accents,
+                ]),
+                // Semantic colors
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [
+                        color,
+                        generateVarShades(color, [ColorCategory.borders, ColorCategory.accents]),
+                    ]),
+                ),
             },
             ringColor: {
                 primary: generateVarShades('primary', [ColorCategory.borders]),
                 tint: generateVarShades('tint', [ColorCategory.borders]),
                 neutral: generateVarShades('neutral', [ColorCategory.borders]),
+                // Semantic colors
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [
+                        color,
+                        generateVarShades(color, [ColorCategory.borders]),
+                    ]),
+                ),
             },
             outlineColor: {
                 primary: generateVarShades('primary', [ColorCategory.borders]),
                 tint: generateVarShades('tint', [ColorCategory.borders]),
                 neutral: generateVarShades('neutral', [ColorCategory.borders]),
+                // Semantic colors
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [
+                        color,
+                        generateVarShades(color, [ColorCategory.borders]),
+                    ]),
+                ),
             },
             boxShadowColor: {
                 primary: generateVarShades('primary', [ColorCategory.borders]),
                 tint: generateVarShades('tint', [ColorCategory.borders]),
                 neutral: generateVarShades('neutral', [ColorCategory.borders]),
+                // Semantic colors
+                ...Object.fromEntries(
+                    semanticColors.map((color) => [
+                        color,
+                        generateVarShades(color, [ColorCategory.borders]),
+                    ]),
+                ),
             },
             textColor: {
                 primary: generateVarShades('primary', [ColorCategory.text]),
@@ -181,6 +251,18 @@ const config: Config = {
                     ColorCategory.backgrounds,
                     ColorCategory.accents,
                 ]),
+                ...Object.fromEntries(
+                    semanticColors.flatMap((color) => [
+                        [color, generateVarShades(color, [ColorCategory.text])],
+                        [
+                            `contrast-${color}`,
+                            generateVarShades(`contrast-${color}`, [
+                                ColorCategory.backgrounds,
+                                ColorCategory.accents,
+                            ]),
+                        ],
+                    ]),
+                ),
             },
             textDecorationColor: {
                 primary: generateVarShades('primary', [ColorCategory.text]),
@@ -198,6 +280,18 @@ const config: Config = {
                     ColorCategory.backgrounds,
                     ColorCategory.accents,
                 ]),
+                ...Object.fromEntries(
+                    semanticColors.flatMap((color) => [
+                        [color, generateVarShades(color, [ColorCategory.text])],
+                        [
+                            `contrast-${color}`,
+                            generateVarShades(`contrast-${color}`, [
+                                ColorCategory.backgrounds,
+                                ColorCategory.accents,
+                            ]),
+                        ],
+                    ]),
+                ),
             },
             animation: {
                 present: 'present .5s ease-out both',


### PR DESCRIPTION
- When you type a heading (1, 2, or 3) as the first child of a hint block, we mark it up into a heading, displayed alongside the icon. Hints without heading are unaffected.
- Instead of the primary colour, info hints now default to blue. We had some comments from people with an orange primary colour that this was a bit off.
- A new customisation option lets you set your own 4 semantic colors for info, warning, danger, and success and generate a palette for each, like we do for tint.
- These semantic colours can then be used in other places like our API blocks too.

<img width="823" alt="Screenshot 2025-02-17 at 13 40 51" src="https://github.com/user-attachments/assets/74c6a5cc-91f3-4a32-b776-3b372e9346e9" />

![Semantic color options](https://github.com/user-attachments/assets/ca6c2cfd-abf2-4eec-ae4b-57801d5a1adf)
