### PR TITLE
Improve tabs link support

### DIFF
--- a/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
@@ -7,7 +7,7 @@ import { getBlockTextStyle } from './spacing';
  * A hash icon which adds the block or active block item's ID in the URL hash.
  * The button needs to be wrapped in a container with `hashLinkButtonWrapperStyles`.
  */
-export const hashLinkButtonWrapperStyles = tcls('relative', 'group');
+export const hashLinkButtonWrapperStyles = tcls('relative', 'group/hash');
 
 export function HashLinkButton(props: {
     id: string;
@@ -28,10 +28,10 @@ export function HashLinkButton(props: {
                 'h-[1em]',
                 'border-0',
                 'opacity-0',
-                'group-hover:opacity-[0]',
-                'group-focus:opacity-[0]',
-                'md:group-hover:md:opacity-[1]',
-                'md:group-focus:md:opacity-[1]',
+                'group-hover/hash:opacity-[0]',
+                'group-focus/hash:opacity-[0]',
+                'md:group-hover/hash:md:opacity-[1]',
+                'md:group-focus/hash:md:opacity-[1]',
                 className
             )}
         >
@@ -47,8 +47,8 @@ export function HashLinkButton(props: {
                         'self-center',
                         'transition-colors',
                         'text-transparent',
-                        'group-hover:text-tint-subtle',
-                        'contrast-more:group-hover:text-tint-strong',
+                        'group-hover/hash:text-tint-subtle',
+                        'contrast-more:group-hover/hash:text-tint-strong',
                         iconClassName
                     )}
                 />

--- a/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
@@ -24,6 +24,7 @@ export function HashLinkButton(props: {
                 'grid',
                 'grid-area-1-1',
                 'w-7',
+                'h-[1em]',
                 'border-0',
                 'opacity-0',
                 'group-hover:opacity-[0]',
@@ -42,6 +43,8 @@ export function HashLinkButton(props: {
                     icon="hashtag"
                     className={tcls(
                         'size-4',
+                        'mt-1',
+                        'self-center',
                         'transition-colors',
                         'text-transparent',
                         'group-hover:text-tint-subtle',

--- a/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
@@ -1,0 +1,54 @@
+import { type ClassValue, tcls } from '@/lib/tailwind';
+import type { DocumentBlockHeading, DocumentBlockTabs } from '@gitbook/api';
+import { Icon } from '@gitbook/icons';
+import { getBlockTextStyle } from './spacing';
+
+/**
+ * A hash icon which adds the block or active block item's ID in the URL hash.
+ */
+export function HashLinkButton(props: {
+    id: string;
+    block: DocumentBlockTabs | DocumentBlockHeading;
+    label?: string;
+    className?: ClassValue;
+}) {
+    const { id, block, className, label = 'Direct link to block' } = props;
+    const textStyle = getBlockTextStyle(block);
+    return (
+        <div
+            className={tcls(
+                'hash',
+                'grid',
+                'grid-area-1-1',
+                // 'absolute',
+                // 'left-0',
+                // 'top-1',
+                'w-7',
+                'border-0',
+                'opacity-0',
+                'group-hover:opacity-[0]',
+                'group-focus:opacity-[0]',
+                'md:group-hover:md:opacity-[1]',
+                'md:group-focus:md:opacity-[1]',
+                className
+            )}
+        >
+            <a
+                href={`#${id}`}
+                aria-label={label}
+                className={tcls('inline-flex', 'h-full', 'items-start', textStyle.lineHeight)}
+            >
+                <Icon
+                    icon="hashtag"
+                    className={tcls(
+                        'size-4',
+                        'transition-colors',
+                        'text-transparent',
+                        'group-hover:text-tint-subtle',
+                        'contrast-more:group-hover:text-tint-strong'
+                    )}
+                />
+            </a>
+        </div>
+    );
+}

--- a/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
@@ -5,7 +5,10 @@ import { getBlockTextStyle } from './spacing';
 
 /**
  * A hash icon which adds the block or active block item's ID in the URL hash.
+ * The button needs to be wrapped in a container with `hashLinkButtonWrapperStyles`.
  */
+export const hashLinkButtonWrapperStyles = tcls('relative', 'group');
+
 export function HashLinkButton(props: {
     id: string;
     block: DocumentBlockTabs | DocumentBlockHeading;
@@ -20,9 +23,6 @@ export function HashLinkButton(props: {
                 'hash',
                 'grid',
                 'grid-area-1-1',
-                // 'absolute',
-                // 'left-0',
-                // 'top-1',
                 'w-7',
                 'border-0',
                 'opacity-0',

--- a/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/HashLinkButton.tsx
@@ -14,16 +14,17 @@ export function HashLinkButton(props: {
     block: DocumentBlockTabs | DocumentBlockHeading;
     label?: string;
     className?: ClassValue;
+    iconClassName?: ClassValue;
 }) {
-    const { id, block, className, label = 'Direct link to block' } = props;
+    const { id, block, className, iconClassName, label = 'Direct link to block' } = props;
     const textStyle = getBlockTextStyle(block);
     return (
         <div
             className={tcls(
+                'relative',
                 'hash',
                 'grid',
                 'grid-area-1-1',
-                'w-7',
                 'h-[1em]',
                 'border-0',
                 'opacity-0',
@@ -42,13 +43,13 @@ export function HashLinkButton(props: {
                 <Icon
                     icon="hashtag"
                     className={tcls(
-                        'size-4',
-                        'mt-1',
+                        'size-3',
                         'self-center',
                         'transition-colors',
                         'text-transparent',
                         'group-hover:text-tint-subtle',
-                        'contrast-more:group-hover:text-tint-strong'
+                        'contrast-more:group-hover:text-tint-strong',
+                        iconClassName
                     )}
                 />
             </a>

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -32,8 +32,8 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
             <HashLinkButton
                 id={id}
                 block={block}
-                className={tcls('-ml-6')}
-                iconClassName={tcls('size-4', textStyle.anchorButtonMarginTop)}
+                className={tcls('-ml-6', textStyle.anchorButtonMarginTop)}
+                iconClassName={tcls('size-4')}
                 label="Direct link to heading"
             />
 

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -32,7 +32,7 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
             <HashLinkButton
                 id={id}
                 block={block}
-                className={tcls('relative', '-ml-6', 'top-1', textStyle.marginTop)}
+                className={tcls('relative', '-ml-6', textStyle.marginTop)}
             />
 
             <div

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -33,6 +33,7 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
                 id={id}
                 block={block}
                 className={tcls('relative', '-ml-6', textStyle.marginTop)}
+                label="Direct link to heading"
             />
 
             <div

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -3,7 +3,7 @@ import type { DocumentBlockHeading } from '@gitbook/api';
 import { tcls } from '@/lib/tailwind';
 
 import type { BlockProps } from './Block';
-import { HashLinkButton } from './HashLinkButton';
+import { HashLinkButton, hashLinkButtonWrapperStyles } from './HashLinkButton';
 import { Inlines } from './Inlines';
 import { getBlockTextStyle } from './spacing';
 
@@ -23,10 +23,9 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
             className={tcls(
                 textStyle.textSize,
                 'heading',
-                'group',
-                'relative',
                 'grid',
                 'scroll-m-12',
+                hashLinkButtonWrapperStyles,
                 style
             )}
         >

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -1,9 +1,9 @@
 import type { DocumentBlockHeading } from '@gitbook/api';
-import { Icon } from '@gitbook/icons';
 
 import { tcls } from '@/lib/tailwind';
 
 import type { BlockProps } from './Block';
+import { HashLinkButton } from './HashLinkButton';
 import { Inlines } from './Inlines';
 import { getBlockTextStyle } from './spacing';
 
@@ -30,43 +30,12 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
                 style
             )}
         >
-            <div
-                className={tcls(
-                    'hash',
-                    'grid',
-                    'grid-area-1-1',
-                    'relative',
-                    '-ml-6',
-                    'w-7',
-                    'border-0',
-                    'opacity-0',
-                    'group-hover:opacity-[0]',
-                    'group-focus:opacity-[0]',
-                    'md:group-hover:md:opacity-[1]',
-                    'md:group-focus:md:opacity-[1]',
-                    textStyle.marginTop
-                )}
-            >
-                <a
-                    href={`#${id}`}
-                    aria-label="Direct link to heading"
-                    className={tcls('inline-flex', 'h-full', 'items-start', textStyle.lineHeight)}
-                >
-                    <Icon
-                        icon="hashtag"
-                        className={tcls(
-                            'w-3.5',
-                            'h-[1em]',
-                            'mt-0.5',
-                            'transition-colors',
-                            'text-transparent',
-                            'group-hover:text-tint-subtle',
-                            'contrast-more:group-hover:text-tint-strong',
-                            'lg:w-4'
-                        )}
-                    />
-                </a>
-            </div>
+            <HashLinkButton
+                id={id}
+                block={block}
+                className={tcls('relative', '-ml-6', 'top-1', textStyle.marginTop)}
+            />
+
             <div
                 className={tcls(
                     'grid-area-1-1',

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -32,7 +32,8 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
             <HashLinkButton
                 id={id}
                 block={block}
-                className={tcls('relative', '-ml-6', textStyle.marginTop)}
+                className={tcls('-ml-6')}
+                iconClassName={tcls('size-4', textStyle.anchorButtonMarginTop)}
                 label="Direct link to heading"
             />
 

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -5,6 +5,8 @@ import React, { useCallback, useMemo } from 'react';
 import { useHash, useIsMounted } from '@/components/hooks';
 import * as storage from '@/lib/local-storage';
 import { type ClassValue, tcls } from '@/lib/tailwind';
+import type { DocumentBlockTabs } from '@gitbook/api';
+import { HashLinkButton } from '../HashLinkButton';
 
 interface TabsState {
     activeIds: {
@@ -68,9 +70,10 @@ export function DynamicTabs(
     props: TabsInput & {
         tabsBody: React.ReactNode[];
         style: ClassValue;
+        block: DocumentBlockTabs;
     }
 ) {
-    const { id, tabs, tabsBody, style } = props;
+    const { id, block, tabs, tabsBody, style } = props;
 
     const hash = useHash();
     const [tabsState, setTabsState] = useTabsState();
@@ -138,107 +141,115 @@ export function DynamicTabs(
     }, [hash, tabs, onSelectTab]);
 
     return (
-        <div
-            className={tcls(
-                'rounded-lg',
-                'straight-corners:rounded-sm',
-                'ring-1',
-                'ring-inset',
-                'ring-tint-subtle',
-                'flex',
-                'overflow-hidden',
-                'flex-col',
-                style
-            )}
-        >
+        <div className={tcls('relative', 'group')}>
+            <HashLinkButton
+                id={getTabButtonId(active.id)}
+                block={block}
+                className={tcls('absolute', 'left-0', 'top-1')}
+            />
+
             <div
-                role="tablist"
                 className={tcls(
-                    'group/tabs',
-                    'inline-flex',
-                    'flex-row',
-                    'self-stretch',
-                    'after:flex-[1]',
-                    'after:bg-tint-12/1',
-                    // if last tab is selected, apply rounded to :after element
-                    '[&:has(button.active-tab:last-of-type):after]:rounded-bl-md'
+                    'rounded-lg',
+                    'straight-corners:rounded-sm',
+                    'ring-1',
+                    'ring-inset',
+                    'ring-tint-subtle',
+                    'flex',
+                    'overflow-hidden',
+                    'flex-col',
+                    style
                 )}
             >
-                {tabs.map((tab) => (
-                    <button
+                <div
+                    role="tablist"
+                    className={tcls(
+                        'group/tabs',
+                        'inline-flex',
+                        'flex-row',
+                        'self-stretch',
+                        'after:flex-[1]',
+                        'after:bg-tint-12/1',
+                        // if last tab is selected, apply rounded to :after element
+                        '[&:has(button.active-tab:last-of-type):after]:rounded-bl-md'
+                    )}
+                >
+                    {tabs.map((tab) => (
+                        <button
+                            key={tab.id}
+                            role="tab"
+                            aria-selected={active.id === tab.id}
+                            aria-controls={getTabPanelId(tab.id)}
+                            id={getTabButtonId(tab.id)}
+                            onClick={() => {
+                                onSelectTab(tab);
+                            }}
+                            className={tcls(
+                                //prev from active-tab
+                                '[&:has(+_.active-tab)]:rounded-br-md',
+
+                                //next from active-tab
+                                '[.active-tab_+_&]:rounded-bl-md',
+
+                                //next from active-tab
+                                '[.active-tab_+_:after]:rounded-br-md',
+
+                                'inline-block',
+                                'text-sm',
+                                'px-3.5',
+                                'py-2',
+                                'transition-[color]',
+                                'font-[500]',
+                                'relative',
+
+                                'after:transition-colors',
+                                'after:border-r',
+                                'after:absolute',
+                                'after:left-[unset]',
+                                'after:right-0',
+                                'after:border-tint',
+                                'after:top-[15%]',
+                                'after:h-[70%]',
+                                'after:w-[1px]',
+
+                                'last:after:border-transparent',
+
+                                'text-tint',
+                                'bg-tint-12/1',
+                                'hover:text-tint-strong',
+
+                                'truncate',
+                                'max-w-full',
+
+                                active.id === tab.id
+                                    ? [
+                                          'shrink-0',
+                                          'active-tab',
+                                          'text-tint-strong',
+                                          'bg-transparent',
+                                          'after:[&.active-tab]:border-transparent',
+                                          'after:[:has(+_&.active-tab)]:border-transparent',
+                                          'after:[:has(&_+)]:border-transparent',
+                                      ]
+                                    : null
+                            )}
+                        >
+                            {tab.title}
+                        </button>
+                    ))}
+                </div>
+                {tabs.map((tab, index) => (
+                    <div
                         key={tab.id}
-                        role="tab"
-                        aria-selected={active.id === tab.id}
-                        aria-controls={getTabPanelId(tab.id)}
-                        id={getTabButtonId(tab.id)}
-                        onClick={() => {
-                            onSelectTab(tab);
-                        }}
-                        className={tcls(
-                            //prev from active-tab
-                            '[&:has(+_.active-tab)]:rounded-br-md',
-
-                            //next from active-tab
-                            '[.active-tab_+_&]:rounded-bl-md',
-
-                            //next from active-tab
-                            '[.active-tab_+_:after]:rounded-br-md',
-
-                            'inline-block',
-                            'text-sm',
-                            'px-3.5',
-                            'py-2',
-                            'transition-[color]',
-                            'font-[500]',
-                            'relative',
-
-                            'after:transition-colors',
-                            'after:border-r',
-                            'after:absolute',
-                            'after:left-[unset]',
-                            'after:right-0',
-                            'after:border-tint',
-                            'after:top-[15%]',
-                            'after:h-[70%]',
-                            'after:w-[1px]',
-
-                            'last:after:border-transparent',
-
-                            'text-tint',
-                            'bg-tint-12/1',
-                            'hover:text-tint-strong',
-
-                            'truncate',
-                            'max-w-full',
-
-                            active.id === tab.id
-                                ? [
-                                      'shrink-0',
-                                      'active-tab',
-                                      'text-tint-strong',
-                                      'bg-transparent',
-                                      'after:[&.active-tab]:border-transparent',
-                                      'after:[:has(+_&.active-tab)]:border-transparent',
-                                      'after:[:has(&_+)]:border-transparent',
-                                  ]
-                                : null
-                        )}
+                        role="tabpanel"
+                        id={getTabPanelId(tab.id)}
+                        aria-labelledby={getTabButtonId(tab.id)}
+                        className={tcls('p-4', tab.id !== active.id ? 'hidden' : null)}
                     >
-                        {tab.title}
-                    </button>
+                        {tabsBody[index]}
+                    </div>
                 ))}
             </div>
-            {tabs.map((tab, index) => (
-                <div
-                    key={tab.id}
-                    role="tabpanel"
-                    id={getTabPanelId(tab.id)}
-                    aria-labelledby={getTabButtonId(tab.id)}
-                    className={tcls('p-4', tab.id !== active.id ? 'hidden' : null)}
-                >
-                    {tabsBody[index]}
-                </div>
-            ))}
         </div>
     );
 }

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -141,11 +141,11 @@ export function DynamicTabs(
     }, [hash, tabs, onSelectTab]);
 
     return (
-        <div className={hashLinkButtonWrapperStyles}>
+        <div className={tcls(hashLinkButtonWrapperStyles, 'flex', style)}>
             <HashLinkButton
                 id={getTabButtonId(active.id)}
                 block={block}
-                className={tcls('absolute', block.data?.fullWidth ? '-left-6' : 'left-6')}
+                className={tcls('absolute', '-left-6')}
             />
 
             <div
@@ -157,8 +157,7 @@ export function DynamicTabs(
                     'ring-tint-subtle',
                     'flex',
                     'overflow-hidden',
-                    'flex-col',
-                    style
+                    'flex-col'
                 )}
             >
                 <div

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -172,7 +172,9 @@ export function DynamicTabs(
                         key={tab.id}
                         className={tcls(
                             hashLinkButtonWrapperStyles,
-                            'flex items-center gap-3.5',
+                            'flex',
+                            'items-center',
+                            'gap-3.5',
 
                             //prev from active-tab
                             '[&:has(+_.active-tab)]:rounded-br-md',

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -204,7 +204,6 @@ export function DynamicTabs(
                             'bg-tint-12/1',
                             'hover:text-tint-strong',
                             'max-w-72',
-                            'truncate',
 
                             active.id === tab.id
                                 ? [
@@ -233,9 +232,7 @@ export function DynamicTabs(
                                 'transition-[color]',
                                 'font-[500]',
                                 'relative',
-
-                                'truncate',
-                                'max-w-full'
+                                'truncate'
                             )}
                         >
                             {tab.title}

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -145,7 +145,7 @@ export function DynamicTabs(
             <HashLinkButton
                 id={getTabButtonId(active.id)}
                 block={block}
-                className={tcls('absolute', 'left-0', 'top-1')}
+                className={tcls('absolute', 'left-6')}
             />
 
             <div

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -141,7 +141,7 @@ export function DynamicTabs(
     }, [hash, tabs, onSelectTab]);
 
     return (
-        <div className={tcls(hashLinkButtonWrapperStyles, 'flex', style)}>
+        <div className={tcls(hashLinkButtonWrapperStyles, 'w-full', style)}>
             <HashLinkButton
                 id={getTabButtonId(active.id)}
                 block={block}

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -141,42 +141,83 @@ export function DynamicTabs(
     }, [hash, tabs, onSelectTab]);
 
     return (
-        <div className={tcls(hashLinkButtonWrapperStyles, 'flex-1', style)}>
-            <HashLinkButton
-                id={getTabButtonId(active.id)}
-                block={block}
-                className={tcls('absolute', '-left-6')}
-                label="Direct link to selected tab"
-            />
-
+        <div
+            className={tcls(
+                'rounded-lg',
+                'straight-corners:rounded-sm',
+                'ring-1',
+                'ring-inset',
+                'ring-tint-subtle',
+                'flex',
+                'overflow-hidden',
+                'flex-col',
+                style
+            )}
+        >
             <div
+                role="tablist"
                 className={tcls(
-                    'rounded-lg',
-                    'straight-corners:rounded-sm',
-                    'ring-1',
-                    'ring-inset',
-                    'ring-tint-subtle',
-                    'flex',
-                    'overflow-hidden',
-                    'flex-col'
+                    'group/tabs',
+                    'inline-flex',
+                    'flex-row',
+                    'self-stretch',
+                    'after:flex-[1]',
+                    'after:bg-tint-12/1',
+                    // if last tab is selected, apply rounded to :after element
+                    '[&:has(button.active-tab:last-of-type):after]:rounded-bl-md'
                 )}
             >
-                <div
-                    role="tablist"
-                    className={tcls(
-                        'group/tabs',
-                        'inline-flex',
-                        'flex-row',
-                        'self-stretch',
-                        'after:flex-[1]',
-                        'after:bg-tint-12/1',
-                        // if last tab is selected, apply rounded to :after element
-                        '[&:has(button.active-tab:last-of-type):after]:rounded-bl-md'
-                    )}
-                >
-                    {tabs.map((tab) => (
+                {tabs.map((tab) => (
+                    <div
+                        key={tab.id}
+                        className={tcls(
+                            hashLinkButtonWrapperStyles,
+                            'flex items-center gap-3.5',
+
+                            //prev from active-tab
+                            '[&:has(+_.active-tab)]:rounded-br-md',
+
+                            //next from active-tab
+                            '[.active-tab_+_&]:rounded-bl-md',
+
+                            //next from active-tab
+                            '[.active-tab_+_:after]:rounded-br-md',
+
+                            'after:transition-colors',
+                            'after:border-r',
+                            'after:absolute',
+                            'after:left-[unset]',
+                            'after:right-0',
+                            'after:border-tint',
+                            'after:top-[15%]',
+                            'after:h-[70%]',
+                            'after:w-[1px]',
+
+                            'px-3.5',
+                            'py-2',
+
+                            'last:after:border-transparent',
+
+                            'text-tint',
+                            'bg-tint-12/1',
+                            'hover:text-tint-strong',
+                            'max-w-72',
+                            'truncate',
+
+                            active.id === tab.id
+                                ? [
+                                      'shrink-0',
+                                      'active-tab',
+                                      'text-tint-strong',
+                                      'bg-transparent',
+                                      'after:[&.active-tab]:border-transparent',
+                                      'after:[:has(+_&.active-tab)]:border-transparent',
+                                      'after:[:has(&_+)]:border-transparent',
+                                  ]
+                                : null
+                        )}
+                    >
                         <button
-                            key={tab.id}
                             role="tab"
                             aria-selected={active.id === tab.id}
                             aria-controls={getTabPanelId(tab.id)}
@@ -185,71 +226,38 @@ export function DynamicTabs(
                                 onSelectTab(tab);
                             }}
                             className={tcls(
-                                //prev from active-tab
-                                '[&:has(+_.active-tab)]:rounded-br-md',
-
-                                //next from active-tab
-                                '[.active-tab_+_&]:rounded-bl-md',
-
-                                //next from active-tab
-                                '[.active-tab_+_:after]:rounded-br-md',
-
                                 'inline-block',
                                 'text-sm',
-                                'px-3.5',
-                                'py-2',
                                 'transition-[color]',
                                 'font-[500]',
                                 'relative',
 
-                                'after:transition-colors',
-                                'after:border-r',
-                                'after:absolute',
-                                'after:left-[unset]',
-                                'after:right-0',
-                                'after:border-tint',
-                                'after:top-[15%]',
-                                'after:h-[70%]',
-                                'after:w-[1px]',
-
-                                'last:after:border-transparent',
-
-                                'text-tint',
-                                'bg-tint-12/1',
-                                'hover:text-tint-strong',
-
                                 'truncate',
-                                'max-w-full',
-
-                                active.id === tab.id
-                                    ? [
-                                          'shrink-0',
-                                          'active-tab',
-                                          'text-tint-strong',
-                                          'bg-transparent',
-                                          'after:[&.active-tab]:border-transparent',
-                                          'after:[:has(+_&.active-tab)]:border-transparent',
-                                          'after:[:has(&_+)]:border-transparent',
-                                      ]
-                                    : null
+                                'max-w-full'
                             )}
                         >
                             {tab.title}
                         </button>
-                    ))}
-                </div>
-                {tabs.map((tab, index) => (
-                    <div
-                        key={tab.id}
-                        role="tabpanel"
-                        id={getTabPanelId(tab.id)}
-                        aria-labelledby={getTabButtonId(tab.id)}
-                        className={tcls('p-4', tab.id !== active.id ? 'hidden' : null)}
-                    >
-                        {tabsBody[index]}
+
+                        <HashLinkButton
+                            id={getTabButtonId(tab.id)}
+                            block={block}
+                            label="Direct link to heading"
+                        />
                     </div>
                 ))}
             </div>
+            {tabs.map((tab, index) => (
+                <div
+                    key={tab.id}
+                    role="tabpanel"
+                    id={getTabPanelId(tab.id)}
+                    aria-labelledby={getTabButtonId(tab.id)}
+                    className={tcls('p-4', tab.id !== active.id ? 'hidden' : null)}
+                >
+                    {tabsBody[index]}
+                </div>
+            ))}
         </div>
     );
 }

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -241,7 +241,7 @@ export function DynamicTabs(
                         <HashLinkButton
                             id={getTabButtonId(tab.id)}
                             block={block}
-                            label="Direct link to heading"
+                            label="Direct link to tab"
                         />
                     </div>
                 ))}

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -141,7 +141,7 @@ export function DynamicTabs(
     }, [hash, tabs, onSelectTab]);
 
     return (
-        <div className={tcls(hashLinkButtonWrapperStyles, 'w-full', style)}>
+        <div className={tcls(hashLinkButtonWrapperStyles, 'flex-1', style)}>
             <HashLinkButton
                 id={getTabButtonId(active.id)}
                 block={block}

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -6,7 +6,7 @@ import { useHash, useIsMounted } from '@/components/hooks';
 import * as storage from '@/lib/local-storage';
 import { type ClassValue, tcls } from '@/lib/tailwind';
 import type { DocumentBlockTabs } from '@gitbook/api';
-import { HashLinkButton } from '../HashLinkButton';
+import { HashLinkButton, hashLinkButtonWrapperStyles } from '../HashLinkButton';
 
 interface TabsState {
     activeIds: {
@@ -141,7 +141,7 @@ export function DynamicTabs(
     }, [hash, tabs, onSelectTab]);
 
     return (
-        <div className={tcls('relative', 'group')}>
+        <div className={hashLinkButtonWrapperStyles}>
             <HashLinkButton
                 id={getTabButtonId(active.id)}
                 block={block}

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -145,7 +145,7 @@ export function DynamicTabs(
             <HashLinkButton
                 id={getTabButtonId(active.id)}
                 block={block}
-                className={tcls('absolute', 'left-6')}
+                className={tcls('absolute', block.data?.fullWidth ? '-left-6' : 'left-6')}
             />
 
             <div

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -149,8 +149,8 @@ export function DynamicTabs(
                 'ring-inset',
                 'ring-tint-subtle',
                 'flex',
-                'overflow-hidden',
                 'flex-col',
+                'overflow-hidden',
                 style
             )}
         >
@@ -203,7 +203,8 @@ export function DynamicTabs(
                             'text-tint',
                             'bg-tint-12/1',
                             'hover:text-tint-strong',
-                            'max-w-72',
+                            'max-w-full',
+                            'truncate',
 
                             active.id === tab.id
                                 ? [
@@ -233,6 +234,7 @@ export function DynamicTabs(
                                 'transition-[color]',
                                 'font-[500]',
                                 'relative',
+                                'max-w-full',
                                 'truncate'
                             )}
                         >

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -146,6 +146,7 @@ export function DynamicTabs(
                 id={getTabButtonId(active.id)}
                 block={block}
                 className={tcls('absolute', '-left-6')}
+                label="Direct link to selected tab"
             />
 
             <div

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -219,6 +219,7 @@ export function DynamicTabs(
                         )}
                     >
                         <button
+                            type="button"
                             role="tab"
                             aria-selected={active.id === tab.id}
                             aria-controls={getTabPanelId(tab.id)}

--- a/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
@@ -39,6 +39,7 @@ export function Tabs(props: BlockProps<DocumentBlockTabs>) {
                     <DynamicTabs
                         key={tab.id}
                         id={block.key!}
+                        block={block}
                         tabs={[tab]}
                         tabsBody={[tabsBody[index]]}
                         style={style}
@@ -48,5 +49,7 @@ export function Tabs(props: BlockProps<DocumentBlockTabs>) {
         );
     }
 
-    return <DynamicTabs id={block.key!} tabs={tabs} tabsBody={tabsBody} style={style} />;
+    return (
+        <DynamicTabs id={block.key!} block={block} tabs={tabs} tabsBody={tabsBody} style={style} />
+    );
 }

--- a/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
@@ -26,7 +26,7 @@ export function Tabs(props: BlockProps<DocumentBlockTabs>) {
                 ancestorBlocks={[...ancestorBlocks, block, tab]}
                 context={context}
                 blockStyle={tcls('flip-heading-hash')}
-                style={tcls('w-full', 'space-y-4')}
+                style={tcls(block.data?.fullWidth ? 'w-full' : null, 'space-y-4')}
             />
         );
     });

--- a/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/Tabs.tsx
@@ -26,7 +26,7 @@ export function Tabs(props: BlockProps<DocumentBlockTabs>) {
                 ancestorBlocks={[...ancestorBlocks, block, tab]}
                 context={context}
                 blockStyle={tcls('flip-heading-hash')}
-                style={tcls(block.data?.fullWidth ? 'w-full' : null, 'space-y-4')}
+                style={tcls('w-full', 'space-y-4')}
             />
         );
     });

--- a/packages/gitbook/src/components/DocumentView/spacing.ts
+++ b/packages/gitbook/src/components/DocumentView/spacing.ts
@@ -24,21 +24,21 @@ export function getBlockTextStyle(block: DocumentBlock): {
                 textSize: 'text-3xl font-semibold',
                 lineHeight: 'leading-tight',
                 marginTop: 'mt-[1em]',
-                anchorButtonMarginTop: 'mt-[1.3em]',
+                anchorButtonMarginTop: 'mt-[1.05em]',
             };
         case 'heading-2':
             return {
                 textSize: 'text-2xl font-semibold',
                 lineHeight: 'leading-snug',
                 marginTop: 'mt-[0.75em]',
-                anchorButtonMarginTop: 'mt-[1.05em]',
+                anchorButtonMarginTop: 'mt-[0.9em]',
             };
         case 'heading-3':
             return {
                 textSize: 'text-xl font-semibold',
                 lineHeight: 'leading-snug',
                 marginTop: 'mt-[0.5em]',
-                anchorButtonMarginTop: 'mt-[0.75em]',
+                anchorButtonMarginTop: 'mt-[0.65em]',
             };
         case 'divider':
             return {

--- a/packages/gitbook/src/components/DocumentView/spacing.ts
+++ b/packages/gitbook/src/components/DocumentView/spacing.ts
@@ -10,6 +10,8 @@ export function getBlockTextStyle(block: DocumentBlock): {
     lineHeight: string;
     /** Tailwind class for the margin top (mt-*) */
     marginTop?: string;
+    /** Tailwind class for the margin top to apply on the anchor link button */
+    anchorButtonMarginTop?: string;
 } {
     switch (block.type) {
         case 'paragraph':
@@ -22,18 +24,21 @@ export function getBlockTextStyle(block: DocumentBlock): {
                 textSize: 'text-3xl font-semibold',
                 lineHeight: 'leading-tight',
                 marginTop: 'mt-[1em]',
+                anchorButtonMarginTop: 'mt-[1.3em]',
             };
         case 'heading-2':
             return {
                 textSize: 'text-2xl font-semibold',
                 lineHeight: 'leading-snug',
                 marginTop: 'mt-[0.75em]',
+                anchorButtonMarginTop: 'mt-[1.05em]',
             };
         case 'heading-3':
             return {
                 textSize: 'text-xl font-semibold',
                 lineHeight: 'leading-snug',
                 marginTop: 'mt-[0.5em]',
+                anchorButtonMarginTop: 'mt-[0.75em]',
             };
         case 'divider':
             return {


### PR DESCRIPTION
Reproducing headings hash links UX: show the hash link button on the left of tabs block when hovered. The URL hash will match the selected tab.

Move hash link button to its component for reusability and unifies its styles for all blocks for consistency.
Improve spacing on headings hash anchor link.

## Preview
**Active tab hovered**
<img width="846" alt="Screenshot 2025-05-09 at 17 23 37" src="https://github.com/user-attachments/assets/5fd6a636-8060-4e44-9627-2fb73a0affdd" />

**Inactive tab hovered**
<img width="833" alt="Screenshot 2025-05-09 at 17 23 43" src="https://github.com/user-attachments/assets/b1f9ca52-5031-49a4-9365-ee67dae3c340" />

**Heading 1 hovered**
<img width="906" alt="Screenshot 2025-05-09 at 17 22 52" src="https://github.com/user-attachments/assets/5fd6af63-d97a-4066-913d-e8bb15ad77e3" />

**Heading 2 hovered**
<img width="950" alt="Screenshot 2025-05-09 at 17 23 50" src="https://github.com/user-attachments/assets/6cd8a02c-17de-4eeb-b0da-851e40111fa9" />

**Heading 3 hovered**
<img width="935" alt="Screenshot 2025-05-09 at 17 23 02" src="https://github.com/user-attachments/assets/73af404d-ae90-49c5-8ebe-5acf88fb5e0e" />