### PR TITLE
Reduce chroma of text layers

### DIFF
--- a/.changeset/eight-vans-judge.md
+++ b/.changeset/eight-vans-judge.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/colors": patch
+---
+
+Update chroma ratio per step

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -220,7 +220,21 @@ export function colorScale(
             continue;
         }
 
-        const chromaRatio = index === 8 || index === 9 ? 1 : index * 0.05;
+        const chromaRatio = (() => {
+            switch (index) {
+                // Step 9 and 10 have max chroma, meaning they are fully saturated.
+                case 8:
+                case 9:
+                    return 1;
+                // Step 12 is fully desaturated
+                case 10:
+                    return 0.4;
+                case 11:
+                    return 0.1;
+                default:
+                    return index * 0.05;
+            }
+        })();
 
         const shade = {
             L: targetL, // Blend lightness


### PR DESCRIPTION
This PR updates the chroma ratios per step, specifically reducing the chroma of the text steps (step 11 and 12) of the color scale. This results in more desaturated and readable text, no matter the selected tint.