### PR TITLE
Fix read-only in generateSchemaExample

### DIFF
--- a/.changeset/short-toes-accept.md
+++ b/.changeset/short-toes-accept.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Fix read-only in generateSchemaExample

--- a/packages/react-openapi/src/OpenAPIResponseExample.tsx
+++ b/packages/react-openapi/src/OpenAPIResponseExample.tsx
@@ -268,6 +268,7 @@ function getExamplesFromMediaTypeObject(args: {
                         value: {
                             [root]: generateSchemaExample(mediaTypeObject.schema, {
                                 xml: mediaType === 'application/xml',
+                                mode: 'read',
                             }),
                         },
                     },
@@ -277,7 +278,11 @@ function getExamplesFromMediaTypeObject(args: {
         return [
             {
                 key: 'default',
-                example: { value: generateSchemaExample(mediaTypeObject.schema) },
+                example: {
+                    value: generateSchemaExample(mediaTypeObject.schema, {
+                        mode: 'read',
+                    }),
+                },
             },
         ];
     }

--- a/packages/react-openapi/src/generateSchemaExample.ts
+++ b/packages/react-openapi/src/generateSchemaExample.ts
@@ -16,14 +16,10 @@ export function generateSchemaExample(
     schema: OpenAPIV3.SchemaObject,
     options?: GenerateSchemaExampleOptions
 ): JSONValue | undefined {
-    return getExampleFromSchema(
-        schema,
-        {
-            emptyString: 'text',
-            ...options,
-        },
-        0 // Max depth for circular references
-    );
+    return getExampleFromSchema(schema, {
+        emptyString: 'text',
+        ...options,
+    });
 }
 
 /**
@@ -65,7 +61,7 @@ export function generateMediaTypeExamples(
 }
 
 /** Hard limit for rendering circular references */
-const MAX_LEVELS_DEEP = 3;
+const MAX_LEVELS_DEEP = 5;
 
 const genericExampleValues: Record<string, string> = {
     'date-time': new Date().toISOString(),
@@ -138,14 +134,8 @@ const getExampleFromSchema = (
     level = 0,
     parentSchema?: Record<string, any>,
     name?: string,
-    _resultCache?: WeakMap<Record<string, any>, any>
+    resultCache = new WeakMap<Record<string, any>, any>()
 ): any => {
-    // Create or reset cache on top-level calls
-    const resultCache =
-        level === 0
-            ? new WeakMap<Record<string, any>, any>()
-            : (_resultCache ?? new WeakMap<Record<string, any>, any>());
-
     // Store result in the cache, and return the result
     function cache(schema: Record<string, any>, result: unknown) {
         // Avoid unnecessary WeakMap operations for primitive values


### PR DESCRIPTION
[This page](https://docs.prioticket.com/17A7Wa8N9rDmXDjKNLOX/endpoints/orders#orders-1) has a very long code sample, the cache for shiki is more of a test but I think further work will be needed