### PR TITLE
Chores: create server worker

### DIFF
--- a/.github/composite/deploy-cloudflare/action.yaml
+++ b/.github/composite/deploy-cloudflare/action.yaml
@@ -73,6 +73,17 @@ runs:
               wranglerVersion: '4.10.0'
               environment: ${{ inputs.environment }}
               command: ${{ inputs.deploy == 'true' && 'deploy' || format('versions upload --tag {0} --message "{1}"', inputs.commitTag, inputs.commitMessage) }} --config ./packages/gitbook-v2/wrangler.jsonc
+        
+        - name: Temporary deploy server CF worker
+          uses: cloudflare/wrangler-action@v3.14.0
+          with:
+              apiToken: ${{ inputs.apiToken }}
+              accountId: ${{ inputs.accountId }}
+              workingDirectory: ./
+              wranglerVersion: '4.10.0'
+              environment: ${{ inputs.environment }}
+              command: 'deploy --config ./packages/gitbook-v2/openNext/customWorkers/defaultWrangler.jsonc'
+        
         - name: Outputs
           shell: bash
           env:

--- a/packages/gitbook-v2/openNext/customWorkers/default.js
+++ b/packages/gitbook-v2/openNext/customWorkers/default.js
@@ -1,0 +1,9 @@
+export default {
+    async fetch() {
+        return new Response('Hello World', {
+            headers: {
+                'Content-Type': 'text/plain',
+            },
+        });
+    },
+};

--- a/packages/gitbook-v2/openNext/customWorkers/defaultWrangler.jsonc
+++ b/packages/gitbook-v2/openNext/customWorkers/defaultWrangler.jsonc
@@ -1,0 +1,38 @@
+{
+    "main": "default.js",
+    "name": "gitbook-open-v2-server",
+    "compatibility_date": "2025-04-14",
+    "compatibility_flags": [
+        "nodejs_compat",
+        "allow_importable_env",
+        "global_fetch_strictly_public"
+    ],
+    "observability": {
+        "enabled": true
+    },
+    "vars": {
+        "NEXT_CACHE_DO_QUEUE_DISABLE_SQLITE": "true"
+    },
+    "env": {
+        "dev": {
+            "vars": {
+                "STAGE": "dev"
+            }
+        },
+        "preview": {
+            "vars": {
+                "STAGE": "preview"
+            }
+        },
+        "staging": {
+            "vars": {
+                "STAGE": "staging"
+            }
+        },
+        "production": {
+            "vars": {
+                "STAGE": "production"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is only there to deploy a dummy server worker at least once in every env.
#3254 Depends on this, because otherwise the `wrangler versions upload` would fail because the worker does not exist yet.