### PR TITLE
Ignore case while pattern-matching to highlight search results

### DIFF
--- a/.changeset/slimy-cows-press.md
+++ b/.changeset/slimy-cows-press.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Ignore case while highlighting search results.

--- a/packages/gitbook/src/components/Search/SearchSectionResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchSectionResultItem.tsx
@@ -88,12 +88,12 @@ export const SearchSectionResultItem = React.forwardRef(function SearchSectionRe
 });
 
 function highlightQueryInBody(body: string, query: string) {
-    const idx = body.indexOf(query);
+    const idx = body.toLocaleLowerCase().indexOf(query.toLocaleLowerCase());
 
     // Ensure the query to be highlighted is visible in the body.
     return (
         <p className={tcls('text-sm', 'line-clamp-3', 'relative')}>
-            <HighlightQuery query={query} text={idx < 20 ? body : `...${body.slice(idx - 15)}`} />
+            <HighlightQuery query={query} text={idx < 20 ? body : `...${body.slice(idx - 10)}`} />
         </p>
     );
 }


### PR DESCRIPTION
Follow up to https://github.com/GitbookIO/gitbook/pull/3323

### Before
<img width="728" alt="image" src="https://github.com/user-attachments/assets/0e118c0e-fde6-4668-8819-75f85f2d3905" />


### After
<img width="730" alt="image" src="https://github.com/user-attachments/assets/73b80166-499f-4eb8-8421-0bc3c3104f69" />
