### PR TITLE
Use absolute URLs in sitemap.xml when pointing to sitemap-pages.xml

### DIFF
--- a/.changeset/real-donkeys-invent.md
+++ b/.changeset/real-donkeys-invent.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix invalid sitemap.xml generated with relative URLs instead of absolute ones

--- a/packages/gitbook/src/routes/sitemap.ts
+++ b/packages/gitbook/src/routes/sitemap.ts
@@ -141,7 +141,7 @@ function getUrlsFromSiteSpaces(context: GitBookSiteContext, siteSpaces: SiteSpac
         }
         const url = new URL(siteSpace.urls.published);
         url.pathname = joinPath(url.pathname, 'sitemap-pages.xml');
-        return context.linker.toLinkForContent(url.toString());
+        return context.linker.toAbsoluteURL(context.linker.toLinkForContent(url.toString()));
     }, []);
     return urls.filter(filterOutNullable);
 }


### PR DESCRIPTION
> Every <loc> must be a fully‑qualified URI (scheme + host + path).See §3.1 of the Sitemap protocol and RFC 3986.
