### PR TITLE
Fix revision ID handling for computed content

### DIFF
--- a/.changeset/dry-pandas-rhyme.md
+++ b/.changeset/dry-pandas-rhyme.md
@@ -1,0 +1,5 @@
+---
+"gitbook-v2": patch
+---
+
+Fix revision id for computed content

--- a/packages/gitbook-v2/src/lib/context.ts
+++ b/packages/gitbook-v2/src/lib/context.ts
@@ -87,6 +87,9 @@ export type GitBookSpaceContext = GitBookBaseContext & {
     /** Revision of the space. */
     revision: Revision;
 
+    /** Identifier of the revision. Could be different than `revision.id` when using computed. */
+    revisionId: string;
+
     /** Share key of the space. */
     shareKey: string | undefined;
 };
@@ -367,6 +370,7 @@ export async function fetchSpaceContextByIds(
         organizationId: space.organization,
         space,
         revision,
+        revisionId,
         changeRequest,
         shareKey: ids.shareKey,
     };

--- a/packages/gitbook/src/components/AdminToolbar/AdminToolbar.tsx
+++ b/packages/gitbook/src/components/AdminToolbar/AdminToolbar.tsx
@@ -58,7 +58,7 @@ export async function AdminToolbar(props: AdminToolbarProps) {
         return <ChangeRequestToolbar context={context} />;
     }
 
-    if (context.revision.id !== context.space.revision) {
+    if (context.revisionId !== context.space.revision) {
         return <RevisionToolbar context={context} />;
     }
 

--- a/packages/gitbook/src/components/SitePage/fetch.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.ts
@@ -36,7 +36,7 @@ export async function fetchPageData(context: GitBookSiteContext, params: PagePar
  * If the path can't be found, we try to resolve it from the API to handle redirects.
  */
 async function resolvePage(context: GitBookSiteContext, params: PagePathParams | PageIdParams) {
-    const { organizationId, site, space, revision, shareKey, linker } = context;
+    const { organizationId, site, space, revision, shareKey, linker, revisionId } = context;
 
     if ('pageId' in params) {
         return resolvePageId(revision.pages, params.pageId);
@@ -59,7 +59,7 @@ async function resolvePage(context: GitBookSiteContext, params: PagePathParams |
         const resolved = await getDataOrNull(
             context.dataFetcher.getRevisionPageByPath({
                 spaceId: space.id,
-                revisionId: revision.id,
+                revisionId: revisionId,
                 path: rawPathname,
             })
         );

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -59,7 +59,7 @@ export function SpaceLayout(props: {
                 siteSectionId={context.sections?.current?.id ?? null}
                 siteSpaceId={context.siteSpace.id}
                 siteShareKey={context.shareKey ?? null}
-                revisionId={context.revision.id}
+                revisionId={context.revisionId}
                 spaceId={context.space.id}
                 visitorAuthClaims={visitorAuthClaims}
                 visitorCookieTrackingEnabled={context.customization.insights?.trackingCookie}

--- a/packages/gitbook/src/lib/seo.ts
+++ b/packages/gitbook/src/lib/seo.ts
@@ -35,7 +35,7 @@ export async function isSiteIndexable(context: GitBookSiteContext) {
     }
 
     // Prevent indexation of preview of revisions / change-requests
-    if (context.changeRequest || context.revision.id !== context.space.revision) {
+    if (context.changeRequest || context.revisionId !== context.space.revision) {
         return false;
     }
 


### PR DESCRIPTION
Update the context to use `revisionId` property for accurate revision identification.