### PR TITLE
Bump hint icon up 1px

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -40,6 +40,7 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
                 className={tcls(
                     'py-3',
                     'pl-3',
+                    '-mt-px', // Bump icon up 1px for optical alignment with heading
                     hasHeading ? hintStyle.header : null,
                     hintStyle.iconColor,
                 )}


### PR DESCRIPTION
Icons in hint blocks were slightly misaligned optically with the headings. Fixed now.

# Before
![Screenshot 2025-02-21 at 15 50 48](https://github.com/user-attachments/assets/7030c605-b18c-4b2a-aad5-58e8a54adb18)
<img width="209" alt="Screenshot 2025-02-24 at 14 05 20" src="https://github.com/user-attachments/assets/c1353e18-c16e-427f-8599-0735ebfb888a" />

# After
![Screenshot 2025-02-24 at 13 58 00](https://github.com/user-attachments/assets/b48ae147-30b8-475b-9e7c-778bb78ef617)
![Screenshot 2025-02-24 at 14 00 27](https://github.com/user-attachments/assets/c59492d7-4d9b-4fa7-a5e0-d6b0a16971f9)
![Screenshot 2025-02-24 at 13 59 38](https://github.com/user-attachments/assets/119ea983-643d-4cfb-a0bd-9a3f6120fa10)
