### PR TITLE
Calculate class more explicitly & separately to fix horizontal table cell alignment issue

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
@@ -115,7 +115,8 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                 return <Tag className={tcls(['w-full', verticalAlignment])}>{''}</Tag>;
             }
 
-            const horizontalAlignment = `[&_*]:${getColumnAlignment(definition)} ${getColumnAlignment(definition)}`;
+            const horizontalAlignment = getColumnAlignment(definition);
+            const childrenHorizontalAlignment = `[&_*]:${horizontalAlignment}`;
 
             return (
                 <Blocks
@@ -131,6 +132,7 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                         'leading-normal',
                         verticalAlignment,
                         horizontalAlignment,
+                        childrenHorizontalAlignment,
                     ]}
                     context={context}
                     blockStyle={['w-full', 'max-w-[unset]']}


### PR DESCRIPTION
In [this PR](https://github.com/GitbookIO/gitbook/pull/3175) I fixed an issue with horizontal alignment not propagating to children of table text cells. It fixed the original case, but customer mentioned another situation still showed the problem.

I don't think the fix is wrong, the prior PR should also correctly target the new case the user mentioned. Instead I think the problem is tailwind being flaky, it's known that inline calculation of classes can cause the classes not to show up in the compiled css. This pr's change made the css apply locally, I'll test once it actually goes through to make sure it's the same case in prod.

~ should close https://linear.app/gitbook-x/issue/RND-6658/annotations-in-table-cells-with-multi-line-text-makes-it-center

before:

![CleanShot 2025-05-21 at 13 35 26@2x](https://github.com/user-attachments/assets/966d0e5c-9aff-47a4-8890-acef7b4525fc)

after:

![CleanShot 2025-05-21 at 13 35 48@2x](https://github.com/user-attachments/assets/a14f08cc-4a49-4dab-9cdd-893557a9874f)

