### PR TITLE
Preserve current variant when navigating between sections

### DIFF
--- a/.changeset/hip-bobcats-cover.md
+++ b/.changeset/hip-bobcats-cover.md
@@ -1,0 +1,5 @@
+---
+"gitbook": minor
+---
+
+Best effort at preserving current variant when navigating between sections by matching the pathname against site spaces in the new section.

--- a/packages/gitbook/src/components/Header/SpacesDropdown.tsx
+++ b/packages/gitbook/src/components/Header/SpacesDropdown.tsx
@@ -1,8 +1,7 @@
 import type { SiteSpace } from '@gitbook/api';
 
+import { getSiteSpaceURL } from '@/lib/sites';
 import { tcls } from '@/lib/tailwind';
-
-import { joinPath } from '@/lib/paths';
 import type { GitBookSiteContext } from '@v2/lib/context';
 import { DropdownChevron, DropdownMenu } from './DropdownMenu';
 import { SpacesDropdownMenuItem } from './SpacesDropdownMenuItem';
@@ -73,24 +72,11 @@ export function SpacesDropdown(props: {
                     variantSpace={{
                         id: otherSiteSpace.id,
                         title: otherSiteSpace.title,
-                        url: otherSiteSpace.urls.published
-                            ? linker.toLinkForContent(otherSiteSpace.urls.published)
-                            : getFallbackSiteSpaceURL(otherSiteSpace, context),
+                        url: getSiteSpaceURL(context, otherSiteSpace),
                     }}
                     active={otherSiteSpace.id === siteSpace.id}
                 />
             ))}
         </DropdownMenu>
-    );
-}
-
-/**
- * When the site is not published yet, `urls.published` is not available.
- * To ensure navigation works in preview, we compute a relative URL from the siteSpace path.
- */
-function getFallbackSiteSpaceURL(siteSpace: SiteSpace, context: GitBookSiteContext) {
-    const { linker, sections } = context;
-    return linker.toPathInSite(
-        sections?.current ? joinPath(sections.current.path, siteSpace.path) : siteSpace.path
     );
 }

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -1,4 +1,6 @@
 import type { SiteSection, SiteSectionGroup, SiteSpace, SiteStructure } from '@gitbook/api';
+import type { GitBookSiteContext } from '@v2/lib/context';
+import { joinPath } from './paths';
 
 /**
  * Get all sections from a site structure.
@@ -62,6 +64,34 @@ export function findSiteSpaceById(siteStructure: SiteStructure, spaceId: string)
     }
 
     return null;
+}
+
+/**
+ * Get the URL to navigate to for a section.
+ * When the site is not published yet, `urls.published` is not available.
+ * To ensure navigation works in preview, we compute a relative URL from the siteSection path.
+ */
+export function getSectionURL(context: GitBookSiteContext, section: SiteSection) {
+    const { linker } = context;
+    return section.urls.published
+        ? linker.toLinkForContent(section.urls.published)
+        : linker.toPathInSite(section.path);
+}
+
+/**
+ * Get the URL to navigate to for a site space.
+ * When the site is not published yet, `urls.published` is not available.
+ * To ensure navigation works in preview, we compute a relative URL from the siteSpace path.
+ */
+export function getSiteSpaceURL(context: GitBookSiteContext, siteSpace: SiteSpace) {
+    const { linker, sections } = context;
+    if (siteSpace.urls.published) {
+        return linker.toLinkForContent(siteSpace.urls.published);
+    }
+
+    return linker.toPathInSite(
+        sections?.current ? joinPath(sections.current.path, siteSpace.path) : siteSpace.path
+    );
 }
 
 function findSiteSpaceByIdInSections(sections: SiteSection[], spaceId: string): SiteSpace | null {


### PR DESCRIPTION
Best effort at preserving current variant when navigating between sections by matching the pathname against site spaces in the new section.