### PR TITLE
Fix OpenAPISchemas description padding

### DIFF
--- a/.changeset/lazy-oranges-play.md
+++ b/.changeset/lazy-oranges-play.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix OpenAPISchemas description padding

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -156,6 +156,10 @@
     @apply prose-sm text-balance mt-1.5 !text-[0.813rem] text-tint overflow-hidden !font-normal select-text prose-strong:font-semibold prose-strong:text-inherit;
 }
 
+.openapi-section-schemas > .openapi-section-body > .openapi-schema-root-description {
+    @apply px-2.5 pt-1 !text-sm;
+}
+
 .openapi-schema-properties {
     @apply flex flex-col;
 }


### PR DESCRIPTION
![CleanShot 2025-04-07 at 20 01 25@2x](https://github.com/user-attachments/assets/3bb0d9f9-a771-4545-a70e-d98b6bb44131)
