### PR TITLE
Allow /~gitbook/image and /~gitbook/icon despite querystring parameters for SEO in robots.txt

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     ],
     "tailwindCSS.classAttributes": ["class", "className", "style", ".*Style"],
     "prettier.enable": false,
+    "editor.formatOnSave": true,
     "editor.defaultFormatter": "biomejs.biome",
     "editor.codeActionsOnSave": {
         "source.organizeImports.biome": "explicit",

--- a/packages/gitbook/src/routes/robots.ts
+++ b/packages/gitbook/src/routes/robots.ts
@@ -8,20 +8,23 @@ export async function serveRobotsTxt(context: GitBookSiteContext) {
     const { linker } = context;
 
     const isRoot = checkIsRootSiteContext(context);
-    const lines = [
-        'User-agent: *',
-        // Disallow dynamic routes / search queries
-        'Disallow: /*?',
-        ...((await isSiteIndexable(context))
-            ? [
-                  'Allow: /',
-                  `Sitemap: ${linker.toAbsoluteURL(linker.toPathInSpace(isRoot ? '/sitemap.xml' : '/sitemap-pages.xml'))}`,
-              ]
-            : ['Disallow: /']),
-    ];
-    const content = lines.join('\n');
+    const isIndexable = await isSiteIndexable(context);
 
-    return new Response(content, {
+    const lines = isIndexable
+        ? [
+              'User-agent: *',
+              // Allow image resizing and icon generation routes for favicons and search results
+              'Allow: /~gitbook/image?*',
+              'Allow: /~gitbook/icon?*',
+              // Disallow other dynamic routes / search queries
+              'Disallow: /*?',
+              'Allow: /',
+              `Sitemap: ${linker.toAbsoluteURL(linker.toPathInSpace(isRoot ? '/sitemap.xml' : '/sitemap-pages.xml'))}`,
+          ]
+        : ['User-agent: *', 'Disallow: /'];
+
+    const robotsTxt = lines.join('\n');
+    return new Response(robotsTxt, {
         headers: {
             'Content-Type': 'text/plain',
         },


### PR DESCRIPTION
Because currently these paths aren't allowed via the `robots.txt` file, preventing favicons to appear in search results, and images too.