### PR TITLE
fix: defaultWidth/fullWidth options in images

### DIFF
--- a/.changeset/breezy-falcons-drop.md
+++ b/.changeset/breezy-falcons-drop.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Respect fullWidth and defaultWidth for images

--- a/packages/gitbook/src/components/DocumentView/Images.tsx
+++ b/packages/gitbook/src/components/DocumentView/Images.tsx
@@ -19,7 +19,6 @@ export function Images(props: BlockProps<DocumentBlockImages>) {
     const isMultipleImages = block.nodes.length > 1;
     const { align = 'center' } = block.data;
 
-
     return (
         <div
             className={tcls(

--- a/packages/gitbook/src/components/DocumentView/Images.tsx
+++ b/packages/gitbook/src/components/DocumentView/Images.tsx
@@ -19,6 +19,7 @@ export function Images(props: BlockProps<DocumentBlockImages>) {
     const isMultipleImages = block.nodes.length > 1;
     const { align = 'center' } = block.data;
 
+
     return (
         <div
             className={tcls(
@@ -29,7 +30,7 @@ export function Images(props: BlockProps<DocumentBlockImages>) {
                 align === 'center' && 'justify-center',
                 align === 'right' && 'justify-end',
                 align === 'left' && 'justify-start',
-                isMultipleImages && ['grid', 'grid-flow-col', 'max-w-none']
+                isMultipleImages && ['grid', 'grid-flow-col']
             )}
         >
             {block.nodes.map((node: any, _i: number) => (


### PR DESCRIPTION
Multiple images not respecting fullWidth/defaultWidth behaviour from Blocks because of `max-w-none`

Resolves RND-5794