### PR TITLE
Remove loading.tsx for static rendering in v2

### DIFF
--- a/packages/gitbook-v2/src/app/sites/static/[mode]/[siteURL]/[pagePath]/loading.tsx
+++ b/packages/gitbook-v2/src/app/sites/static/[mode]/[siteURL]/[pagePath]/loading.tsx
@@ -1,5 +1,0 @@
-import { SitePageSkeleton } from '@/components/SitePage';
-
-export default function Loading() {
-    return <SitePageSkeleton />;
-}


### PR DESCRIPTION
This should fix the status code returned by Next.js for page not found.