### PR TITLE
Resolve sections in reusable content

### DIFF
--- a/.changeset/khaki-ravens-scream.md
+++ b/.changeset/khaki-ravens-scream.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Resolve sections in reusable content blocks

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -252,7 +252,9 @@ export async function PageAside(props: {
 async function PageAsideSections(props: { document: JSONDocument; context: ContentRefContext }) {
     const { document, context } = props;
 
-    const sections = await getDocumentSections(document, (ref) => resolveContentRef(ref, context));
+    const sections = await getDocumentSections(context.space, document, (ref) =>
+        resolveContentRef(ref, context),
+    );
 
     return sections.length > 1 ? <ScrollSectionsList sections={sections} /> : null;
 }

--- a/packages/gitbook/src/lib/document-sections.ts
+++ b/packages/gitbook/src/lib/document-sections.ts
@@ -1,5 +1,6 @@
-import { JSONDocument, ContentRef } from '@gitbook/api';
+import { JSONDocument, ContentRef, Space } from '@gitbook/api';
 
+import { getDocument } from './api';
 import { getNodeText } from './document';
 import { fetchOpenAPIBlock } from './openapi/fetch';
 import { ResolvedContentRef } from './references';
@@ -16,6 +17,7 @@ export interface DocumentSection {
  * Extract a list of sections from a document.
  */
 export async function getDocumentSections(
+    space: Space,
     document: JSONDocument,
     resolveContentRef: (ref: ContentRef) => Promise<ResolvedContentRef | null>,
 ): Promise<DocumentSection[]> {
@@ -48,6 +50,31 @@ export async function getDocumentSections(
                     deprecated: operation.operation.deprecated,
                 });
             }
+        }
+
+        if (block.type === 'reusable-content') {
+            const resolved = await resolveContentRef(block.data.ref);
+            const documentId = resolved?.reusableContent?.document;
+            if (!documentId) {
+                throw new Error(`Expected a document ID for reusable content block`);
+            }
+
+            const document = await getDocument(space.id, documentId);
+            if (!document) {
+                throw new Error(`Document not found for reusable content block`);
+            }
+
+            const resuableContentSections = await getDocumentSections(
+                space,
+                document,
+                resolveContentRef,
+            );
+            sections.push(
+                ...resuableContentSections.map((section) => ({
+                    ...section,
+                    depth: section.depth + depth,
+                })),
+            );
         }
     }
 


### PR DESCRIPTION
Needed as after RND-6192 is merged, we'll need to show the sections of the reusable block in the sidebar