### PR TITLE
Make skeletons client component

### DIFF
--- a/packages/gitbook/src/components/primitives/Skeleton.tsx
+++ b/packages/gitbook/src/components/primitives/Skeleton.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { type ClassValue, tcls } from '@/lib/tailwind';
 
 import { LoadingPane } from './LoadingPane';


### PR DESCRIPTION
This single line change can make us go from 14.3Mb to 9.2Mb in certain cases.

I think once we drop V1, we should drop most of the inner `<Suspense>` as they are not really needed in ISR and just increase the size and the complexity.
Dropping Suspense for Blocks on top of this one make it go from 9.2 to 7.7