### PR TITLE
Fix Mentions with broken links showing as empty in published content.

### DIFF
--- a/packages/gitbook/src/components/DocumentView/InlineLink/InlineLink.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineLink/InlineLink.tsx
@@ -22,7 +22,7 @@ export async function InlineLink(props: InlineProps<DocumentInlineLink>) {
 
     if (!context.contentContext || !resolved) {
         return (
-            <span title="Broken link" className="underline">
+            <span title="Page not found" className="underline">
                 <Inlines
                     context={context}
                     document={document}

--- a/packages/gitbook/src/components/DocumentView/Mention.tsx
+++ b/packages/gitbook/src/components/DocumentView/Mention.tsx
@@ -15,7 +15,7 @@ export async function Mention(props: InlineProps<DocumentInlineMention>) {
         : null;
 
     if (!resolved) {
-        return <span className="underline">Broken link</span>;
+        return <span className="underline">⚠️ Page not found</span>;
     }
 
     return (


### PR DESCRIPTION
Bug report came in because of PDF export. It's easier to find these broken links if they're visible (that's what we do for inline links).

The orginal source of the bug is cross-space links being exported to PDF, but that's a larger fix and not a priority right now.
