### PR TITLE
Rearrange item types in OpenAPI blocks

### DIFF
--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -21,7 +21,7 @@
 }
 
 .openapi-deprecated-sunset-date {
-    @apply font-semibold font-mono;
+    @apply font-semibold font-mono truncate;
 }
 
 .openapi-description.openapi-markdown {
@@ -169,6 +169,14 @@
     @apply mt-3;
 }
 
+.openapi-schema-items {
+    @apply pt-3;
+}
+
+.openapi-schema-items .openapi-schema-items-property {
+    @apply mt-3 flex flex-col gap-1.5;
+}
+
 /* Schema Presentation */
 .openapi-schema-presentation {
     @apply flex flex-col gap-1.5 font-normal;
@@ -181,7 +189,7 @@
 .openapi-schema-name {
     /* To make double click on the property name select only the name,
     we disable selection on the parent and re-enable it on the children. */
-    @apply select-none flex gap-2.5 items-baseline text-sm;
+    @apply select-none flex gap-x-2.5 items-baseline text-sm flex-wrap;
 }
 
 .openapi-schema-name .openapi-deprecated {
@@ -571,11 +579,15 @@
 
 /* Disclosure */
 .openapi-disclosure-trigger {
-    @apply transition-all duration-300 hover:text-tint-strong rounded-2xl border border-tint-subtle px-2.5 py-1 text-[0.813rem] text-tint flex flex-row items-center gap-1.5 -outline-offset-1;
+    @apply transition-all truncate duration-300 max-w-full hover:text-tint-strong rounded-2xl border border-tint-subtle px-2.5 py-1 text-[0.813rem] text-tint flex flex-row items-center gap-1.5 -outline-offset-1;
+}
+
+.openapi-disclosure-trigger span {
+    @apply truncate;
 }
 
 .openapi-disclosure svg {
-    @apply size-3 transition-transform duration-300;
+    @apply size-3 shrink-0 transition-transform duration-300;
 }
 
 .openapi-disclosure-trigger[aria-expanded='true'] svg {

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -169,14 +169,6 @@
     @apply mt-3;
 }
 
-.openapi-schema-items {
-    @apply pt-3;
-}
-
-.openapi-schema-items .openapi-schema-items-property {
-    @apply mt-3 flex flex-col gap-1.5;
-}
-
 /* Schema Presentation */
 .openapi-schema-presentation {
     @apply flex flex-col gap-1.5 font-normal;

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -227,7 +227,7 @@ export function OpenAPISchemaPresentation(props: OpenAPISchemaPropertyEntry) {
 
     const shouldDisplayExample = (schema: OpenAPIV3.SchemaObject): boolean => {
         return (
-            typeof schema.example === 'string' ||
+            (typeof schema.example === 'string' && !!schema.example) ||
             typeof schema.example === 'number' ||
             typeof schema.example === 'boolean' ||
             (Array.isArray(schema.example) && schema.example.length > 0) ||

--- a/packages/react-openapi/src/OpenAPISchemaName.tsx
+++ b/packages/react-openapi/src/OpenAPISchemaName.tsx
@@ -1,8 +1,10 @@
+import { OpenAPIV3 } from '@gitbook/openapi-parser';
+
 interface OpenAPISchemaNameProps {
+    schema?: OpenAPIV3.SchemaObject;
     propertyName?: string | JSX.Element;
     required?: boolean;
     type?: string;
-    deprecated?: boolean;
 }
 
 /**
@@ -10,18 +12,48 @@ interface OpenAPISchemaNameProps {
  * It includes the property name, type, required and deprecated status.
  */
 export function OpenAPISchemaName(props: OpenAPISchemaNameProps): JSX.Element {
-    const { type, propertyName, required, deprecated } = props;
+    const { schema, type, propertyName, required } = props;
+
+    const additionalItems = schema && getAdditionalItems(schema);
 
     return (
         <div className="openapi-schema-name">
             {propertyName ? (
-                <span data-deprecated={deprecated} className="openapi-schema-propertyname">
+                <span data-deprecated={schema?.deprecated} className="openapi-schema-propertyname">
                     {propertyName}
                 </span>
             ) : null}
-            {type ? <span className="openapi-schema-type">{type}</span> : null}
+            <span>
+                {type ? <span className="openapi-schema-type">{type}</span> : null}
+                {additionalItems ? (
+                    <span className="openapi-schema-type">{additionalItems}</span>
+                ) : null}
+            </span>
             {required ? <span className="openapi-schema-required">required</span> : null}
-            {deprecated ? <span className="openapi-deprecated">Deprecated</span> : null}
+            {schema?.deprecated ? <span className="openapi-deprecated">Deprecated</span> : null}
         </div>
     );
+}
+
+function getAdditionalItems(schema: OpenAPIV3.SchemaObject): string {
+    let additionalItems = '';
+
+    if (schema.minimum || schema.minLength) {
+        additionalItems += ` · min: ${schema.minimum || schema.minLength}`;
+    }
+
+    if (schema.maximum || schema.maxLength) {
+        additionalItems += ` · max: ${schema.maximum || schema.maxLength}`;
+    }
+
+    // If the schema has a default value, we display it
+    if (typeof schema.default !== 'undefined') {
+        additionalItems += ` · default: ${schema.default}`;
+    }
+
+    if (schema.nullable) {
+        additionalItems = ` | nullable`;
+    }
+
+    return additionalItems;
 }

--- a/packages/react-openapi/src/utils.ts
+++ b/packages/react-openapi/src/utils.ts
@@ -13,7 +13,11 @@ export function createStateKey(key: string, scope?: string) {
 /**
  * Resolve the description of an object.
  */
-export function resolveDescription(object: AnyObject) {
+export function resolveDescription(object: OpenAPIV3.SchemaObject | AnyObject) {
+    if ('items' in object && object.items) {
+        return resolveDescription(object.items);
+    }
+
     return 'x-gitbook-description-html' in object &&
         typeof object['x-gitbook-description-html'] === 'string'
         ? object['x-gitbook-description-html'].trim()


### PR DESCRIPTION
Some improvements on the properties part

## DEMO

### one of :
Before:
![CleanShot 2025-02-20 at 21 18 41@2x](https://github.com/user-attachments/assets/3361ef3f-98f1-4940-bc3c-8ece052a1989)

After:
![CleanShot 2025-02-20 at 21 17 49@2x](https://github.com/user-attachments/assets/03a3b302-c401-4779-b2e1-415be59e167a)


### all of
Before:
![CleanShot 2025-02-20 at 21 20 27@2x](https://github.com/user-attachments/assets/f1bb15ea-3aae-415a-b1e4-bd309cab9a77)

After:
![CleanShot 2025-02-20 at 21 20 38@2x](https://github.com/user-attachments/assets/ff4e0aa2-1480-4254-b027-3f4b5100866b)

### one of[]
Before:
![CleanShot 2025-02-20 at 21 23 30@2x](https://github.com/user-attachments/assets/66a1644c-27b2-459b-8f21-a5bc5e4a4df7)

After:
![CleanShot 2025-02-20 at 21 23 05@2x](https://github.com/user-attachments/assets/74cca675-a9b2-48ac-9f97-123072fd4389)
