### PR TITLE
Desaturate text colours by decreasing chroma for the last steps of the color scale

### DIFF
--- a/.changeset/moody-jeans-explain.md
+++ b/.changeset/moody-jeans-explain.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/colors": patch
+---
+
+Desaturate text colors by decreasing chroma for the last steps of the color scale

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -220,7 +220,7 @@ export function colorScale(
             continue;
         }
 
-        const chromaRatio = index < 8 ? index * 0.05 : 1;
+        const chromaRatio = index === 8 || index === 9 ? 1 : index * 0.05;
 
         const shade = {
             L: targetL, // Blend lightness


### PR DESCRIPTION
This PR decreases the `chromaRatio` for steps 11 and 12 of the color scale (primarily used for text). Before, the `chromaRatio` was increased up to step 8 of the scale, and step 9 and onwards cranked it all the way to `1`, or the full saturation of the original colour. 

This is intended for step 9 and 10 of the scale, which are used as colour fills, but inadvertently also applied a strong saturation to step 11 and 12, resulting in strongly saturated text. The effect is particularly noticeable in dark mode. Light mode masks the effect because the text colour is close enough to black that saturating it doesn't perceptually do much.

With this PR, the high `chromaRatio` is now only set to `1` for step 9 and 10 of the scale. Step 11 and 12 resume the original increasing step function.

# Before
<img width="1401" alt="Screenshot 2025-04-04 at 17 29 22" src="https://github.com/user-attachments/assets/e9b0c3b0-54c6-497e-8305-3e7623d8f5fa" />

# After
<img width="1401" alt="Screenshot 2025-04-04 at 17 29 27" src="https://github.com/user-attachments/assets/232b31e0-6d0f-48ae-8787-69dd9db2707e" />
