### PR TITLE
Have all nodes within a text-cells adhere to alignments

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
@@ -115,7 +115,7 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                 return <Tag className={tcls(['w-full', verticalAlignment])}>{''}</Tag>;
             }
 
-            const alignment = getColumnAlignment(definition);
+            const horizontalAlignment = `[&_*]:${getColumnAlignment(definition)} ${getColumnAlignment(definition)}`;
 
             return (
                 <Blocks
@@ -130,8 +130,7 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                         'lg:space-y-3',
                         'leading-normal',
                         verticalAlignment,
-                        alignment === 'right' ? 'text-right' : null,
-                        alignment === 'center' ? 'text-center' : null,
+                        horizontalAlignment,
                     ]}
                     context={context}
                     blockStyle={['w-full', 'max-w-[unset]']}

--- a/packages/gitbook/src/components/DocumentView/Table/ViewGrid.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/ViewGrid.tsx
@@ -42,32 +42,28 @@ export function ViewGrid(props: TableViewProps<DocumentTableViewGrid>) {
                         )}
                     >
                         <div role="row" className={tcls('flex', 'w-full')}>
-                            {view.columns.map((column) => {
-                                const alignment = getColumnAlignment(block.data.definition[column]);
-                                return (
-                                    <div
-                                        key={column}
-                                        role="columnheader"
-                                        className={tcls(
-                                            styles.columnHeader,
-                                            alignment === 'right' ? 'text-right' : null,
-                                            alignment === 'center' ? 'text-center' : null
-                                        )}
-                                        style={{
-                                            width: getColumnWidth({
-                                                column,
-                                                columnWidths,
-                                                autoSizedColumns,
-                                                fixedColumns,
-                                            }),
-                                            minWidth: columnWidths?.[column] || '100px',
-                                        }}
-                                        title={block.data.definition[column].title}
-                                    >
-                                        {block.data.definition[column].title}
-                                    </div>
-                                );
-                            })}
+                            {view.columns.map((column) => (
+                                <div
+                                    key={column}
+                                    role="columnheader"
+                                    className={tcls(
+                                        styles.columnHeader,
+                                        getColumnAlignment(block.data.definition[column])
+                                    )}
+                                    style={{
+                                        width: getColumnWidth({
+                                            column,
+                                            columnWidths,
+                                            autoSizedColumns,
+                                            fixedColumns,
+                                        }),
+                                        minWidth: columnWidths?.[column] || '100px',
+                                    }}
+                                    title={block.data.definition[column].title}
+                                >
+                                    {block.data.definition[column].title}
+                                </div>
+                            ))}
                         </div>
                     </div>
                 )}

--- a/packages/gitbook/src/components/DocumentView/Table/table.module.css
+++ b/packages/gitbook/src/components/DocumentView/Table/table.module.css
@@ -23,7 +23,7 @@
 }
 
 .columnHeader {
-    @apply text-sm font-medium py-2 px-4 text-tint-strong;
+    @apply text-sm font-medium py-2 px-3 text-tint-strong;
 }
 
 .row {

--- a/packages/gitbook/src/components/DocumentView/Table/utils.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/utils.ts
@@ -1,4 +1,5 @@
 import type { ContentRef, DocumentTableDefinition, DocumentTableRecord } from '@gitbook/api';
+import assertNever from 'assert-never';
 
 /**
  * Get the value for a column in a record.
@@ -14,11 +15,24 @@ export function getRecordValue<T extends number | string | boolean | string[] | 
 /**
  * Get the text alignment for a column.
  */
-export function getColumnAlignment(column: DocumentTableDefinition): 'left' | 'right' | 'center' {
+export function getColumnAlignment(column: DocumentTableDefinition) {
+    const defaultAlignment = 'text-left';
+
     if (column.type === 'text') {
-        return column.textAlignment ?? 'left';
+        switch (column.textAlignment) {
+            case undefined:
+            case 'left':
+                return defaultAlignment;
+            case 'center':
+                return 'text-center';
+            case 'right':
+                return 'text-right';
+            default:
+                assertNever(column.textAlignment);
+        }
     }
-    return 'left';
+
+    return defaultAlignment;
 }
 
 /**

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -90,7 +90,7 @@ export function Button({
         'contrast-more:hover:ring-2',
         'contrast-more:hover:ring-tint-12',
 
-        'hover:scale-105',
+        'hover:scale-104',
         'active:scale-100',
         'transition-all',
 

--- a/packages/gitbook/tailwind.config.ts
+++ b/packages/gitbook/tailwind.config.ts
@@ -443,6 +443,7 @@ const config: Config = {
             scale: {
                 '98': '0.98',
                 '102': '1.02',
+                '104': '1.04',
             },
         },
         opacity: opacity(),


### PR DESCRIPTION
Fixes issue raised by aimlapi.com, text cells can receive additional markup including captions. We weren't accounting for those with the alignments, so now we are.

~closes https://linear.app/gitbook-x/issue/RND-6658/annotations-in-table-cells-with-multi-line-text-makes-it-center

Before
![CleanShot 2025-04-22 at 10 12 56@2x](https://github.com/user-attachments/assets/a461782e-d5e2-47db-adf2-04ea02f40918)

After
![CleanShot 2025-04-22 at 10 13 06@2x](https://github.com/user-attachments/assets/c9735406-6b76-42c2-879d-82b02f106e63)

