### PR TITLE
Remove loading state for recommended questions

### DIFF
--- a/packages/gitbook/src/components/Search/SearchResults.tsx
+++ b/packages/gitbook/src/components/Search/SearchResults.tsx
@@ -77,7 +77,8 @@ export const SearchResults = React.forwardRef(function SearchResults(
 
             let cancelled = false;
 
-            setResultsState({ results: [], fetching: true });
+            // Silently fetch the recommended questions, instead of showing a spinner
+            setResultsState({ results: [], fetching: false });
 
             // We currently have a bug where the same question can be returned multiple times.
             // This is a workaround to avoid that.


### PR DESCRIPTION
The loading state for recommended AI questions makes it feel like search isn't ready yet, while it is. This one-liner sets the `fetching` state to `false`, while the questions are still loaded in and displayed once ready.