### PR TITLE
Fix OGImage icon fetch on cloudflare

### DIFF
--- a/packages/gitbook/src/routes/ogimage.tsx
+++ b/packages/gitbook/src/routes/ogimage.tsx
@@ -344,6 +344,7 @@ const staticImagesCache = new Map<string, string>();
  * Read a static image and cache it in memory.
  */
 async function readStaticImage(url: string) {
+    logOnCloudflareOnly(`Reading static image: ${url}, cache size: ${staticImagesCache.size}`);
     const cached = staticImagesCache.get(url);
     if (cached) {
         return cached;


### PR DESCRIPTION
When a request for OG Image arrives for a custom domain, the requested favicon is requested from the same domain (i.e. `https://thedomain.com/~gitbook/icon`)
In Cloudflare, we were using a service binding, but by doing so, this bypass setting the `x-gitbook-url` header and thus the request will end up not being able to match `getSiteUrlFromRequest` https://github.com/GitbookIO/gitbook/blob/ba0094a862e28b83728cc05c2503c4b652cf93ed/packages/gitbook-v2/src/middleware.ts#L382-L391
We should be fine without the service binding since we set `global_fetch_strictly_public` compatibility flag

The icon will return a 404 and the OG Image Generation will fail with a 500

Should fix RND-7140