### PR TITLE
Adjust hint spacing

### DIFF
--- a/.changeset/clean-meals-stare.md
+++ b/.changeset/clean-meals-stare.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Adjust hint block spacing

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -52,7 +52,7 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
                 <Block
                     style={tcls(
                         'flip-heading-hash p-4 pl-3 text-[1em] *:mt-0',
-                        hasHeading ? hintStyle.header : null,
+                        hasHeading ? hintStyle.header : null
                     )}
                     ancestorBlocks={[...ancestorBlocks, block]}
                     {...contextProps}

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -37,23 +37,22 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
         >
             <div
                 className={tcls(
-                    'py-3',
-                    'pl-3',
-                    '-mt-px', // Bump icon up 1px for optical alignment with heading
+                    'py-4',
+                    'pl-4',
                     hasHeading ? hintStyle.header : null,
                     hintStyle.iconColor
                 )}
             >
                 <Icon
                     icon={hintStyle.icon}
-                    className={tcls('size-[1.2em]', 'mt-0.5', firstLine.lineHeight)}
+                    className={tcls('size-[1.2em]', 'mt-px', firstLine.lineHeight)}
                 />
             </div>
             {hasHeading ? (
                 <Block
                     style={tcls(
-                        'flip-heading-hash p-3 text-[1em] *:mt-0',
-                        hasHeading ? hintStyle.header : null
+                        'flip-heading-hash p-4 pl-3 text-[1em] *:mt-0',
+                        hasHeading ? hintStyle.header : null,
                     )}
                     ancestorBlocks={[...ancestorBlocks, block]}
                     {...contextProps}
@@ -70,11 +69,12 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
                     'flip-heading-hash'
                 )}
                 style={[
-                    'p-3',
+                    'p-4',
+                    'pl-3',
                     'empty:p-0',
                     '-row-end-1',
                     '-col-end-1',
-                    'space-y-4',
+                    'space-y-3',
                     '[&_.hint]:border',
                     '[&_pre]:border',
                     '[&_pre]:border-neutral',


### PR DESCRIPTION
The spacing of the redesigned hint block could use some improvement. With this PR, the padding around the block is increased a bit, while the space between blocks is decreased for a more harmonious look.

# Before & after
<img width="844" alt="EI Before" src="https://github.com/user-attachments/assets/64557797-406c-4829-bcd4-da759fedb85c" />
<img width="844" alt="EI After" src="https://github.com/user-attachments/assets/9ee05610-a358-4ef4-9ef2-9ffe45c91d70" />
