### PR TITLE
📝 docs(readme): clarify badge examples to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
 
 ## Table of Contents
 
--   [Getting Started](#getting-started)
--   [Contributing](#contributing)
-    -   [Types of contributions](#types-of-contributions)
--   [Licensing](#license)
--   [Acknowledgements](#acknowledgements)
--   [Legacy GitBook](#legacy-gitbook-deprecated)
+- [Getting Started](#getting-started)
+- [Contributing](#contributing)
+  - [Types of contributions](#types-of-contributions)
+- [Licensing](#license)
+- [Acknowledgements](#acknowledgements)
+- [Legacy GitBook](#legacy-gitbook-deprecated)
 
 ## Getting Started
 
@@ -35,10 +35,10 @@ To run a local version of this project, please follow these simple steps.
 
 ### Prerequisites
 
--   Node.js (Version: >=20.6)
-  - Use nvm for easy Node management
--   Bun (Version: >=1.2.1)
-  - We use a text-based lockfile which isn't supported below 1.2.1
+- Node.js (Version: >=20.6)
+- Use nvm for easy Node management
+- Bun (Version: >=1.2.1)
+- We use a text-based lockfile which isn't supported below 1.2.1
 
 ### Set up
 
@@ -49,7 +49,6 @@ git clone https://github.com/gitbookIO/gitbook.git
 ```
 
 2. Ensure you are using the project's version of `node`. Running `nvm use` will change your local version to the correct one.
-
 3. Install the project's dependencies through Bun.
 
 ```
@@ -72,15 +71,15 @@ bun dev:v2
 
 examples:
 
--   http://localhost:3000/url/gitbook.com/docs
--   http://localhost:3000/url/open-source.gitbook.io/midjourney
+- http://localhost:3000/url/gitbook.com/docs
+- http://localhost:3000/url/open-source.gitbook.io/midjourney
 
 Any published GitBook site can be accessed through your local development instance, and any updates you make to the codebase will be reflected in your browser.
 
 ### Other development commands
 
--   `bun format`: format the code
--   `bun lint`: lint the code
+- `bun format`: format the code
+- `bun lint`: lint the code
 
 ### CI and testing
 
@@ -124,13 +123,13 @@ Encounter a bug or find an issue you'd like to fix? Helping us fix issues relate
 
 ## Deployment
 
-> [!WARNING]  
+> [!WARNING]
 > While it is possible to self-host this project, we do not recommend this unless you are certain this option fits your need.
->
+> 
 > _Looking to add a specific feature in GitBook? Head to our [contributing guide](https://github.com/GitbookIO/gitbook/blob/main/.github/CONTRIBUTING.md) to get started._
->
+> 
 > Self-hosting this project puts the responsibility of maintaining and merging future updates on **you**. We cannot guarantee support, maintenance, or updates to forked and self-hosted instances of this project.
->
+> 
 > We want to make it as easy as possible for our community to collaborate and push the future of GitBook, which is why we encourage you to contribute to our product directly instead of creating your own version.
 
 This project allows you to self-host the rendering portion of your GitBook published content. Self-hosting has pros and cons.
@@ -155,9 +154,13 @@ See `LICENSE` for more information.
   <a href="https://gitbook.com"><img src="https://img.shields.io/static/v1?message=Documented%20on%20GitBook&logo=gitbook&logoColor=ffffff&label=%20&labelColor=5c5c5c&color=FDA599"></a>
 </p>
 
+Markdown example:
+
 ```md
 [![GitBook](https://img.shields.io/static/v1?message=Documented%20on%20GitBook&logo=gitbook&logoColor=ffffff&label=%20&labelColor=5c5c5c&color=3F89A1)](https://www.gitbook.com/preview?utm_source=gitbook_readme_badge&utm_medium=organic&utm_campaign=preview_documentation&utm_content=link)
 ```
+
+HTML example:
 
 ```html
 <a href="https://www.gitbook.com/preview?utm_source=gitbook_readme_badge&utm_medium=organic&utm_campaign=preview_documentation&utm_content=link">
@@ -171,10 +174,10 @@ See `LICENSE` for more information.
 
 GitBook wouldn't be possible without these projects:
 
--   [Next.js](https://nextjs.org/)
--   [Bun](https://bun.sh/)
--   [Tailwind CSS](https://tailwindcss.com/)
--   [Framer Motion](https://www.npmjs.com/package/framer-motion)
+- [Next.js](https://nextjs.org/)
+- [Bun](https://bun.sh/)
+- [Tailwind CSS](https://tailwindcss.com/)
+- [Framer Motion](https://www.npmjs.com/package/framer-motion)
 
 ## Contributors
 
@@ -185,3 +188,4 @@ GitBook wouldn't be possible without these projects:
 ## Legacy GitBook (Deprecated)
 
 Our previous version of GitBook and it's CLI tool are now deprecated. You can still view the old repository and it's commits on this [branch](https://github.com/GitbookIO/gitbook/tree/legacy).
+


### PR DESCRIPTION
This PR updates the README to clarify that the Markdown and HTML **badge** snippets are intended as usage examples and not broken or un-rendered badges.

_NOTE:_ While editing, I ran the project's formatting/linting commands as instructed (`bun format`), which resulted in additional formatting changes within the README.md — mainly minor whitespace and structure updates.

These changes were auto-generated, not made manually. If needed, I’m happy to separate them into a new PR.

✅ Docs-only change in README.md
✅ Follows GitBook's contribution guide  
✅ Resolves https://github.com/GitbookIO/gitbook/issues/3244