### PR TITLE
Remove top level circular refs in alternatives

### DIFF
--- a/.changeset/little-experts-deny.md
+++ b/.changeset/little-experts-deny.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Remove top level circular refs in alternatives

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -57,7 +57,7 @@ function OpenAPISchemaProperty(props: {
                             <OpenAPISchemaAlternative
                                 key={index}
                                 schema={schema}
-                                circularRefs={circularRefs}
+                                circularRefs={new Map(circularRefs)}
                                 context={context}
                             />
                         ))}


### PR DESCRIPTION
Recreating a new Map in OpenAPISchemaAlternatives to prevent showing unnecessary circular refs

Before:
![CleanShot 2025-03-05 at 09 50 11@2x](https://github.com/user-attachments/assets/5c7168ba-9627-47f2-978f-a3cb39dcb34e)

After:
![CleanShot 2025-03-05 at 09 49 58@2x](https://github.com/user-attachments/assets/56ff23ad-7932-4e2d-a00e-1c1d63ab20df)
