### PR TITLE
Fix dismissed annoucement banner ignored when switching sites

### DIFF
--- a/packages/gitbook/src/components/Announcement/AnnouncementDismissedScript.tsx
+++ b/packages/gitbook/src/components/Announcement/AnnouncementDismissedScript.tsx
@@ -19,7 +19,7 @@ export function AnnouncementDismissedScript() {
         ANNOUNCEMENT_CSS_CLASS,
     ]).slice(1, -1);
 
-    // makes sure keeps the banner state when navigating between sites
+    // makes sure the banner dismissed state is kept when navigating between sites
     React.useEffect(() => {
         checkStorageForDismissedScript(
             ANNOUNCEMENT_STORAGE_KEY,

--- a/packages/gitbook/src/components/Announcement/AnnouncementDismissedScript.tsx
+++ b/packages/gitbook/src/components/Announcement/AnnouncementDismissedScript.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as React from 'react';
 import {
     ANNOUNCEMENT_CSS_CLASS,
     ANNOUNCEMENT_DAYS_TILL_RESET,
@@ -17,6 +18,15 @@ export function AnnouncementDismissedScript() {
         ANNOUNCEMENT_DAYS_TILL_RESET,
         ANNOUNCEMENT_CSS_CLASS,
     ]).slice(1, -1);
+
+    // makes sure keeps the banner state when navigating between sites
+    React.useEffect(() => {
+        checkStorageForDismissedScript(
+            ANNOUNCEMENT_STORAGE_KEY,
+            ANNOUNCEMENT_DAYS_TILL_RESET,
+            ANNOUNCEMENT_CSS_CLASS
+        );
+    }, []);
 
     return (
         <script

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -101,7 +101,10 @@ export function SiteSectionTabs(props: { sections: ClientSiteSections }) {
                                 ) : (
                                     <NavigationMenu.Link asChild>
                                         <SectionTab
-                                            url={sectionOrGroup.url}
+                                            url={sectionOrGroup.url.replace(
+                                                'https://',
+                                                'https://pr3057.gitbook-open.pages.dev/'
+                                            )}
                                             isActive={isActive}
                                             title={title}
                                             icon={icon ? (icon as IconName) : undefined}

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -101,10 +101,7 @@ export function SiteSectionTabs(props: { sections: ClientSiteSections }) {
                                 ) : (
                                     <NavigationMenu.Link asChild>
                                         <SectionTab
-                                            url={sectionOrGroup.url.replace(
-                                                'https://',
-                                                'https://pr3057.gitbook-open.pages.dev/'
-                                            )}
+                                            url={sectionOrGroup.url}
                                             isActive={isActive}
                                             title={title}
                                             icon={icon ? (icon as IconName) : undefined}


### PR DESCRIPTION
Fixes an issue in v2 where the announcement banner would reappear during client-side navigation between routes despite being previously dismissed.  The fix complements the existing page-load script with useEffect that reapplies the banner's dismissed state after next navigation updates the DOM.

**before**

https://github.com/user-attachments/assets/704ce4ea-11b1-4c1a-bba4-a4f01cb80315

**after**

https://github.com/user-attachments/assets/82e9c38b-13cc-4d54-8312-91fbf768296f


