### PR TITLE
Stop variant selector from growing too large

### DIFF
--- a/packages/gitbook/src/components/Header/SpacesDropdown.tsx
+++ b/packages/gitbook/src/components/Header/SpacesDropdown.tsx
@@ -63,7 +63,7 @@ export function SpacesDropdown(props: {
                         className
                     )}
                 >
-                    <span className={tcls('truncate', 'grow')}>{siteSpace.title}</span>
+                    <span className={tcls('line-clamp-1', 'grow')}>{siteSpace.title}</span>
                     <DropdownChevron />
                 </div>
             )}


### PR DESCRIPTION
# Before
<img width="527" alt="Screenshot 2025-03-27 at 10 35 20" src="https://github.com/user-attachments/assets/ac3f5a9f-ded7-4e73-9ad2-912cf3b31299" />

# After
<img width="527" alt="Screenshot 2025-03-27 at 10 35 38" src="https://github.com/user-attachments/assets/06f0c196-5909-4f23-a4d6-58488dd54369" />
