### PR TITLE
Fix href being empty in TOC

### DIFF
--- a/.changeset/cool-jars-matter.md
+++ b/.changeset/cool-jars-matter.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+fix href being empty in TOC

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -17,7 +17,11 @@ export async function PageDocumentItem(props: {
     context: GitBookSiteContext;
 }) {
     const { rootPages, page, context } = props;
-    const href = context.linker.toPathForPage({ pages: rootPages, page });
+    let href = context.linker.toPathForPage({ pages: rootPages, page });
+    // toPathForPage can returns an empty path, this will cause all links to point to the current page.
+    if (href === '') {
+        href = '/';
+    }
 
     return (
         <li className="flex flex-col">


### PR DESCRIPTION
`href` can be empty in `toPageForPath`, this will cause the TOC link for the root to always point to the currently visited path