### PR TITLE
Override tint lightness if supplied color is out of bounds

### DIFF
--- a/.changeset/large-toys-travel.md
+++ b/.changeset/large-toys-travel.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/colors": minor
+---
+
+Override tint lightness if supplied color is out of bounds

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -184,6 +184,7 @@ export function colorScale(
     const mixColor = mix?.color ? rgbToOklch(hexToRgbArray(mix.color)) : null;
     const foregroundColor = rgbToOklch(hexToRgbArray(foreground));
     const backgroundColor = rgbToOklch(hexToRgbArray(background));
+    let mapping = darkMode ? colorMixMapping.dark : colorMixMapping.light;
 
     if (mixColor && mix?.ratio && mix.ratio > 0) {
         // If defined, we mix in a (tiny) bit of the mix color with the base color.
@@ -192,7 +193,20 @@ export function colorScale(
         baseColor.H = mix.color === DEFAULT_TINT_COLOR ? baseColor.H : mixColor.H;
     }
 
-    const mapping = darkMode ? colorMixMapping.dark : colorMixMapping.light;
+    if (
+        (darkMode && baseColor.L < backgroundColor.L) ||
+        (!darkMode && baseColor.L > backgroundColor.L)
+    ) {
+        // If the supplied color is outside of our lightness bounds, use the supplied color's lightness.
+        // This is mostly used to allow darker-than-dark backgrounds for brands that specifically want that look.
+        const difference = (backgroundColor.L - baseColor.L) / backgroundColor.L;
+        backgroundColor.L = baseColor.L;
+        // At the edges of the scale, the subtle lightness changes stop being perceptible. We need to amp up our mapping to still stand out.
+        const amplifier = 1;
+        mapping = mapping.map((step, index) =>
+            index < 9 ? step + (step * amplifier * difference) : step
+        );
+    }
 
     const result = [];
 

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -204,7 +204,7 @@ export function colorScale(
         // At the edges of the scale, the subtle lightness changes stop being perceptible. We need to amp up our mapping to still stand out.
         const amplifier = 1;
         mapping = mapping.map((step, index) =>
-            index < 9 ? step + (step * amplifier * difference) : step
+            index < 9 ? step + step * amplifier * difference : step
         );
     }
 


### PR DESCRIPTION
Our colour system uses lightness values based on reference greys to generate the right shades for different situations, and the background uses the darkest shade, which is set at a value slightly above pure black for aesthetics. 

But sometimes you do want to go even darker, and we should support that. If the lightness value of the tint colour is lower (or higher) than the set min/max, we can use the supplied lightness instead. 

Additionally, at the edges of the scale the subtle lightness changes used for backgrounds and borders stop being perceptible. We add a little amplification in these cases to make elements still stand out, even when pure black is used.