### PR TITLE
Improve efficiency of the queue

### DIFF
--- a/packages/gitbook-v2/openNext/customWorkers/defaultWrangler.jsonc
+++ b/packages/gitbook-v2/openNext/customWorkers/defaultWrangler.jsonc
@@ -122,6 +122,11 @@
             ]
         },
         "production": {
+            "vars": {
+                // This is a bit misleading, but it means that we can have 500 concurrent revalidations
+                // This means that we'll have up to 100 durable objects instance running at the same time
+                "MAX_REVALIDATE_CONCURRENCY": "100"
+            },
             "r2_buckets": [
                 {
                     "binding": "NEXT_INC_CACHE_R2_BUCKET",

--- a/packages/gitbook-v2/openNext/customWorkers/doWrangler.jsonc
+++ b/packages/gitbook-v2/openNext/customWorkers/doWrangler.jsonc
@@ -98,7 +98,11 @@
         },
         "production": {
             "vars": {
+                // R2 is strongly consistent, so we can disable SQLite
                 "NEXT_CACHE_DO_QUEUE_DISABLE_SQLITE": "true",
+                // We don't want to pollute the memory with broken cache entries
+                // Most of the time, those are fake requests.
+                "NEXT_CACHE_DO_QUEUE_MAX_RETRIES": "1",
                 "STAGE": "production"
             },
             "r2_buckets": [


### PR DESCRIPTION
We missed setting an env variable in the default server function, meaning that we overloaded some of the DO queue instance (especially true for fake request which will bypass the cache interception)

We also reduce the number of retries to reduce the memory size. The one that fails are also usually fake request increasing the memory footprint for no reason. 