### PR TITLE
Update lists margin top

### DIFF
--- a/packages/gitbook/src/components/DocumentView/List.tsx
+++ b/packages/gitbook/src/components/DocumentView/List.tsx
@@ -22,7 +22,7 @@ export function List(
             nodes={block.nodes}
             ancestorBlocks={[...ancestorBlocks, block]}
             // `-mt-4` because we apply a `mt-5` to all blocks but we only want a margin top of 6px for lists
-            style={['min-w-0 space-y-2 -mt-4', style]}
+            style={[style, 'min-w-0 space-y-2 -mt-4']}
         />
     );
 }

--- a/packages/gitbook/src/components/DocumentView/List.tsx
+++ b/packages/gitbook/src/components/DocumentView/List.tsx
@@ -21,7 +21,8 @@ export function List(
             tag={getListTag(block.type)}
             nodes={block.nodes}
             ancestorBlocks={[...ancestorBlocks, block]}
-            style={['min-w-0 space-y-2', style]}
+            // `-mt-4` because we apply a `mt-5` to all blocks but we only want a margin top of 6px for lists
+            style={['min-w-0 space-y-2 -mt-4', style]}
         />
     );
 }

--- a/packages/gitbook/src/components/DocumentView/List.tsx
+++ b/packages/gitbook/src/components/DocumentView/List.tsx
@@ -21,8 +21,7 @@ export function List(
             tag={getListTag(block.type)}
             nodes={block.nodes}
             ancestorBlocks={[...ancestorBlocks, block]}
-            // `-mt-4` because we apply a `mt-5` to all blocks but we only want a margin top of 6px for lists
-            style={[style, 'min-w-0 space-y-2 -mt-4']}
+            style={['min-w-0 space-y-2', style]}
         />
     );
 }

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -72,7 +72,7 @@ export function PageBody(props: {
                     >
                         <DocumentView
                             document={document}
-                            style={['[&>*+*]:mt-5', '[&>*:is(ul,ol)]:mt-1.5', 'grid']}
+                            style={['[&>*+*]:mt-5', '[&>*:is(ul,ol)]:mt-2', 'grid']}
                             blockStyle={['page-api-block:ml-0']}
                             context={{
                                 mode: 'default',

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -72,7 +72,7 @@ export function PageBody(props: {
                     >
                         <DocumentView
                             document={document}
-                            style={['[&>*+*]:mt-5', 'grid']}
+                            style={['[&>*+*]:mt-5','[&>ul+*]:mt-1', '[&>ol+*]:mt-1', 'grid']}
                             blockStyle={['page-api-block:ml-0']}
                             context={{
                                 mode: 'default',

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -72,7 +72,7 @@ export function PageBody(props: {
                     >
                         <DocumentView
                             document={document}
-                            style={['[&>*+*]:mt-5','[&>ul*]:mt-1.5', '[&>ol*]:mt-1.5', 'grid']}
+                            style={['[&>*+*]:mt-5', '[&>*:is(ul,ol)]:mt-1.5', 'grid']}
                             blockStyle={['page-api-block:ml-0']}
                             context={{
                                 mode: 'default',

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -72,7 +72,7 @@ export function PageBody(props: {
                     >
                         <DocumentView
                             document={document}
-                            style={['[&>*+*]:mt-5','[&>ul+*]:mt-1', '[&>ol+*]:mt-1', 'grid']}
+                            style={['[&>*+*]:mt-5','[&>ul*]:mt-1.5', '[&>ol*]:mt-1.5', 'grid']}
                             blockStyle={['page-api-block:ml-0']}
                             context={{
                                 mode: 'default',


### PR DESCRIPTION
Reducing `margin-top` for lists to align on similar update made in GitBook editor.