### PR TITLE
Fix UX issue about highlighting the search term in search result sections

### DIFF
--- a/.changeset/afraid-gifts-sparkle.md
+++ b/.changeset/afraid-gifts-sparkle.md
@@ -1,5 +1,5 @@
 ---
-"gitbook": minor
+"gitbook": patch
 ---
 
 Fix UX issue about highlighting the search term in search result sections

--- a/.changeset/afraid-gifts-sparkle.md
+++ b/.changeset/afraid-gifts-sparkle.md
@@ -1,0 +1,5 @@
+---
+"gitbook": minor
+---
+
+Fix UX issue about highlighting the search term in search result sections

--- a/README.md
+++ b/README.md
@@ -56,13 +56,19 @@ git clone https://github.com/gitbookIO/gitbook.git
 bun install
 ```
 
-4. Start your local development server.
+4. Run build.
+
+```
+bun build:v2
+```
+
+5. Start your local development server.
 
 ```
 bun dev:v2
 ```
 
-5. Open a published GitBook space in your web browser, prefixing it with `http://localhost:3000/`.
+6. Open a published GitBook space in your web browser, prefixing it with `http://localhost:3000/`.
 
 examples:
 

--- a/packages/gitbook/src/components/Search/SearchSectionResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchSectionResultItem.tsx
@@ -66,11 +66,7 @@ export const SearchSectionResultItem = React.forwardRef(function SearchSectionRe
                         <HighlightQuery query={query} text={item.title} />
                     </p>
                 ) : null}
-                {item.body ? (
-                    <p className={tcls('text-sm', 'line-clamp-3', 'relative')}>
-                        <HighlightQuery query={query} text={item.body} />
-                    </p>
-                ) : null}
+                {item.body ? highlightQueryInBody(item.body, query) : null}
             </div>
             <div
                 className={tcls(
@@ -90,3 +86,14 @@ export const SearchSectionResultItem = React.forwardRef(function SearchSectionRe
         </Link>
     );
 });
+
+function highlightQueryInBody(body: string, query: string) {
+    const idx = body.indexOf(query);
+
+    // Ensure the query to be highlighted is visible in the body.
+    return (
+        <p className={tcls('text-sm', 'line-clamp-3', 'relative')}>
+            <HighlightQuery query={query} text={idx < 20 ? body : `...${body.slice(idx - 15)}`} />
+        </p>
+    );
+}


### PR DESCRIPTION
## Description

Sometimes the search result sections are too large to fit into the (highlighted) search results component, making the search term/query not visible.

This PR trims the section text in such cases to ensure that the search term is always visible and can be highlighted.

### Before
<img width="740" alt="image" src="https://github.com/user-attachments/assets/04747313-b130-47e0-b7ba-7d3bb93a99d8" />


### After
<img width="735" alt="image" src="https://github.com/user-attachments/assets/6a5ed137-42a3-48c6-b616-caaf93e5f02e" />
