### PR TITLE
Revert investigation work around URL caches.

### DIFF
--- a/.changeset/sweet-schools-flow.md
+++ b/.changeset/sweet-schools-flow.md
@@ -1,0 +1,6 @@
+---
+"gitbook-v2": patch
+"gitbook": patch
+---
+
+Increase logging around caching behaviour causing page crashes.

--- a/.changeset/sweet-schools-flow.md
+++ b/.changeset/sweet-schools-flow.md
@@ -1,6 +1,0 @@
----
-"gitbook-v2": patch
-"gitbook": patch
----
-
-Increase logging around caching behaviour causing page crashes.

--- a/.changeset/young-games-talk.md
+++ b/.changeset/young-games-talk.md
@@ -1,0 +1,6 @@
+---
+"gitbook": patch
+"gitbook-v2": patch
+---
+
+Revert investigation work around URL caches.

--- a/packages/gitbook-v2/src/lib/context.ts
+++ b/packages/gitbook-v2/src/lib/context.ts
@@ -407,7 +407,7 @@ export function checkIsRootSiteContext(context: GitBookSiteContext): boolean {
 function parseSiteSectionsAndGroups(structure: SiteStructure, siteSectionId: string) {
     const sectionsAndGroups = getSiteStructureSections(structure, { ignoreGroups: false });
     const section = parseCurrentSection(structure, siteSectionId);
-    assert(section, 'A section must be defined when there are multiple sections');
+    assert(section, `couldn't find section "${siteSectionId}" in site structure`);
     return { list: sectionsAndGroups, current: section } satisfies SiteSections;
 }
 

--- a/packages/gitbook-v2/src/lib/context.ts
+++ b/packages/gitbook-v2/src/lib/context.ts
@@ -220,8 +220,6 @@ export async function fetchSiteContextByIds(
 ): Promise<GitBookSiteContext> {
     const { dataFetcher } = baseContext;
 
-    const DEBUG = ids.site === 'site_cu2ih';
-
     const [{ site: orgSite, structure: siteStructure, customizations, scripts }, spaceContext] =
         await Promise.all([
             throwIfDataError(
@@ -233,22 +231,6 @@ export async function fetchSiteContextByIds(
             ),
             fetchSpaceContextByIds(baseContext, ids),
         ]);
-
-    DEBUG && console.log('ids', JSON.stringify(ids));
-    DEBUG &&
-        console.log(
-            'siteStructure',
-            siteStructure
-                ? JSON.stringify({
-                      type: siteStructure.type,
-                      structure: siteStructure.structure.map((s) => {
-                          // @ts-ignore
-                          const { siteSpaces, urls, ...rest } = s;
-                          return rest;
-                      }),
-                  })
-                : 'null'
-        );
 
     // override the title with the customization title
     // TODO: remove this hack once we have a proper way to handle site customizations
@@ -425,7 +407,7 @@ export function checkIsRootSiteContext(context: GitBookSiteContext): boolean {
 function parseSiteSectionsAndGroups(structure: SiteStructure, siteSectionId: string) {
     const sectionsAndGroups = getSiteStructureSections(structure, { ignoreGroups: false });
     const section = parseCurrentSection(structure, siteSectionId);
-    assert(section, `couldn't find section "${siteSectionId}" in site structure`);
+    assert(section, 'A section must be defined when there are multiple sections');
     return { list: sectionsAndGroups, current: section } satisfies SiteSections;
 }
 

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -674,9 +674,6 @@ async function lookupSiteByAPI(
             }
         );
 
-        alternative.url.includes('minas-tirith') &&
-            console.log(`resolved ${alternative.url} -> ${JSON.stringify(data)}`);
-
         if ('error' in data) {
             if (alternative.primary) {
                 // We only return an error for the primary alternative (full URL),


### PR DESCRIPTION
Revert any logging and other investigation work around URL caches.
