### PR TITLE
fix: section groups went missing

### DIFF
--- a/.changeset/silent-games-know.md
+++ b/.changeset/silent-games-know.md
@@ -1,0 +1,6 @@
+---
+'gitbook-v2': patch
+'gitbook': patch
+---
+
+fix: lost section groups

--- a/packages/gitbook-v2/src/lib/context.ts
+++ b/packages/gitbook-v2/src/lib/context.ts
@@ -189,7 +189,7 @@ export async function fetchSiteContextByIds(
         ...(customizations.site?.title ? { title: customizations.site.title } : {}),
     };
 
-    const sections = ids.siteSection ? parseSiteSectionsList(siteStructure, ids.siteSection) : null;
+    const sections = ids.siteSection ? parseSiteSectionsAndGroups(siteStructure, ids.siteSection) : null;
 
     const siteSpace = (
         siteStructure.type === 'siteSpaces' && siteStructure.structure
@@ -283,9 +283,14 @@ export async function fetchSpaceContextByIds(
     };
 }
 
-function parseSiteSectionsList(structure: SiteStructure, siteSectionId: string) {
-    const sections = getSiteStructureSections(structure);
-    const section = sections.find((section) => section.id === siteSectionId);
+function parseSiteSectionsAndGroups(structure: SiteStructure, siteSectionId: string) {
+    const sectionsAndGroups = getSiteStructureSections(structure, { ignoreGroups: false });
+    const section = parseCurrentSection(structure, siteSectionId);
     assert(section, 'A section must be defined when there are multiple sections');
-    return { list: sections, current: section } satisfies SiteSections;
+    return { list: sectionsAndGroups, current: section } satisfies SiteSections;
+}
+
+function parseCurrentSection(structure: SiteStructure, siteSectionId: string) {
+    const sections = getSiteStructureSections(structure, { ignoreGroups: true });
+    return sections.find((section) => section.id === siteSectionId);
 }

--- a/packages/gitbook-v2/src/lib/context.ts
+++ b/packages/gitbook-v2/src/lib/context.ts
@@ -189,7 +189,9 @@ export async function fetchSiteContextByIds(
         ...(customizations.site?.title ? { title: customizations.site.title } : {}),
     };
 
-    const sections = ids.siteSection ? parseSiteSectionsAndGroups(siteStructure, ids.siteSection) : null;
+    const sections = ids.siteSection
+        ? parseSiteSectionsAndGroups(siteStructure, ids.siteSection)
+        : null;
 
     const siteSpace = (
         siteStructure.type === 'siteSpaces' && siteStructure.structure

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -234,6 +234,16 @@ const testCases: TestsCase[] = [
                 run: async (page) => {
                     const sectionGroupDropdown = await page.getByText('Test Section Group 1');
                     await sectionGroupDropdown.hover();
+                    await page.getByText('Section B');
+                },
+            },
+            {
+                name: 'Section group link',
+                url: '',
+                screenshot: false,
+                run: async (page) => {
+                    const sectionGroupDropdown = await page.getByText('Test Section Group 1');
+                    await sectionGroupDropdown.hover();
                     await page.getByText('Section B').click();
                     await page.waitForURL(
                         'https://gitbook-open-e2e-sites.gitbook.io/sections/sections-4'

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -232,9 +232,8 @@ const testCases: TestsCase[] = [
                 name: 'Section group dropdown',
                 url: '',
                 run: async (page) => {
-                    const sectionGroupDropdown = await page.getByText('Test Section Group 1');
-                    await sectionGroupDropdown.hover();
-                    await expect(page.getByRole('link', { name: 'Section B' })).toBeVisible();
+                    await page.getByRole('button', { name: 'Test Section Group 1' }).hover();
+                    await expect(page.getByRole('link', { name: /Section B/ })).toBeVisible();
                 },
             },
             {

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -226,9 +226,9 @@ const testCases: TestsCase[] = [
         tests: [
             {
                 name: 'Site with sections and section groups',
-                url: ''
-            }
-        ]
+                url: '',
+            },
+        ],
     },
     {
         name: 'GitBook',

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -221,6 +221,16 @@ const testCases: TestsCase[] = [
         ],
     },
     {
+        name: 'GitBook Site (Sections and Section Groups)',
+        baseUrl: 'https://gitbook-open-e2e-sites.gitbook.io/sections/',
+        tests: [
+            {
+                name: 'Site with sections and section groups',
+                url: ''
+            }
+        ]
+    },
+    {
         name: 'GitBook',
         baseUrl: 'https://docs.gitbook.com',
         tests: [

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -238,8 +238,8 @@ const testCases: TestsCase[] = [
                     await page.waitForURL(
                         'https://gitbook-open-e2e-sites.gitbook.io/sections/sections-4'
                     );
-                }
-            }
+                },
+            },
         ],
     },
     {

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -234,7 +234,7 @@ const testCases: TestsCase[] = [
                 run: async (page) => {
                     const sectionGroupDropdown = await page.getByText('Test Section Group 1');
                     await sectionGroupDropdown.hover();
-                    await page.getByText('Section B');
+                    await expect(page.getByRole('link', { name: 'Section B' })).toBeVisible();
                 },
             },
             {

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -228,6 +228,18 @@ const testCases: TestsCase[] = [
                 name: 'Site with sections and section groups',
                 url: '',
             },
+            {
+                name: 'Section group dropdown',
+                url: '',
+                run: async (page) => {
+                    const sectionGroupDropdown = await page.getByText('Test Section Group 1');
+                    await sectionGroupDropdown.hover();
+                    await page.getByText('Section B').click();
+                    await page.waitForURL(
+                        'https://gitbook-open-e2e-sites.gitbook.io/sections/sections-4'
+                    );
+                }
+            }
         ],
     },
     {

--- a/packages/gitbook/src/app/middleware/(site)/(core)/llms.txt/route.ts
+++ b/packages/gitbook/src/app/middleware/(site)/(core)/llms.txt/route.ts
@@ -60,7 +60,9 @@ export async function GET(_req: NextRequest) {
 async function getNodesFromSiteStructure(siteStructure: SiteStructure): Promise<RootContent[]> {
     switch (siteStructure.type) {
         case 'sections':
-            return getNodesFromSections(getSiteStructureSections(siteStructure, { ignoreGroups: true }));
+            return getNodesFromSections(
+                getSiteStructureSections(siteStructure, { ignoreGroups: true })
+            );
         case 'siteSpaces':
             return getNodesFromSiteSpaces(siteStructure.structure, { heading: true });
         default:

--- a/packages/gitbook/src/app/middleware/(site)/(core)/llms.txt/route.ts
+++ b/packages/gitbook/src/app/middleware/(site)/(core)/llms.txt/route.ts
@@ -60,7 +60,7 @@ export async function GET(_req: NextRequest) {
 async function getNodesFromSiteStructure(siteStructure: SiteStructure): Promise<RootContent[]> {
     switch (siteStructure.type) {
         case 'sections':
-            return getNodesFromSections(getSiteStructureSections(siteStructure));
+            return getNodesFromSections(getSiteStructureSections(siteStructure, { ignoreGroups: true }));
         case 'siteSpaces':
             return getNodesFromSiteSpaces(siteStructure.structure, { heading: true });
         default:

--- a/packages/gitbook/src/app/middleware/(site)/(core)/sitemap.xml/route.ts
+++ b/packages/gitbook/src/app/middleware/(site)/(core)/sitemap.xml/route.ts
@@ -62,7 +62,7 @@ export async function GET() {
 async function getUrlsFromSiteStructure(siteStructure: SiteStructure): Promise<string[]> {
     switch (siteStructure.type) {
         case 'sections':
-            return getUrlsFromSiteSections(getSiteStructureSections(siteStructure));
+            return getUrlsFromSiteSections(getSiteStructureSections(siteStructure, { ignoreGroups: true }));
         case 'siteSpaces':
             return getUrlsFromSiteSpaces(siteStructure.structure);
         default:

--- a/packages/gitbook/src/app/middleware/(site)/(core)/sitemap.xml/route.ts
+++ b/packages/gitbook/src/app/middleware/(site)/(core)/sitemap.xml/route.ts
@@ -62,7 +62,9 @@ export async function GET() {
 async function getUrlsFromSiteStructure(siteStructure: SiteStructure): Promise<string[]> {
     switch (siteStructure.type) {
         case 'sections':
-            return getUrlsFromSiteSections(getSiteStructureSections(siteStructure, { ignoreGroups: true }));
+            return getUrlsFromSiteSections(
+                getSiteStructureSections(siteStructure, { ignoreGroups: true })
+            );
         case 'siteSpaces':
             return getUrlsFromSiteSpaces(siteStructure.structure);
         default:

--- a/packages/gitbook/src/lib/pointer.ts
+++ b/packages/gitbook/src/lib/pointer.ts
@@ -53,7 +53,7 @@ export function checkIsRootPointer(
 ): boolean {
     switch (siteStructure.type) {
         case 'sections': {
-            return getSiteStructureSections(siteStructure).some(
+            return getSiteStructureSections(siteStructure, { ignoreGroups: true }).some(
                 (structure) =>
                     structure.default &&
                     structure.id === pointer.siteSectionId &&

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -1,13 +1,16 @@
-import type { SiteSection, SiteSpace, SiteStructure } from '@gitbook/api';
+import type { SiteSection, SiteSectionGroup, SiteSpace, SiteStructure } from '@gitbook/api';
 
 /**
- * Get all sections from a site structure.
+ * Get all sections from a site structure. If `includeGroups` is false, flat to not include SiteSectionGroups.
  */
-export function getSiteStructureSections(siteStructure: SiteStructure) {
+export function getSiteStructureSections(siteStructure: SiteStructure, options: { ignoreGroups: true }): SiteSection[];
+export function getSiteStructureSections(siteStructure: SiteStructure, options?: { ignoreGroups: false }): SiteSection[] | SiteSectionGroup[];
+export function getSiteStructureSections(siteStructure: SiteStructure, options?: { ignoreGroups: boolean }) {
+    const { ignoreGroups } = options ?? { ignoreGroups: false };
     return siteStructure.type === 'sections'
-        ? siteStructure.structure.flatMap((item) =>
+        ? ignoreGroups ? siteStructure.structure.flatMap((item) =>
               item.object === 'site-section-group' ? item.sections : item
-          )
+          ) : siteStructure.structure
         : [];
 }
 

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -3,14 +3,25 @@ import type { SiteSection, SiteSectionGroup, SiteSpace, SiteStructure } from '@g
 /**
  * Get all sections from a site structure. If `includeGroups` is false, flat to not include SiteSectionGroups.
  */
-export function getSiteStructureSections(siteStructure: SiteStructure, options: { ignoreGroups: true }): SiteSection[];
-export function getSiteStructureSections(siteStructure: SiteStructure, options?: { ignoreGroups: false }): SiteSection[] | SiteSectionGroup[];
-export function getSiteStructureSections(siteStructure: SiteStructure, options?: { ignoreGroups: boolean }) {
+export function getSiteStructureSections(
+    siteStructure: SiteStructure,
+    options: { ignoreGroups: true }
+): SiteSection[];
+export function getSiteStructureSections(
+    siteStructure: SiteStructure,
+    options?: { ignoreGroups: false }
+): SiteSection[] | SiteSectionGroup[];
+export function getSiteStructureSections(
+    siteStructure: SiteStructure,
+    options?: { ignoreGroups: boolean }
+) {
     const { ignoreGroups } = options ?? { ignoreGroups: false };
     return siteStructure.type === 'sections'
-        ? ignoreGroups ? siteStructure.structure.flatMap((item) =>
-              item.object === 'site-section-group' ? item.sections : item
-          ) : siteStructure.structure
+        ? ignoreGroups
+            ? siteStructure.structure.flatMap((item) =>
+                  item.object === 'site-section-group' ? item.sections : item
+              )
+            : siteStructure.structure
         : [];
 }
 

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -1,7 +1,8 @@
 import type { SiteSection, SiteSectionGroup, SiteSpace, SiteStructure } from '@gitbook/api';
 
 /**
- * Get all sections from a site structure. If `includeGroups` is false, flat to not include SiteSectionGroups.
+ * Get all sections from a site structure.
+ * Set the `ignoreGroups` option to true to flatten the list to only include SiteSection and to not include SiteSectionGroups.
  */
 export function getSiteStructureSections(
     siteStructure: SiteStructure,


### PR DESCRIPTION
We temporarily lost section groups as we were using the flattened section list to populate navigation.