### PR TITLE
Show additional fields in OpenAPI block

### DIFF
--- a/.changeset/shiny-adults-suffer.md
+++ b/.changeset/shiny-adults-suffer.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Show additional fields in OpenAPI block

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -397,7 +397,7 @@ export function getSchemaTitle(
     let type = 'any';
 
     if (schema.enum) {
-        type = 'enum';
+        type = `${schema.type} · enum`;
         // check array AND schema.items as this is sometimes null despite what the type indicates
     } else if (schema.type === 'array' && !!schema.items) {
         type = `${getSchemaTitle(schema.items)}[]`;
@@ -407,7 +407,7 @@ export function getSchemaTitle(
         type = schema.type ?? 'object';
 
         if (schema.format) {
-            type += ` ${schema.format}`;
+            type += ` · ${schema.format}`;
         }
     } else if ('anyOf' in schema) {
         type = 'any of';
@@ -419,8 +419,20 @@ export function getSchemaTitle(
         type = 'not';
     }
 
+    if(schema.minimum || schema.minLength){
+        type += ` · min: ${schema.minimum || schema.minLength}`;
+    }
+
+    if(schema.maximum || schema.maxLength){
+        type += ` · max: ${schema.maximum || schema.maxLength}`;
+    }
+
+    if(schema.default){
+        type += ` · default: ${schema.default}`;
+    }
+
     if (schema.nullable) {
-        type = `nullable ${type}`;
+        type = `${type} | nullable`;
     }
 
     return type;

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -419,15 +419,15 @@ export function getSchemaTitle(
         type = 'not';
     }
 
-    if(schema.minimum || schema.minLength){
+    if (schema.minimum || schema.minLength) {
         type += ` · min: ${schema.minimum || schema.minLength}`;
     }
 
-    if(schema.maximum || schema.maxLength){
+    if (schema.maximum || schema.maxLength) {
         type += ` · max: ${schema.maximum || schema.maxLength}`;
     }
 
-    if(schema.default){
+    if (schema.default) {
         type += ` · default: ${schema.default}`;
     }
 


### PR DESCRIPTION
Show additional fields in OpenAPI block like min, max, default

Before: 
![CleanShot 2025-02-19 at 12 43 40@2x](https://github.com/user-attachments/assets/42e6bcf3-6b39-4f9c-a5a9-124f3cb789e9)

After:
![CleanShot 2025-02-19 at 12 55 17@2x](https://github.com/user-attachments/assets/be7ae66b-1371-471b-8166-cb2aeb7b81d7)