### PR TITLE
Fix spacing in OpenAPISecurities

### DIFF
--- a/.changeset/eight-kids-peel.md
+++ b/.changeset/eight-kids-peel.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Fix spacing in OpenAPISecurities

--- a/packages/react-openapi/src/OpenAPISecurities.tsx
+++ b/packages/react-openapi/src/OpenAPISecurities.tsx
@@ -31,7 +31,7 @@ export function OpenAPISecurities(props: {
                     key: key,
                     label: key,
                     body: (
-                        <div className="openapi-schema-body">
+                        <div className="openapi-schema">
                             <div className="openapi-schema-presentation">
                                 {getLabelForType(security)}
 


### PR DESCRIPTION
Before:
![CleanShot 2025-03-10 at 19 04 11@2x](https://github.com/user-attachments/assets/f73d9dbd-7290-49f6-865e-4fd3a9c8a05c)

After:
![CleanShot 2025-03-10 at 19 03 55@2x](https://github.com/user-attachments/assets/454a1d7c-e23c-4ad8-8eae-3582bfb59beb)
