### PR TITLE
V2: Add `urlObject.hash` to `linker.toLinkForContent`

### DIFF
--- a/packages/gitbook-v2/src/lib/context.ts
+++ b/packages/gitbook-v2/src/lib/context.ts
@@ -165,7 +165,7 @@ export function getBaseContext(input: {
         // Create link in the same format for links to other sites/sections.
         linker.toLinkForContent = (rawURL: string) => {
             const urlObject = new URL(rawURL);
-            return `/url/${urlObject.host}${urlObject.pathname}${urlObject.search}`;
+            return `/url/${urlObject.host}${urlObject.pathname}${urlObject.hash}${urlObject.search}`;
         };
     }
 


### PR DESCRIPTION
To pass through URL fragment identifiers, used in search