### PR TITLE
Fix `prominent` search bar width on `md` screens

### DIFF
--- a/.changeset/tender-snails-mate.md
+++ b/.changeset/tender-snails-mate.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix `prominent` search bar width on `md` screens

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -102,13 +102,14 @@ export function Header(props: { context: GitBookSiteContext; withTopHeader?: boo
                                     ? [
                                           'md:grow-[0.8]',
                                           'lg:basis-40',
-                                          'max-w-lg',
+                                          'md:max-w-[40%]',
+                                          'lg:max-w-lg',
                                           'lg:ml-[max(calc((100%-18rem-48rem-3rem)/2),1.5rem)]', // container (100%) - sidebar (18rem) - content (48rem) - margin (3rem)
                                           'xl:ml-[max(calc((100%-18rem-48rem-14rem-3rem)/2),1.5rem)]', // container (100%) - sidebar (18rem) - content (48rem) - outline (14rem) - margin (3rem)
                                           'page-no-toc:lg:ml-[max(calc((100%-18rem-48rem-18rem-3rem)/2),0rem)]',
                                           'page-full-width:lg:ml-[max(calc((100%-18rem-103rem-3rem)/2),1.5rem)]',
                                           'page-full-width:2xl:ml-[max(calc((100%-18rem-96rem-14rem+3rem)/2),1.5rem)]',
-                                          'lg:mr-auto',
+                                          'md:mr-auto',
                                           'order-last',
                                           'md:order-[unset]',
                                       ]


### PR DESCRIPTION
# Before
<img width="867" alt="Screenshot 2025-03-19 at 13 46 00" src="https://github.com/user-attachments/assets/7d2999e9-8102-4bce-986a-2521b168efe1" />

# After
<img width="867" alt="Screenshot 2025-03-19 at 13 45 57" src="https://github.com/user-attachments/assets/4a46933b-78d1-41bf-8cf1-6d8fe8fa407f" />