### PR TITLE
Set tw classes correctly for horizontal alignment in tables

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
@@ -115,8 +115,13 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                 return <Tag className={tcls(['w-full', verticalAlignment])}>{''}</Tag>;
             }
 
+            const alignmentMap = {
+                'text-left': '[&_*]:text-left text-left',
+                'text-center': '[&_*]:text-center text-center',
+                'text-right': '[&_*]:text-right text-right',
+            };
             const horizontalAlignment = getColumnAlignment(definition);
-            const childrenHorizontalAlignment = `[&_*]:${horizontalAlignment}`;
+            const horizontalClasses = alignmentMap[horizontalAlignment];
 
             return (
                 <Blocks
@@ -131,8 +136,7 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                         'lg:space-y-3',
                         'leading-normal',
                         verticalAlignment,
-                        horizontalAlignment,
-                        childrenHorizontalAlignment,
+                        horizontalClasses,
                     ]}
                     context={context}
                     blockStyle={['w-full', 'max-w-[unset]']}


### PR DESCRIPTION
When a table column would have horizontal alignment set, some text nodes in cells would not use the correct horizontal alignment, e.g. when a table cell would have an annotation. While fixing this, I also noticed that the recent horizontal alignment on paragraph-level would also interfere.

This PR:
- correctly targets the nested paragraph node and sets the text alignment based on the column alignment
- alignment set on column-level overrides the newly added horizontal alignment on paragraph-level, as copy-pasted paragraphs in a cell would not listen to the column-level alignment (cc @SamyPesse)
- constructs the text-alignment in a way that doesnt break with [tailwind's JIT principles](https://tailwindcss.com/docs/detecting-classes-in-source-files#dynamic-class-names) (which caused prior PR's on this issue to not reliably fix the problem)



~closes https://linear.app/gitbook-x/issue/RND-6658/annotations-in-table-cells-with-multi-line-text-makes-it-center