### PR TITLE
Fix alignment of `prominent` search bar on full-width pages

### DIFF
--- a/.changeset/forty-kangaroos-joke.md
+++ b/.changeset/forty-kangaroos-joke.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix alignment of `prominent` search bar on full-width pages

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -106,7 +106,8 @@ export function Header(props: { context: GitBookSiteContext; withTopHeader?: boo
                                           'lg:ml-[max(calc((100%-18rem-48rem-3rem)/2),1.5rem)]', // container (100%) - sidebar (18rem) - content (48rem) - margin (3rem)
                                           'xl:ml-[max(calc((100%-18rem-48rem-14rem-3rem)/2),1.5rem)]', // container (100%) - sidebar (18rem) - content (48rem) - outline (14rem) - margin (3rem)
                                           'page-no-toc:lg:ml-[max(calc((100%-18rem-48rem-18rem-3rem)/2),0rem)]',
-                                          'page-full-width:lg:ml-6',
+                                          'page-full-width:lg:ml-[max(calc((100%-18rem-103rem-3rem)/2),1.5rem)]',
+                                          'page-full-width:2xl:ml-[max(calc((100%-18rem-96rem-14rem+3rem)/2),1.5rem)]',
                                           'lg:mr-auto',
                                           'order-last',
                                           'md:order-[unset]',
@@ -179,44 +180,46 @@ export function Header(props: { context: GitBookSiteContext; withTopHeader?: boo
             </div>
 
             {sections || siteSpaces.length > 1 ? (
-                <div
-                    className={tcls(
-                        'w-full',
-                        'overflow-x-scroll',
-                        'overflow-y-hidden',
-                        'hide-scroll',
-                        '-mb-4 pb-4', // Positive padding / negative margin allows the navigation menu indicator to show in a scroll viewƒ
-                        !sections ? ['hidden', 'page-no-toc:flex'] : 'flex'
-                    )}
-                >
+                <div className="scroll-nojump">
                     <div
                         className={tcls(
-                            CONTAINER_STYLE,
-                            'page-default-width:max-w-[unset]',
-                            'grow',
-                            'flex',
-                            'items-end',
-                            'page-default-width:2xl:px-[calc((100%-1536px+4rem)/2)]'
+                            'w-full',
+                            'overflow-x-scroll',
+                            'overflow-y-hidden',
+                            'hide-scroll',
+                            '-mb-4 pb-4', // Positive padding / negative margin allows the navigation menu indicator to show in a scroll viewƒ
+                            !sections ? ['hidden', 'page-no-toc:flex'] : 'flex'
                         )}
                     >
-                        {siteSpaces.length > 1 && (
-                            <div
-                                id="variants"
-                                className="my-2 mr-5 page-no-toc:flex hidden grow border-tint border-r pr-5 *:grow only:mr-0 only:border-none only:pr-0 sm:max-w-64"
-                            >
-                                <SpacesDropdown
-                                    context={context}
-                                    siteSpace={siteSpace}
-                                    siteSpaces={siteSpaces}
-                                    className="w-full grow py-1"
+                        <div
+                            className={tcls(
+                                CONTAINER_STYLE,
+                                'page-default-width:max-w-[unset]',
+                                'grow',
+                                'flex',
+                                'items-end',
+                                'page-default-width:2xl:px-[calc((100%-1536px+4rem)/2)]'
+                            )}
+                        >
+                            {siteSpaces.length > 1 && (
+                                <div
+                                    id="variants"
+                                    className="my-2 mr-5 page-no-toc:flex hidden grow border-tint border-r pr-5 *:grow only:mr-0 only:border-none only:pr-0 sm:max-w-64"
+                                >
+                                    <SpacesDropdown
+                                        context={context}
+                                        siteSpace={siteSpace}
+                                        siteSpaces={siteSpaces}
+                                        className="w-full grow py-1"
+                                    />
+                                </div>
+                            )}
+                            {sections && (
+                                <SiteSectionTabs
+                                    sections={encodeClientSiteSections(context, sections)}
                                 />
-                            </div>
-                        )}
-                        {sections && (
-                            <SiteSectionTabs
-                                sections={encodeClientSiteSections(context, sections)}
-                            />
-                        )}
+                            )}
+                        </div>
                     </div>
                 </div>
             ) : null}

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -46,7 +46,7 @@ export function PageBody(props: {
                         // When in api page mode without the aside, we align with the border of the main content
                         'page-api-block:xl:max-2xl:pr-0',
                         // Max size to ensure one column in api is aligned with rest of content (2 x 3xl) + (gap-3 + 2) * px-12
-                        'page-api-block:max-w-[1654px]',
+                        'page-api-block:max-w-screen-2xl',
                         'page-api-block:mx-auto'
 
                         // page.layout.tableOfContents ? null : 'xl:ml-56'

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -143,6 +143,10 @@
             margin-right: 0;
             width: calc(100% - var(--scrollbar-width));
         }
+        body:has(.page-full-width) .scroll-nojump {
+            margin-left: 0;
+            width: calc(100% + var(--scrollbar-width));
+        }
     }
 }
 

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -62,79 +62,81 @@ export function SpaceLayout(props: {
                 spaceId={context.space.id}
             >
                 <Header withTopHeader={withTopHeader} context={context} />
-                <div
-                    className={tcls(
-                        'flex',
-                        'flex-col',
-                        'lg:flex-row',
-                        CONTAINER_STYLE,
+                <div className="scroll-nojump">
+                    <div
+                        className={tcls(
+                            'flex',
+                            'flex-col',
+                            'lg:flex-row',
+                            CONTAINER_STYLE,
 
-                        // Ensure the footer is display below the viewport even if the content is not enough
-                        withFooter && 'min-h-[calc(100vh-64px)]',
-                        withTopHeader ? null : 'lg:min-h-screen'
-                    )}
-                >
-                    <TableOfContents
-                        context={context}
-                        header={
-                            withTopHeader ? null : (
-                                <div
-                                    className={tcls(
-                                        'hidden',
-                                        'pr-4',
-                                        'lg:flex',
-                                        'grow-0',
-                                        'flex-wrap',
-                                        'dark:shadow-light/1',
-                                        'text-base/tight'
-                                    )}
-                                >
-                                    <HeaderLogo context={context} />
-                                </div>
-                            )
-                        }
-                        innerHeader={
-                            // displays the search button and/or the space dropdown in the ToC according to the header/variant settings. E.g if there is no header, the search button will be displayed in the ToC.
-                            <>
-                                {!withTopHeader && (
-                                    <div className={tcls('hidden', 'lg:block')}>
-                                        <React.Suspense fallback={null}>
-                                            <SearchButton>
-                                                <span className={tcls('flex-1')}>
-                                                    {t(
-                                                        getSpaceLanguage(customization),
-                                                        customization.aiSearch.enabled
-                                                            ? 'search_or_ask'
-                                                            : 'search'
-                                                    )}
-                                                    ...
-                                                </span>
-                                            </SearchButton>
-                                        </React.Suspense>
-                                    </div>
-                                )}
-                                {!withTopHeader && withSections && sections && (
-                                    <SiteSectionList
-                                        className={tcls('hidden', 'lg:block')}
-                                        sections={encodeClientSiteSections(context, sections)}
-                                    />
-                                )}
-                                {isMultiVariants && (
-                                    <SpacesDropdown
-                                        context={context}
-                                        siteSpace={siteSpace}
-                                        siteSpaces={siteSpaces}
+                            // Ensure the footer is display below the viewport even if the content is not enough
+                            withFooter && 'min-h-[calc(100vh-64px)]',
+                            withTopHeader ? null : 'lg:min-h-screen'
+                        )}
+                    >
+                        <TableOfContents
+                            context={context}
+                            header={
+                                withTopHeader ? null : (
+                                    <div
                                         className={tcls(
-                                            'w-full',
-                                            'page-no-toc:hidden',
-                                            'site-header-none:page-no-toc:flex'
+                                            'hidden',
+                                            'pr-4',
+                                            'lg:flex',
+                                            'grow-0',
+                                            'flex-wrap',
+                                            'dark:shadow-light/1',
+                                            'text-base/tight'
                                         )}
-                                    />
-                                )}
-                            </>
-                        }
-                    />
-                    <div className={tcls('flex-1', 'flex', 'flex-col')}>{children}</div>
+                                    >
+                                        <HeaderLogo context={context} />
+                                    </div>
+                                )
+                            }
+                            innerHeader={
+                                // displays the search button and/or the space dropdown in the ToC according to the header/variant settings. E.g if there is no header, the search button will be displayed in the ToC.
+                                <>
+                                    {!withTopHeader && (
+                                        <div className={tcls('hidden', 'lg:block')}>
+                                            <React.Suspense fallback={null}>
+                                                <SearchButton>
+                                                    <span className={tcls('flex-1')}>
+                                                        {t(
+                                                            getSpaceLanguage(customization),
+                                                            customization.aiSearch.enabled
+                                                                ? 'search_or_ask'
+                                                                : 'search'
+                                                        )}
+                                                        ...
+                                                    </span>
+                                                </SearchButton>
+                                            </React.Suspense>
+                                        </div>
+                                    )}
+                                    {!withTopHeader && withSections && sections && (
+                                        <SiteSectionList
+                                            className={tcls('hidden', 'lg:block')}
+                                            sections={encodeClientSiteSections(context, sections)}
+                                        />
+                                    )}
+                                    {isMultiVariants && (
+                                        <SpacesDropdown
+                                            context={context}
+                                            siteSpace={siteSpace}
+                                            siteSpaces={siteSpaces}
+                                            className={tcls(
+                                                'w-full',
+                                                'page-no-toc:hidden',
+                                                'site-header-none:page-no-toc:flex'
+                                            )}
+                                        />
+                                    )}
+                                </>
+                            }
+                        />
+                        <div className={tcls('flex-1', 'flex', 'flex-col')}>{children}</div>
+                    </div>
                 </div>
 
                 {withFooter ? <Footer context={context} /> : null}


### PR DESCRIPTION
Before:
<img width="1106" alt="Screenshot 2025-03-17 at 13 21 16" src="https://github.com/user-attachments/assets/0a029934-4d07-437f-8cb8-8f0c5003412b" />

After:
<img width="1106" alt="Screenshot 2025-03-17 at 13 19 46" src="https://github.com/user-attachments/assets/40ae8fcc-ccf3-4aa1-b520-19f2dcc99b64" />
