### PR TITLE
Custom Incremental Cache

### DIFF
--- a/packages/gitbook-v2/.gitignore
+++ b/packages/gitbook-v2/.gitignore
@@ -6,6 +6,7 @@
 
 # cloudflare
 .open-next
+.wrangler
 
 # Symbolic links
 public

--- a/packages/gitbook-v2/open-next.config.ts
+++ b/packages/gitbook-v2/open-next.config.ts
@@ -1,6 +1,4 @@
 import { defineCloudflareConfig } from '@opennextjs/cloudflare';
-import r2IncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache';
-import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
 import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
 import doShardedTagCache from '@opennextjs/cloudflare/overrides/tag-cache/do-sharded-tag-cache';
 import {
@@ -9,7 +7,7 @@ import {
 } from '@opennextjs/cloudflare/overrides/tag-cache/tag-cache-filter';
 
 export default defineCloudflareConfig({
-    incrementalCache: withRegionalCache(r2IncrementalCache, { mode: 'long-lived' }),
+    incrementalCache: () => import('./openNext/incrementalCache').then((m) => m.default),
     tagCache: withFilter({
         tagCache: doShardedTagCache({
             baseShardSize: 12,

--- a/packages/gitbook-v2/openNext/incrementalCache.ts
+++ b/packages/gitbook-v2/openNext/incrementalCache.ts
@@ -9,8 +9,6 @@ import type {
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 
 export const BINDING_NAME = 'NEXT_INC_CACHE_R2_BUCKET';
-export const PREFIX_ENV_NAME = 'NEXT_INC_CACHE_R2_PREFIX';
-export const FALLBACK_BUILD_ID = 'no-build-id';
 export const DEFAULT_PREFIX = 'incremental-cache';
 
 export type KeyOptions = {
@@ -27,8 +25,16 @@ class GitbookIncrementalCache implements IncrementalCache {
         cacheType?: CacheType
     ): Promise<WithLastModified<CacheValue<CacheType>> | null> {
         const r2 = getCloudflareContext().env[BINDING_NAME];
+        const localCache = await this.getCacheInstance();
         if (!r2) throw new Error('No R2 bucket');
         try {
+            const cacheKey = this.getR2Key(key, cacheType);
+            // Check local cache first if available
+            const localCacheEntry = await localCache.match(this.getCacheUrlKey(cacheKey));
+            if (localCacheEntry) {
+                return localCacheEntry.json();
+            }
+
             const r2Object = await r2.get(this.getR2Key(key, cacheType));
             if (!r2Object) return null;
 
@@ -48,10 +54,41 @@ class GitbookIncrementalCache implements IncrementalCache {
         cacheType?: CacheType
     ): Promise<void> {
         const r2 = getCloudflareContext().env[BINDING_NAME];
+        const localCache = await this.getCacheInstance();
         if (!r2) throw new Error('No R2 bucket');
 
         try {
-            await r2.put(this.getR2Key(key, cacheType), JSON.stringify(value));
+            const cacheKey = this.getR2Key(key, cacheType);
+            await r2.put(cacheKey, JSON.stringify(value));
+
+            //TODO: Check if there is any places where we don't have tags
+            // Ideally we should always have tags, but in case we don't, we need to decide how to handle it
+            // For now we default to a build ID tag, which allow us to invalidate the cache in case something is wrong in this deployment
+            const tags = this.getTagsFromCacheEntry(value) ?? [
+                `build_id/${process.env.NEXT_BUILD_ID}`,
+            ];
+
+            // We consider R2 as the source of truth, so we update the local cache
+            // only after a successful R2 write
+            await localCache.put(
+                this.getCacheUrlKey(cacheKey),
+                new Response(
+                    JSON.stringify({
+                        value,
+                        // Note: `Date.now()` returns the time of the last IO rather than the actual time.
+                        //       See https://developers.cloudflare.com/workers/reference/security-model/
+                        lastModified: Date.now(),
+                    }),
+                    {
+                        headers: {
+                            // Cache-Control default to 30 minutes, will be overridden by `revalidate`
+                            // In theory we should always get the `revalidate` value
+                            'cache-control': `max-age=${value.revalidate ?? 60 * 30}`,
+                            'cache-tag': tags.join(','),
+                        },
+                    }
+                )
+            );
         } catch (e) {
             console.error('Failed to set to cache', e);
         }
@@ -59,23 +96,56 @@ class GitbookIncrementalCache implements IncrementalCache {
 
     async delete(key: string): Promise<void> {
         const r2 = getCloudflareContext().env[BINDING_NAME];
+        const localCache = await this.getCacheInstance();
         if (!r2) throw new Error('No R2 bucket');
 
         try {
-            await r2.delete(this.getR2Key(key));
+            const cacheKey = this.getR2Key(key);
+
+            await r2.delete(cacheKey);
+
+            // Here again R2 is the source of truth, so we delete from local cache first
+            await localCache.delete(this.getCacheUrlKey(cacheKey));
         } catch (e) {
             console.error('Failed to delete from cache', e);
         }
     }
 
-    // Utility function to generate keys for R2/Cache API
+    async getCacheInstance(): Promise<Cache> {
+        if (this.localCache) return this.localCache;
+        this.localCache = await caches.open('incremental-cache');
+        return this.localCache;
+    }
 
+    // Utility function to generate keys for R2/Cache API
     getR2Key(key: string, cacheType?: CacheEntryType): string {
         const hash = createHash('sha256').update(key).digest('hex');
         return `${DEFAULT_PREFIX}/${cacheType === 'cache' ? process.env?.NEXT_BUILD_ID : 'dataCache'}/${hash}.${cacheType}`.replace(
             /\/+/g,
             '/'
         );
+    }
+
+    getCacheUrlKey(cacheKey: string): string {
+        return `http://cache.local/${cacheKey}`;
+    }
+
+    getTagsFromCacheEntry<CacheType extends CacheEntryType>(
+        entry: CacheValue<CacheType>
+    ): string[] | undefined {
+        if ('tags' in entry && entry.tags) {
+            return entry.tags;
+        }
+
+        if ('meta' in entry && entry.meta && 'headers' in entry.meta && entry.meta.headers) {
+            const rawTags = entry.meta.headers['x-next-cache-tags'];
+            if (typeof rawTags === 'string') {
+                return rawTags.split(',');
+            }
+        }
+        if ('value' in entry) {
+            return entry.tags;
+        }
     }
 }
 

--- a/packages/gitbook-v2/openNext/incrementalCache.ts
+++ b/packages/gitbook-v2/openNext/incrementalCache.ts
@@ -1,0 +1,82 @@
+import { createHash } from 'node:crypto';
+
+import type {
+    CacheEntryType,
+    CacheValue,
+    IncrementalCache,
+    WithLastModified,
+} from '@opennextjs/aws/types/overrides.js';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
+export const BINDING_NAME = 'NEXT_INC_CACHE_R2_BUCKET';
+export const PREFIX_ENV_NAME = 'NEXT_INC_CACHE_R2_PREFIX';
+export const FALLBACK_BUILD_ID = 'no-build-id';
+export const DEFAULT_PREFIX = 'incremental-cache';
+
+export type KeyOptions = {
+    cacheType?: CacheEntryType;
+};
+
+class GitbookIncrementalCache implements IncrementalCache {
+    name = 'GitbookIncrementalCache';
+
+    protected localCache: Cache | undefined;
+
+    async get<CacheType extends CacheEntryType = 'cache'>(
+        key: string,
+        cacheType?: CacheType
+    ): Promise<WithLastModified<CacheValue<CacheType>> | null> {
+        const r2 = getCloudflareContext().env[BINDING_NAME];
+        if (!r2) throw new Error('No R2 bucket');
+        try {
+            const r2Object = await r2.get(this.getR2Key(key, cacheType));
+            if (!r2Object) return null;
+
+            return {
+                value: await r2Object.json(),
+                lastModified: r2Object.uploaded.getTime(),
+            };
+        } catch (e) {
+            console.error('Failed to get from cache', e);
+            return null;
+        }
+    }
+
+    async set<CacheType extends CacheEntryType = 'cache'>(
+        key: string,
+        value: CacheValue<CacheType>,
+        cacheType?: CacheType
+    ): Promise<void> {
+        const r2 = getCloudflareContext().env[BINDING_NAME];
+        if (!r2) throw new Error('No R2 bucket');
+
+        try {
+            await r2.put(this.getR2Key(key, cacheType), JSON.stringify(value));
+        } catch (e) {
+            console.error('Failed to set to cache', e);
+        }
+    }
+
+    async delete(key: string): Promise<void> {
+        const r2 = getCloudflareContext().env[BINDING_NAME];
+        if (!r2) throw new Error('No R2 bucket');
+
+        try {
+            await r2.delete(this.getR2Key(key));
+        } catch (e) {
+            console.error('Failed to delete from cache', e);
+        }
+    }
+
+    // Utility function to generate keys for R2/Cache API
+
+    getR2Key(key: string, cacheType?: CacheEntryType): string {
+        const hash = createHash('sha256').update(key).digest('hex');
+        return `${DEFAULT_PREFIX}/${cacheType === 'cache' ? process.env?.NEXT_BUILD_ID : 'dataCache'}/${hash}.${cacheType}`.replace(
+            /\/+/g,
+            '/'
+        );
+    }
+}
+
+export default new GitbookIncrementalCache();

--- a/packages/gitbook-v2/package.json
+++ b/packages/gitbook-v2/package.json
@@ -29,7 +29,7 @@
         "build:v2": "next build",
         "start": "next start",
         "build:v2:cloudflare": "opennextjs-cloudflare build",
-        "dev:v2:cloudflare": "wrangler dev --port 8771",
+        "dev:v2:cloudflare": "wrangler dev --port 8771 --env preview",
         "unit": "bun test",
         "typecheck": "tsc --noEmit"
     }


### PR DESCRIPTION
This PR add a custom incremental cache instead of the one from cloudflare.

It does not use the `BUILD_ID` as part of the key for the data cache. 
It also add tracing for the different methods of the incremental cache. (This is broken right now as esbuild replace `NODE_ENV` with development during compilation of the config file for the edge runtime, fix needs to be done in aws)