### PR TITLE
Always link main logo to the root of the site

### DIFF
--- a/.changeset/tough-starfishes-grin.md
+++ b/.changeset/tough-starfishes-grin.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Always link main logo to the root of the site

--- a/packages/gitbook/src/components/Header/HeaderLogo.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLogo.tsx
@@ -20,7 +20,7 @@ export async function HeaderLogo(props: HeaderLogoProps) {
 
     return (
         <Link
-            href={linker.toAbsoluteURL(linker.toPathInSpace(''))}
+            href={linker.toAbsoluteURL(linker.toPathInSite(''))}
             className={tcls('group/headerlogo', 'min-w-0', 'shrink', 'flex', 'items-center')}
         >
             {customization.header.logo ? (


### PR DESCRIPTION
It's made possible because of this fix I previously made: https://github.com/GitbookIO/gitbook/pull/3220