### PR TITLE
Add temporary logging for Cloudflare debugging

### DIFF
--- a/packages/gitbook-v2/wrangler.jsonc
+++ b/packages/gitbook-v2/wrangler.jsonc
@@ -93,7 +93,10 @@
             "vars": {
                 // This is a bit misleading, but it means that we can have 500 concurrent revalidations
                 // This means that we'll have up to 100 durable objects instance running at the same time
-                "MAX_REVALIDATE_CONCURRENCY": "100"
+                "MAX_REVALIDATE_CONCURRENCY": "100",
+                // Temporary variable to find the issue once deployed
+                // TODO: remove this once the issue is fixed
+                "DEBUG_CLOUDFLARE": "true"
             },
             "routes": [
                 {


### PR DESCRIPTION
OG Image generation seems to fail for bot once deployed with this error `Error: Invalid content type: text/html; charset=utf-8`

Same URL, when accessed manually works. Haven't been able to reproduce.

This just add a bunch of logs to help narrow what could go wrong here