### PR TITLE
Check ancestorBlocks for tables before applying text alignment

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -9,7 +9,7 @@ import { getBlockTextStyle } from './spacing';
 import { getTextAlignment } from './utils';
 
 export function Heading(props: BlockProps<DocumentBlockHeading>) {
-    const { block, style, context, ...rest } = props;
+    const { block, style, context, ancestorBlocks, ...rest } = props;
 
     const textStyle = getBlockTextStyle(block);
 
@@ -43,7 +43,7 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
                     'grid-area-1-1',
                     'z-[1]',
                     'justify-self-start',
-                    getTextAlignment(block.data.align),
+                    getTextAlignment(block.data.align, ancestorBlocks),
                     textStyle.lineHeight,
                     textStyle.marginTop
                 )}

--- a/packages/gitbook/src/components/DocumentView/Paragraph.tsx
+++ b/packages/gitbook/src/components/DocumentView/Paragraph.tsx
@@ -7,10 +7,10 @@ import { Inlines } from './Inlines';
 import { getTextAlignment } from './utils';
 
 export function Paragraph(props: BlockProps<DocumentBlockParagraph>) {
-    const { block, style, ...contextProps } = props;
+    const { block, style, ancestorBlocks, ...contextProps } = props;
 
     return (
-        <p className={tcls(style, getTextAlignment(block.data?.align))}>
+        <p className={tcls(style, getTextAlignment(block.data?.align, ancestorBlocks))}>
             <Inlines {...contextProps} nodes={block.nodes} ancestorInlines={[]} />
         </p>
     );

--- a/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordColumnValue.tsx
@@ -128,7 +128,7 @@ export async function RecordColumnValue<Tag extends React.ElementType = 'div'>(
                 <Blocks
                     tag={Tag}
                     document={document}
-                    ancestorBlocks={[]}
+                    ancestorBlocks={[...props.ancestorBlocks, block]}
                     nodes={fragment.nodes}
                     style={[
                         'blocks',

--- a/packages/gitbook/src/components/DocumentView/utils/textAlignment.ts
+++ b/packages/gitbook/src/components/DocumentView/utils/textAlignment.ts
@@ -1,11 +1,23 @@
 import type { ClassValue } from '@/lib/tailwind';
 import { nullIfNever } from '@/lib/typescript';
-import { TextAlignment } from '@gitbook/api';
+import { type DocumentBlock, TextAlignment } from '@gitbook/api';
 
 /**
  * Get the tailwind class for a text alignment.
  */
-export function getTextAlignment(textAlignment: TextAlignment | undefined): ClassValue {
+export function getTextAlignment(
+    textAlignment: TextAlignment | undefined,
+    ancestorBlocks: DocumentBlock[]
+): ClassValue {
+    // Text nodes within a table will have their alignment governed by columns instead.)
+    for (let i = ancestorBlocks.length - 1; i >= 0; i--) {
+        const ancestor = ancestorBlocks[i];
+        if (ancestor.type === 'table') {
+            return null;
+        }
+    }
+
+    // If not inside a table, use the normal alignment logic
     switch (textAlignment) {
         case undefined:
         case TextAlignment.Start:


### PR DESCRIPTION
When we apply text alignment on text nodes like Paragraph/Heading, we check if the node is not within a table. If that is the case, we don't want to set text alignment through getTextAlignment as it'd override the column-level alignment.