### PR TITLE
Fix crash during rendering of ogimage for VA sites with default icon

### DIFF
--- a/.changeset/thick-cups-shout.md
+++ b/.changeset/thick-cups-shout.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix crash during rendering of ogimage for VA sites with default icon.

--- a/packages/gitbook/src/routes/icon.tsx
+++ b/packages/gitbook/src/routes/icon.tsx
@@ -70,8 +70,10 @@ export async function serveIcon(context: GitBookSiteContext, req: Request) {
 export function SiteDefaultIcon(props: {
     context: GitBookSiteContext;
     options: RenderIconOptions;
+    style?: React.CSSProperties;
+    tw?: string;
 }) {
-    const { context, options } = props;
+    const { context, options, style, tw } = props;
     const size = SIZES[options.size];
 
     const { site, customization } = context;
@@ -79,13 +81,14 @@ export function SiteDefaultIcon(props: {
 
     return (
         <div
-            tw={tcls(options.theme === 'light' ? 'bg-white' : 'bg-black', size.boxStyle)}
+            tw={tcls(options.theme === 'light' ? 'bg-white' : 'bg-black', size.boxStyle, tw)}
             style={{
                 width: '100%',
                 height: '100%',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
+                ...style,
             }}
         >
             <h2

--- a/packages/gitbook/src/routes/ogimage.tsx
+++ b/packages/gitbook/src/routes/ogimage.tsx
@@ -165,7 +165,6 @@ export async function serveOGImage(baseContext: GitBookSiteContext, params: Page
                 <img
                     {...(await fetchImage(customization.favicon.icon[theme], faviconSize))}
                     {...faviconSize}
-                    // tw="mr-4"
                     alt="Icon"
                 />
             );

--- a/packages/gitbook/src/routes/ogimage.tsx
+++ b/packages/gitbook/src/routes/ogimage.tsx
@@ -155,33 +155,30 @@ export async function serveOGImage(baseContext: GitBookSiteContext, params: Page
             return null;
         }
 
+        const faviconSize = {
+            width: 48,
+            height: 48,
+        };
+
         if ('icon' in customization.favicon)
             return (
                 <img
-                    {...(await fetchImage(customization.favicon.icon[theme]))}
-                    width={40}
-                    height={40}
-                    tw="mr-4"
+                    {...(await fetchImage(customization.favicon.icon[theme], faviconSize))}
+                    {...faviconSize}
+                    // tw="mr-4"
                     alt="Icon"
                 />
             );
 
         return (
-            <div
-                tw="mr-4"
-                style={{
-                    width: 40,
-                    height: 40,
+            <SiteDefaultIcon
+                context={context}
+                options={{
+                    size: 'small',
+                    theme,
                 }}
-            >
-                <SiteDefaultIcon
-                    context={context}
-                    options={{
-                        size: 'medium',
-                        theme: customization.themes.default,
-                    }}
-                />
-            </div>
+                style={faviconSize}
+            />
         );
     };
 
@@ -233,9 +230,9 @@ export async function serveOGImage(baseContext: GitBookSiteContext, params: Page
                     <img {...logo} alt="Logo" tw="h-[60px]" />
                 </div>
             ) : (
-                <div tw="flex">
+                <div tw="flex flex-row items-center">
                     {favicon}
-                    <h3 tw="text-4xl my-0 font-bold">{transformText(site.title)}</h3>
+                    <h3 tw="text-4xl ml-4 my-0 font-bold">{transformText(site.title)}</h3>
                 </div>
             )}
 

--- a/packages/gitbook/src/routes/ogimage.tsx
+++ b/packages/gitbook/src/routes/ogimage.tsx
@@ -14,6 +14,7 @@ import { filterOutNullable } from '@/lib/typescript';
 import { getCacheTag } from '@gitbook/cache-tags';
 import type { GitBookSiteContext } from '@v2/lib/context';
 import { getResizedImageURL } from '@v2/lib/images';
+import { SiteDefaultIcon } from './icon';
 
 /**
  * Render the OpenGraph image for a site content.
@@ -142,34 +143,40 @@ export async function serveOGImage(baseContext: GitBookSiteContext, params: Page
     }
 
     const faviconLoader = async () => {
+        if (customization.header.logo) {
+            // Don't load the favicon if we have a logo
+            // as it'll not be used.
+            return null;
+        }
+
         if ('icon' in customization.favicon)
             return (
                 <img
-                    src={customization.favicon.icon[theme]}
+                    {...(await fetchImage(customization.favicon.icon[theme]))}
                     width={40}
                     height={40}
                     tw="mr-4"
                     alt="Icon"
                 />
             );
-        if ('emoji' in customization.favicon)
-            return (
-                <span tw="text-4xl mr-4">
-                    {String.fromCodePoint(Number.parseInt(`0x${customization.favicon.emoji}`))}
-                </span>
-            );
-        const iconImage = await fetchImage(
-            linker.toAbsoluteURL(
-                linker.toPathInSpace(
-                    `~gitbook/icon?size=medium&theme=${customization.themes.default}`
-                )
-            )
-        );
-        if (!iconImage) {
-            throw new Error('Icon image should always be fetchable');
-        }
 
-        return <img {...iconImage} alt="Icon" width={40} height={40} tw="mr-4" />;
+        return (
+            <div
+                tw="mr-4"
+                style={{
+                    width: 40,
+                    height: 40,
+                }}
+            >
+                <SiteDefaultIcon
+                    context={context}
+                    options={{
+                        size: 'medium',
+                        theme: customization.themes.default,
+                    }}
+                />
+            </div>
+        );
     };
 
     const logoLoader = async () => {


### PR DESCRIPTION
It was failing to fetch the icon because the request couldn't be authenticated correctly between the ogimage and the icon. Instead, we use the same component to render the default image.