### PR TITLE
Fix padding in OpenAPI schemas

### DIFF
--- a/.changeset/proud-jokes-raise.md
+++ b/.changeset/proud-jokes-raise.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix padding in schemas

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -131,7 +131,7 @@
 
 /* Schema Structure */
 .openapi-schema-root {
-    @apply mt-2;
+    /* unstyled */
 }
 
 .openapi-schema-properties {
@@ -655,7 +655,8 @@
     @apply border border-tint-subtle rounded-lg;
 }
 
-.openapi-section-schemas > .openapi-section-body > .openapi-schema-properties > .openapi-schema {
+.openapi-section-schemas > .openapi-section-body > .openapi-schema-properties > .openapi-schema,
+.openapi-section-schemas > .openapi-section-body > .openapi-schema-root {
     @apply p-2.5;
 }
 


### PR DESCRIPTION
Before: 
![CleanShot 2025-03-31 at 10 48 11@2x](https://github.com/user-attachments/assets/b441a270-056e-4869-89a9-19e72fc9c879)

After:
![CleanShot 2025-03-31 at 11 39 33@2x](https://github.com/user-attachments/assets/3bec4552-f073-4d58-84f9-fc163b54854d)
