### PR TITLE
Override Scalar's overscroll-behavior

### DIFF
--- a/.changeset/tame-camels-sparkle.md
+++ b/.changeset/tame-camels-sparkle.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Override Scalar's overscroll-behavior

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/scalar.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/scalar.css
@@ -1,5 +1,11 @@
 @import "@scalar/api-client-react/style.css";
 
+html,
+body {
+    /** Override Scalar's overscroll-behavior */
+    @apply !overscroll-auto;
+}
+
 .light .scalar-modal-layout,
 .light .scalar-app,
 .light .scalar {


### PR DESCRIPTION
Scalar's `overscroll-behavior: none` is preventing 2 fingers back/forward navigation, we can disable it as the body/html has `overflow: hidden` when the modal is open