### PR TITLE
Remove trailing slash from linker

### DIFF
--- a/.changeset/wise-gifts-smash.md
+++ b/.changeset/wise-gifts-smash.md
@@ -1,0 +1,5 @@
+---
+"gitbook-v2": patch
+---
+
+remove trailing slash from linker

--- a/packages/gitbook-v2/src/lib/links.test.ts
+++ b/packages/gitbook-v2/src/lib/links.test.ts
@@ -19,7 +19,7 @@ const siteGitBookIO = createLinker({
     siteBasePath: '/sitename/',
 });
 
-describe('toPathInContent', () => {
+describe('toPathInSpace', () => {
     it('should return the correct path', () => {
         expect(root.toPathInSpace('some/path')).toBe('/some/path');
         expect(variantInSection.toPathInSpace('some/path')).toBe('/section/variant/some/path');
@@ -29,12 +29,32 @@ describe('toPathInContent', () => {
         expect(root.toPathInSpace('/some/path')).toBe('/some/path');
         expect(variantInSection.toPathInSpace('/some/path')).toBe('/section/variant/some/path');
     });
+
+    it('should remove the trailing slash', () => {
+        expect(root.toPathInSpace('some/path/')).toBe('/some/path');
+        expect(variantInSection.toPathInSpace('some/path/')).toBe('/section/variant/some/path');
+    });
+
+    it('should not add a trailing slash', () => {
+        expect(root.toPathInSpace('')).toBe('');
+        expect(variantInSection.toPathInSpace('')).toBe('/section/variant');
+    });
 });
 
 describe('toPathInSite', () => {
     it('should return the correct path', () => {
         expect(root.toPathInSite('some/path')).toBe('/some/path');
         expect(siteGitBookIO.toPathInSite('some/path')).toBe('/sitename/some/path');
+    });
+
+    it('should remove the trailing slash', () => {
+        expect(root.toPathInSite('some/path/')).toBe('/some/path');
+        expect(siteGitBookIO.toPathInSite('some/path/')).toBe('/sitename/some/path');
+    });
+
+    it('should not add a trailing slash', () => {
+        expect(root.toPathInSite('')).toBe('');
+        expect(siteGitBookIO.toPathInSite('')).toBe('/sitename');
     });
 });
 

--- a/packages/gitbook-v2/src/lib/links.ts
+++ b/packages/gitbook-v2/src/lib/links.ts
@@ -128,5 +128,9 @@ export function createLinker(
 function joinPaths(prefix: string, path: string): string {
     const prefixPath = prefix.endsWith('/') ? prefix : `${prefix}/`;
     const suffixPath = path.startsWith('/') ? path.slice(1) : path;
-    return prefixPath + suffixPath;
+    return removeTrailingSlash(prefixPath + suffixPath);
+}
+
+function removeTrailingSlash(path: string): string {
+    return path.endsWith('/') ? path.slice(0, -1) : path;
 }


### PR DESCRIPTION
While joining paths, the `GitBookLinker` will sometimes add a trailing slash (or not remove it)

This will cause unnecessary redirect in GBO v2