### PR TITLE
Revert getPublishedContentByUrl timeout back to 10s

### DIFF
--- a/packages/gitbook/src/lib/api.ts
+++ b/packages/gitbook/src/lib/api.ts
@@ -242,7 +242,6 @@ export const getLatestOpenAPISpecVersionContent = cache({
  * Resolve a URL to the content to render.
  */
 export const getPublishedContentByUrl = cache({
-    timeout: 30 * 1000,
     name: 'api.getPublishedContentByUrl.v7',
     tag: (url) => getCacheTagForURL(url),
     get: async (


### PR DESCRIPTION
Queries are fixed so no need for a larger timeout