### PR TITLE
Fix page group not expanded by default

### DIFF
--- a/.changeset/real-trains-perform.md
+++ b/.changeset/real-trains-perform.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix page group not expanded by default

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -1,4 +1,4 @@
-import { getPagePath, hasPageVisibleDescendant } from '@/lib/pages';
+import { getPagePaths, hasPageVisibleDescendant } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
 import {
     type RevisionPage,
@@ -27,7 +27,7 @@ export async function PageDocumentItem(props: {
         <li className="flex flex-col">
             <ToggleableLinkItem
                 href={href}
-                pathname={getPagePath(rootPages, page)}
+                pathnames={getPagePaths(rootPages, page)}
                 insights={{
                     type: 'link_click',
                     link: {

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -16,15 +16,15 @@ import { useScrollToActiveTOCItem } from './TOCScroller';
 export function ToggleableLinkItem(
     props: {
         href: string;
-        pathname: string;
+        pathnames: string[];
         children: React.ReactNode;
         descendants: React.ReactNode;
     } & LinkInsightsProps
 ) {
-    const { href, children, descendants, pathname, insights } = props;
+    const { href, children, descendants, pathnames, insights } = props;
 
     const currentPagePath = useCurrentPagePath();
-    const isActive = currentPagePath === pathname;
+    const isActive = pathnames.some((pathname) => pathname === currentPagePath);
 
     if (!descendants) {
         return (
@@ -37,7 +37,9 @@ export function ToggleableLinkItem(
     return (
         <DescendantsRenderer
             descendants={descendants}
-            defaultIsOpen={isActive || currentPagePath.startsWith(`${pathname}/`)}
+            defaultIsOpen={
+                isActive || pathnames.some((pathname) => currentPagePath.startsWith(`${pathname}/`))
+            }
         >
             {({ descendants, toggler }) => (
                 <>

--- a/packages/gitbook/src/lib/pages.ts
+++ b/packages/gitbook/src/lib/pages.ts
@@ -121,6 +121,20 @@ export function getPagePath(
 }
 
 /**
+ * Get all possible paths for a page.
+ */
+export function getPagePaths(
+    rootPages: Revision['pages'],
+    page: RevisionPageDocument | RevisionPageGroup
+): string[] {
+    const path = getPagePath(rootPages, page);
+    if (path === page.path) {
+        return [path];
+    }
+    return [path, page.path];
+}
+
+/**
  * Test if a page has at least one descendant.
  */
 export function hasPageVisibleDescendant(page: RevisionPageGroup | RevisionPageDocument): boolean {


### PR DESCRIPTION
When the page is the root, the path is "". To test if a page is a
children of this one we have to test all possible paths of the page.
