### PR TITLE
Fix hint hover style

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -114,7 +114,7 @@ const HINT_STYLES: {
         body: [
             'text-neutral-strong',
             'links-default:[&_a]:text-warning',
-            'links-default:[&_a]:hover:text-warning-strong',
+            'links-default:[&_a:hover]:text-warning-strong',
             'links-default:[&_a]:decoration-warning/6',
             'links-accent:[&_a]:decoration-warning',
             'decoration-warning/6',
@@ -131,7 +131,7 @@ const HINT_STYLES: {
         body: [
             'text-neutral-strong',
             'links-default:[&_a]:text-danger',
-            'links-default:[&_a]:hover:text-danger-strong',
+            'links-default:[&_a:hover]:text-danger-strong',
             'links-default:[&_a]:decoration-danger/6',
             'links-accent:[&_a]:decoration-danger',
             'decoration-danger/6',
@@ -148,7 +148,7 @@ const HINT_STYLES: {
         body: [
             'text-neutral-strong',
             'links-default:[&_a]:text-success',
-            'links-default:[&_a]:hover:text-success-strong',
+            'links-default:[&_a:hover]:text-success-strong',
             'links-default:[&_a]:decoration-success/6',
             'links-accent:[&_a]:decoration-success',
             'decoration-success/6',


### PR DESCRIPTION
Fixing a small mistake in `:hover` targeting, which accidentally targeted all links in a hint block at once, instead of a single link at a time.
![2025-03-11 11 36 38](https://github.com/user-attachments/assets/379ba35d-30de-4001-9243-093f5c73444c)
