### PR TITLE
Fix OpenAPI disclosure label ("Show properties") misalignment on mobile

### DIFF
--- a/.changeset/young-poets-cry.md
+++ b/.changeset/young-poets-cry.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix OpenAPI disclosure label ("Show properties") misalignment on mobile

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -806,7 +806,7 @@ body:has(.openapi-select-popover) {
 @media (hover: none) {
     /* Make button label always visible on non-hover devices like phones */
     .openapi-disclosure-trigger-label {
-        @apply relative ring-1 bg-tint-base;
+        @apply relative ring-1 bg-tint-base right-0;
     }
     .openapi-disclosure-trigger-label span {
         @apply block;


### PR DESCRIPTION
# Before
![CleanShot 2025-04-29 at 18 28 55@2x](https://github.com/user-attachments/assets/7208b6c8-875f-4356-95ce-4a658ffc8fd6)

# After
![CleanShot 2025-04-29 at 18 28 50@2x](https://github.com/user-attachments/assets/1299594a-384f-439b-9669-9a44592e3975)