### PR TITLE
Allow high-contrast input colors to be used as-is

### DIFF
--- a/.changeset/rich-lamps-compare.md
+++ b/.changeset/rich-lamps-compare.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/colors": patch
+---
+
+Change lightness check for color step 9 to allow input colors with a higher-than-needed contrast

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -214,7 +214,11 @@ export function colorScale(
         const targetL =
             foregroundColor.L * mapping[index] + backgroundColor.L * (1 - mapping[index]);
 
-        if (index === 8 && !mix && Math.abs(baseColor.L - targetL) < 0.2) {
+        if (
+            index === 8 &&
+            !mix &&
+            (darkMode ? targetL - baseColor.L < 0.2 : baseColor.L - targetL < 0.2)
+        ) {
             // Original colour is close enough to target, so let's use the original colour as step 9.
             result.push(hex);
             continue;


### PR DESCRIPTION
For step 9 of the color scale, we try to respect the user's chosen color, unless it really isn't accessible. We use a lightness check and if the color is within 20% of the target lightness, we allow it to be used even if it doesn't exactly match.

This PR changes the logic of this check slightly to no longer restrict the _lower and higher_ contrast bounds, but only the _lower_ bound. In practice, it means that if you have a color that is _higher contrast than needed_, it will now be used as-is instead of being reduced to a less-contrasting version.

This is particularly useful if you set the primary color to black on light mode, or white on dark mode. Before this would result in a grey color being used for your buttons, but now you can get exact blacks or whites since they are more contrasting anyway.

Before

![CleanShot 2025-05-02 at 19 25 35@2x](https://github.com/user-attachments/assets/0fc24c0e-c02e-4422-9adb-553f64451034)

After

![CleanShot 2025-05-02 at 19 25 40@2x](https://github.com/user-attachments/assets/041d4aaf-83dd-4d22-bc91-25f9037d2a4c)
