### PR TITLE
fix variant space change when pathname equals space-path

### DIFF
--- a/packages/gitbook/src/components/Header/SpacesDropdown.tsx
+++ b/packages/gitbook/src/components/Header/SpacesDropdown.tsx
@@ -74,6 +74,7 @@ export function SpacesDropdown(props: {
                         url: getSiteSpaceURL(context, otherSiteSpace),
                     }}
                     active={otherSiteSpace.id === siteSpace.id}
+                    currentSpacePath={siteSpace.path}
                 />
             ))}
         </DropdownMenu>

--- a/packages/gitbook/src/components/Header/SpacesDropdownMenuItem.tsx
+++ b/packages/gitbook/src/components/Header/SpacesDropdownMenuItem.tsx
@@ -6,12 +6,19 @@ import { joinPath } from '@/lib/paths';
 import { useCurrentPagePath } from '../hooks';
 import { DropdownMenuItem } from './DropdownMenu';
 
-function useVariantSpaceHref(variantSpaceUrl: string) {
+function useVariantSpaceHref(variantSpaceUrl: string, currentSpacePath: string, active = false) {
     const currentPathname = useCurrentPagePath();
+
+    if (!active && currentPathname.startsWith(currentSpacePath)) {
+        // If the variant space is not active, we need to ensure that we return to the variant space URL
+        // without the current pathname, otherwise we get stuck in the current space.
+        return variantSpaceUrl;
+    }
 
     if (URL.canParse(variantSpaceUrl)) {
         const targetUrl = new URL(variantSpaceUrl);
         targetUrl.pathname = joinPath(targetUrl.pathname, currentPathname);
+
         targetUrl.searchParams.set('fallback', 'true');
 
         return targetUrl.toString();
@@ -24,9 +31,10 @@ function useVariantSpaceHref(variantSpaceUrl: string) {
 export function SpacesDropdownMenuItem(props: {
     variantSpace: { id: Space['id']; title: Space['title']; url: string };
     active: boolean;
+    currentSpacePath: string;
 }) {
-    const { variantSpace, active } = props;
-    const variantHref = useVariantSpaceHref(variantSpace.url);
+    const { variantSpace, active, currentSpacePath } = props;
+    const variantHref = useVariantSpaceHref(variantSpace.url, currentSpacePath, active);
 
     return (
         <DropdownMenuItem key={variantSpace.id} href={variantHref} active={active}>


### PR DESCRIPTION
If the current page path equals the space path, the `SpacesDropdown` won't work for this space and you'll stay stuck on this specific space.
In this PR, for these cases, we always set the target url to the root of the other spaces