### PR TITLE
Default to the first ID as being active in scroll detection

### DIFF
--- a/packages/gitbook/src/components/hooks/useScrollActiveId.ts
+++ b/packages/gitbook/src/components/hooks/useScrollActiveId.ts
@@ -12,11 +12,12 @@ export function useScrollActiveId(
 ) {
     const { rootMargin, threshold = 0.5 } = options;
 
-    const [activeId, setActiveId] = React.useState<string | null>(null);
+    const [activeId, setActiveId] = React.useState<string>(ids[0]);
     const sectionsIntersectingMap = React.useRef<Map<string, boolean>>(new Map());
 
     React.useEffect(() => {
-        setActiveId(null);
+        const defaultActiveId = ids[0];
+        setActiveId((activeId) => (ids.indexOf(activeId) !== -1 ? activeId : defaultActiveId));
 
         if (typeof IntersectionObserver === 'undefined') {
             return;


### PR DESCRIPTION
This PR fixes https://linear.app/gitbook-x/issue/RND-6694/pill-highlighting-missing-on-page-outline-navigation

The previous logic defaulted to `null` and kept the value as `null` if no heading was in the viewport, but it was inconsistent with how the pill was displayed when scrolling: scrolling back to the top of the page still showed the first item as active.