### PR TITLE
Open image zoon viewer on click for any image size

### DIFF
--- a/.changeset/six-adults-jog.md
+++ b/.changeset/six-adults-jog.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Open image zoom viewer for all image sizes

--- a/packages/gitbook/src/components/utils/ZoomImage.tsx
+++ b/packages/gitbook/src/components/utils/ZoomImage.tsx
@@ -55,9 +55,6 @@ export function ZoomImage(
             if (!mediaQueryList.matches) {
                 // Don't allow zooming on mobile
                 setZoomable(false);
-            } else if (resizeObserver && imageWidth && viewWidth && imageWidth <= viewWidth) {
-                // Image can't be zoomed if it's already rendered as it's largest size
-                setZoomable(false);
             } else {
                 setZoomable(true);
             }

--- a/packages/gitbook/src/components/utils/ZoomImage.tsx
+++ b/packages/gitbook/src/components/utils/ZoomImage.tsx
@@ -32,9 +32,6 @@ export function ZoomImage(
             return;
         }
 
-        const imageWidth = typeof width === 'number' ? width : 0;
-        let viewWidth = 0;
-
         const mediaQueryList = window.matchMedia('(min-width: 768px)');
         const resizeObserver =
             typeof ResizeObserver !== 'undefined'
@@ -44,7 +41,6 @@ export function ZoomImage(
                       // Since the image is removed from the DOM when the modal is opened,
                       // We only care when the size is defined.
                       if (imgEntry && imgEntry.contentRect.width !== 0) {
-                          viewWidth = entries[0]?.contentRect.width;
                           setPlaceholderRect(entries[0].contentRect);
                           onChange();
                       }


### PR DESCRIPTION
The image viewer should open on click whatever the image size is. Otherwise when the viewer doesn't open there's no clear reason for the user who clicked why that is which is confusing.