### PR TITLE
Make icons for page groups more contrasting

### DIFF
--- a/.changeset/sharp-jeans-burn.md
+++ b/.changeset/sharp-jeans-burn.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Make icons for page groups more contrasting

--- a/packages/gitbook/src/components/TableOfContents/TOCPageIcon.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCPageIcon.tsx
@@ -13,7 +13,7 @@ export function TOCPageIcon({ page }: { page: RevisionPage }) {
             page={page}
             style={tcls(
                 'text-base',
-                'text-tint-strong/6',
+                '[.toclink_&]:text-tint-strong/6',
                 'group-aria-current-page/toclink:text-primary-subtle',
                 'contrast-more:group-aria-current-page/toclink:text-primary',
 

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -67,7 +67,7 @@ function LinkItem(
             insights={insights}
             aria-current={isActive ? 'page' : undefined}
             className={tcls(
-                'group/toclink relative transition-colors',
+                'group/toclink toclink relative transition-colors',
                 'flex flex-row justify-between',
                 'circular-corners:rounded-2xl rounded-md straight-corners:rounded-none p-1.5 pl-3',
                 'text-balance font-normal text-sm text-tint-strong/7 hover:bg-tint-hover hover:text-tint-strong contrast-more:text-tint-strong',


### PR DESCRIPTION
# Before

![CleanShot 2025-06-08 at 04 36 14@2x](https://github.com/user-attachments/assets/c1e7d93b-0e3e-4cae-8395-5de4e2d54783)


# After
![CleanShot 2025-06-08 at 04 36 17@2x](https://github.com/user-attachments/assets/5afdfc3e-46ad-4e6e-a785-3666b8d3b634)
