### PR TITLE
Hide deprecated properties in examples

### DIFF
--- a/.changeset/two-colts-help.md
+++ b/.changeset/two-colts-help.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/react-openapi": patch
+---
+
+Hide deprecated properties in examples

--- a/packages/react-openapi/src/generateSchemaExample.ts
+++ b/packages/react-openapi/src/generateSchemaExample.ts
@@ -166,6 +166,11 @@ const getExampleFromSchema = (
     // But if `emptyString` is  set, we do want to see some values.
     const makeUpRandomData = !!options?.emptyString;
 
+    // If the property is deprecated we don't show it in examples.
+    if (schema.deprecated) {
+        return undefined;
+    }
+
     // Check if the property is read-only/write-only
     if (
         (options?.mode === 'write' && schema.readOnly) ||


### PR DESCRIPTION
It's the behaviour of Swagger and it makes sense, if the user only
relies on example it will not be tempted of using it.
