### PR TITLE
refactor toc components to client

### DIFF
--- a/packages/gitbook/src/components/PageIcon/PageIcon.tsx
+++ b/packages/gitbook/src/components/PageIcon/PageIcon.tsx
@@ -4,7 +4,10 @@ import { Icon, type IconName } from '@gitbook/icons';
 import { Emoji } from '@/components/primitives';
 import { type ClassValue, tcls } from '@/lib/tailwind';
 
-export function PageIcon(props: { page: RevisionPage; style?: ClassValue }) {
+export function PageIcon(props: {
+    page: Pick<RevisionPage, 'emoji' | 'icon'>;
+    style?: ClassValue;
+}) {
     const { page, style } = props;
 
     if (page.emoji) {

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -1,48 +1,25 @@
-import type { GitBookSiteContext } from '@/lib/context';
-import { getPagePaths, hasPageVisibleDescendant } from '@/lib/pages';
+'use client';
+
 import { tcls } from '@/lib/tailwind';
-import {
-    type RevisionPage,
-    type RevisionPageDocument,
-    SiteInsightsLinkPosition,
-} from '@gitbook/api';
+import type { ClientTOCPage } from './encodeClientTableOfContents';
 
 import { PagesList } from './PagesList';
 import { TOCPageIcon } from './TOCPageIcon';
 import { ToggleableLinkItem } from './ToggleableLinkItem';
 
-export async function PageDocumentItem(props: {
-    rootPages: RevisionPage[];
-    page: RevisionPageDocument;
-    context: GitBookSiteContext;
-}) {
-    const { rootPages, page, context } = props;
-    let href = context.linker.toPathForPage({ pages: rootPages, page });
-    // toPathForPage can returns an empty path, this will cause all links to point to the current page.
-    if (href === '') {
-        href = '/';
-    }
+export function PageDocumentItem(props: { page: ClientTOCPage }) {
+    const { page } = props;
 
     return (
         <li className="flex flex-col">
             <ToggleableLinkItem
-                href={href}
-                pathnames={getPagePaths(rootPages, page)}
-                insights={{
-                    type: 'link_click',
-                    link: {
-                        target: {
-                            kind: 'page',
-                            page: page.id,
-                        },
-                        position: SiteInsightsLinkPosition.Sidebar,
-                    },
-                }}
+                href={page.href}
+                pathnames={page.pathnames}
+                insights={page.insights}
                 descendants={
-                    hasPageVisibleDescendant(page) ? (
+                    page.descendants && page.descendants.length > 0 ? (
                         <PagesList
-                            rootPages={rootPages}
-                            pages={page.pages}
+                            pages={page.descendants}
                             style={tcls(
                                 'ml-5',
                                 'my-2',
@@ -50,7 +27,6 @@ export async function PageDocumentItem(props: {
                                 'sidebar-list-default:border-l',
                                 'sidebar-list-line:border-l'
                             )}
-                            context={context}
                         />
                     ) : null
                 }

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -13,7 +13,7 @@ export function PageDocumentItem(props: { page: ClientTOCPage }) {
     return (
         <li className="flex flex-col">
             <ToggleableLinkItem
-                href={page.href}
+                href={page.href ?? '#'}
                 pathnames={page.pathnames}
                 insights={page.insights}
                 descendants={

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { tcls } from '@/lib/tailwind';
-import type { ClientTOCPage } from './encodeClientTableOfContents';
+import type { ClientTOCPageDocument } from './encodeClientTableOfContents';
 
 import { SiteInsightsLinkPosition } from '@gitbook/api';
 import { PagesList } from './PagesList';
 import { TOCPageIcon } from './TOCPageIcon';
 import { ToggleableLinkItem } from './ToggleableLinkItem';
 
-export function PageDocumentItem(props: { page: ClientTOCPage }) {
+export function PageDocumentItem(props: { page: ClientTOCPageDocument }) {
     const { page } = props;
 
     return (

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -3,6 +3,7 @@
 import { tcls } from '@/lib/tailwind';
 import type { ClientTOCPage } from './encodeClientTableOfContents';
 
+import { SiteInsightsLinkPosition } from '@gitbook/api';
 import { PagesList } from './PagesList';
 import { TOCPageIcon } from './TOCPageIcon';
 import { ToggleableLinkItem } from './ToggleableLinkItem';
@@ -15,7 +16,13 @@ export function PageDocumentItem(props: { page: ClientTOCPage }) {
             <ToggleableLinkItem
                 href={page.href ?? '#'}
                 pathnames={page.pathnames}
-                insights={page.insights}
+                insights={{
+                    type: 'link_click',
+                    link: {
+                        target: { kind: 'page', page: page.id },
+                        position: SiteInsightsLinkPosition.Sidebar,
+                    },
+                }}
                 descendants={
                     page.descendants && page.descendants.length > 0 ? (
                         <PagesList

--- a/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import type { ClientTOCPage } from './encodeClientTableOfContents';
+import type { ClientTOCPageGroup } from './encodeClientTableOfContents';
 
 import { tcls } from '@/lib/tailwind';
 
 import { PagesList } from './PagesList';
 import { TOCPageIcon } from './TOCPageIcon';
 
-export function PageGroupItem(props: { page: ClientTOCPage }) {
+export function PageGroupItem(props: { page: ClientTOCPageGroup }) {
     const { page } = props;
 
     return (

--- a/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
@@ -1,18 +1,14 @@
-import type { GitBookSiteContext } from '@/lib/context';
-import type { RevisionPage, RevisionPageGroup } from '@gitbook/api';
+'use client';
 
-import { hasPageVisibleDescendant } from '@/lib/pages';
+import type { ClientTOCPage } from './encodeClientTableOfContents';
+
 import { tcls } from '@/lib/tailwind';
 
 import { PagesList } from './PagesList';
 import { TOCPageIcon } from './TOCPageIcon';
 
-export function PageGroupItem(props: {
-    rootPages: RevisionPage[];
-    page: RevisionPageGroup;
-    context: GitBookSiteContext;
-}) {
-    const { rootPages, page, context } = props;
+export function PageGroupItem(props: { page: ClientTOCPage }) {
+    const { page } = props;
 
     return (
         <li className="group/page-group-item flex flex-col">
@@ -36,8 +32,8 @@ export function PageGroupItem(props: {
                 <TOCPageIcon page={page} />
                 {page.title}
             </div>
-            {hasPageVisibleDescendant(page) ? (
-                <PagesList rootPages={rootPages} pages={page.pages} context={context} />
+            {page.descendants && page.descendants.length > 0 ? (
+                <PagesList pages={page.descendants} />
             ) : null}
         </li>
     );

--- a/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
@@ -6,6 +6,7 @@ import type { ClientTOCPage } from './encodeClientTableOfContents';
 import { Link } from '@/components/primitives';
 import { tcls } from '@/lib/tailwind';
 
+import { SiteInsightsLinkPosition } from '@gitbook/api';
 import { TOCPageIcon } from './TOCPageIcon';
 
 export function PageLinkItem(props: { page: ClientTOCPage }) {
@@ -16,7 +17,17 @@ export function PageLinkItem(props: { page: ClientTOCPage }) {
             <Link
                 href={page.href ?? '#'}
                 classNames={['PageLinkItemStyles']}
-                insights={page.insights}
+                insights={
+                    page.target
+                        ? {
+                              type: 'link_click',
+                              link: {
+                                  target: page.target,
+                                  position: SiteInsightsLinkPosition.Sidebar,
+                              },
+                          }
+                        : undefined
+                }
             >
                 <TOCPageIcon page={page} />
                 {page.title}

--- a/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Icon } from '@gitbook/icons';
-import type { ClientTOCPage } from './encodeClientTableOfContents';
+import type { ClientTOCPageLink } from './encodeClientTableOfContents';
 
 import { Link } from '@/components/primitives';
 import { tcls } from '@/lib/tailwind';
@@ -9,7 +9,7 @@ import { tcls } from '@/lib/tailwind';
 import { SiteInsightsLinkPosition } from '@gitbook/api';
 import { TOCPageIcon } from './TOCPageIcon';
 
-export function PageLinkItem(props: { page: ClientTOCPage }) {
+export function PageLinkItem(props: { page: ClientTOCPageLink }) {
     const { page } = props;
 
     return (
@@ -17,17 +17,13 @@ export function PageLinkItem(props: { page: ClientTOCPage }) {
             <Link
                 href={page.href ?? '#'}
                 classNames={['PageLinkItemStyles']}
-                insights={
-                    page.target
-                        ? {
-                              type: 'link_click',
-                              link: {
-                                  target: page.target,
-                                  position: SiteInsightsLinkPosition.Sidebar,
-                              },
-                          }
-                        : undefined
-                }
+                insights={{
+                    type: 'link_click',
+                    link: {
+                        target: page.target,
+                        position: SiteInsightsLinkPosition.Sidebar,
+                    },
+                }}
             >
                 <TOCPageIcon page={page} />
                 {page.title}

--- a/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
@@ -1,31 +1,19 @@
-import type { GitBookSiteContext } from '@/lib/context';
-import { type RevisionPageLink, SiteInsightsLinkPosition } from '@gitbook/api';
+'use client';
+
 import { Icon } from '@gitbook/icons';
+import type { ClientTOCPage } from './encodeClientTableOfContents';
 
 import { Link } from '@/components/primitives';
-import { resolveContentRef } from '@/lib/references';
 import { tcls } from '@/lib/tailwind';
 
 import { TOCPageIcon } from './TOCPageIcon';
 
-export async function PageLinkItem(props: { page: RevisionPageLink; context: GitBookSiteContext }) {
-    const { page, context } = props;
-
-    const resolved = await resolveContentRef(page.target, context);
+export function PageLinkItem(props: { page: ClientTOCPage }) {
+    const { page } = props;
 
     return (
         <li className={tcls('flex', 'flex-col')}>
-            <Link
-                href={resolved?.href ?? '#'}
-                classNames={['PageLinkItemStyles']}
-                insights={{
-                    type: 'link_click',
-                    link: {
-                        target: page.target,
-                        position: SiteInsightsLinkPosition.Sidebar,
-                    },
-                }}
-            >
+            <Link href={page.href} classNames={['PageLinkItemStyles']} insights={page.insights}>
                 <TOCPageIcon page={page} />
                 {page.title}
                 <Icon

--- a/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
@@ -13,7 +13,11 @@ export function PageLinkItem(props: { page: ClientTOCPage }) {
 
     return (
         <li className={tcls('flex', 'flex-col')}>
-            <Link href={page.href} classNames={['PageLinkItemStyles']} insights={page.insights}>
+            <Link
+                href={page.href ?? '#'}
+                classNames={['PageLinkItemStyles']}
+                insights={page.insights}
+            >
                 <TOCPageIcon page={page} />
                 {page.title}
                 <Icon

--- a/packages/gitbook/src/components/TableOfContents/PagesList.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PagesList.tsx
@@ -26,7 +26,6 @@ export function PagesList(props: { pages: ClientTOCPage[]; style?: ClassValue })
                         return <PageGroupItem key={page.id} page={page} />;
 
                     default:
-                        //@ts-ignore Just for testing
                         assertNever(page);
                 }
             })}

--- a/packages/gitbook/src/components/TableOfContents/PagesList.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PagesList.tsx
@@ -1,5 +1,6 @@
-import type { GitBookSiteContext } from '@/lib/context';
-import type { RevisionPage } from '@gitbook/api';
+'use client';
+
+import type { ClientTOCPage } from './encodeClientTableOfContents';
 
 import { type ClassValue, tcls } from '@/lib/tailwind';
 
@@ -8,50 +9,21 @@ import { PageDocumentItem } from './PageDocumentItem';
 import { PageGroupItem } from './PageGroupItem';
 import { PageLinkItem } from './PageLinkItem';
 
-export function PagesList(props: {
-    context: GitBookSiteContext;
-    rootPages: RevisionPage[];
-    pages: RevisionPage[];
-    style?: ClassValue;
-}) {
-    const { rootPages, pages, context, style } = props;
+export function PagesList(props: { pages: ClientTOCPage[]; style?: ClassValue }) {
+    const { pages, style } = props;
 
     return (
         <ul className={tcls('flex flex-col gap-y-0.5', style)}>
             {pages.map((page) => {
-                if (page.type === 'computed') {
-                    throw new Error(
-                        'Unexpected computed page, it should have been computed in the API'
-                    );
-                }
-
-                if (page.hidden) {
-                    return null;
-                }
-
                 switch (page.type) {
                     case 'document':
-                        return (
-                            <PageDocumentItem
-                                key={page.id}
-                                rootPages={rootPages}
-                                page={page}
-                                context={context}
-                            />
-                        );
+                        return <PageDocumentItem key={page.id} page={page} />;
 
                     case 'link':
-                        return <PageLinkItem key={page.id} page={page} context={context} />;
+                        return <PageLinkItem key={page.id} page={page} />;
 
                     case 'group':
-                        return (
-                            <PageGroupItem
-                                key={page.id}
-                                rootPages={rootPages}
-                                page={page}
-                                context={context}
-                            />
-                        );
+                        return <PageGroupItem key={page.id} page={page} />;
 
                     default:
                         assertNever(page);

--- a/packages/gitbook/src/components/TableOfContents/PagesList.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PagesList.tsx
@@ -26,6 +26,7 @@ export function PagesList(props: { pages: ClientTOCPage[]; style?: ClassValue })
                         return <PageGroupItem key={page.id} page={page} />;
 
                     default:
+                        //@ts-ignore Just for testing
                         assertNever(page);
                 }
             })}

--- a/packages/gitbook/src/components/TableOfContents/TOCPageIcon.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TOCPageIcon.tsx
@@ -7,7 +7,7 @@ import { PageIcon } from '../PageIcon';
 /**
  * Styled page icon for the table of contents.
  */
-export function TOCPageIcon({ page }: { page: RevisionPage }) {
+export function TOCPageIcon({ page }: { page: Pick<RevisionPage, 'emoji' | 'icon'> }) {
     return (
         <PageIcon
             page={page}

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -8,14 +8,17 @@ import { PagesList } from './PagesList';
 import { TOCScrollContainer } from './TOCScroller';
 import { TableOfContentsScript } from './TableOfContentsScript';
 import { Trademark } from './Trademark';
+import { encodeClientTableOfContents } from './encodeClientTableOfContents';
 
-export function TableOfContents(props: {
+export async function TableOfContents(props: {
     context: GitBookSiteContext;
     header?: React.ReactNode; // Displayed outside the scrollable TOC as a sticky header
     innerHeader?: React.ReactNode; // Displayed outside the scrollable TOC, directly above the page list
 }) {
     const { innerHeader, context, header } = props;
     const { space, customization, revision } = context;
+
+    const pages = await encodeClientTableOfContents(context, revision.pages, revision.pages);
 
     return (
         <>
@@ -106,9 +109,7 @@ export function TableOfContents(props: {
                         )}
                     >
                         <PagesList
-                            rootPages={revision.pages}
-                            pages={revision.pages}
-                            context={context}
+                            pages={pages}
                             style="page-no-toc:hidden border-tint-subtle sidebar-list-line:border-l"
                         />
                         {customization.trademark.enabled ? (

--- a/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
+++ b/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
@@ -1,9 +1,8 @@
 import type { GitBookSiteContext } from '@/lib/context';
 import { getPagePaths, hasPageVisibleDescendant } from '@/lib/pages';
 import { resolveContentRef } from '@/lib/references';
-import { type RevisionPage, SiteInsightsLinkPosition } from '@gitbook/api';
+import type { ContentRef, RevisionPage } from '@gitbook/api';
 import assertNever from 'assert-never';
-import type { TrackEventInput } from '../Insights';
 
 export type ClientTOCPage = {
     id: string;
@@ -12,8 +11,8 @@ export type ClientTOCPage = {
     emoji?: string;
     icon?: string;
     pathnames: string[];
-    insights?: TrackEventInput<'link_click'>;
     descendants?: ClientTOCPage[];
+    target?: ContentRef;
     type: 'document' | 'link' | 'group';
 };
 
@@ -52,13 +51,6 @@ export async function encodeClientTableOfContents(
                         emoji: page.emoji,
                         icon: page.icon,
                         pathnames: getPagePaths(rootPages, page),
-                        insights: {
-                            type: 'link_click',
-                            link: {
-                                target: { kind: 'page', page: page.id },
-                                position: SiteInsightsLinkPosition.Sidebar,
-                            },
-                        },
                         descendants,
                         type: 'document',
                     })
@@ -74,14 +66,8 @@ export async function encodeClientTableOfContents(
                         href: resolved?.href ?? '#',
                         emoji: page.emoji,
                         icon: page.icon,
+                        target: page.target,
                         pathnames: [],
-                        insights: {
-                            type: 'link_click',
-                            link: {
-                                target: page.target,
-                                position: SiteInsightsLinkPosition.Sidebar,
-                            },
-                        },
                         type: 'link',
                     })
                 );

--- a/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
+++ b/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
@@ -1,0 +1,108 @@
+import type { GitBookSiteContext } from '@/lib/context';
+import { getPagePaths, hasPageVisibleDescendant } from '@/lib/pages';
+import { resolveContentRef } from '@/lib/references';
+import { type RevisionPage, SiteInsightsLinkPosition } from '@gitbook/api';
+import assertNever from 'assert-never';
+import type { TrackEventInput } from '../Insights';
+
+export type ClientTOCPage = {
+    id: string;
+    title: string;
+    href?: string;
+    emoji?: string | null;
+    icon?: string | null;
+    pathnames: string[];
+    insights?: TrackEventInput<'link_click'>;
+    descendants?: ClientTOCPage[];
+    type: 'document' | 'link' | 'group';
+};
+
+export async function encodeClientTableOfContents(
+    context: GitBookSiteContext,
+    rootPages: RevisionPage[],
+    pages: RevisionPage[]
+): Promise<ClientTOCPage[]> {
+    const result: ClientTOCPage[] = [];
+
+    for (const page of pages) {
+        if (page.type === 'computed') {
+            throw new Error('Unexpected computed page, it should have been computed in the API');
+        }
+
+        if (page.hidden) {
+            continue;
+        }
+
+        switch (page.type) {
+            case 'document': {
+                let href = context.linker.toPathForPage({ pages: rootPages, page });
+                if (href === '') {
+                    href = '/';
+                }
+
+                const descendants = hasPageVisibleDescendant(page)
+                    ? await encodeClientTableOfContents(context, rootPages, page.pages)
+                    : undefined;
+
+                result.push({
+                    id: page.id,
+                    title: page.title,
+                    href,
+                    emoji: page.emoji,
+                    icon: page.icon,
+                    pathnames: getPagePaths(rootPages, page),
+                    insights: {
+                        type: 'link_click',
+                        link: {
+                            target: { kind: 'page', page: page.id },
+                            position: SiteInsightsLinkPosition.Sidebar,
+                        },
+                    },
+                    descendants,
+                    type: 'document',
+                });
+                break;
+            }
+            case 'link': {
+                const resolved = await resolveContentRef(page.target, context);
+                result.push({
+                    id: page.id,
+                    title: page.title,
+                    href: resolved?.href ?? '#',
+                    emoji: page.emoji,
+                    icon: page.icon,
+                    pathnames: [],
+                    insights: {
+                        type: 'link_click',
+                        link: {
+                            target: page.target,
+                            position: SiteInsightsLinkPosition.Sidebar,
+                        },
+                    },
+                    type: 'link',
+                });
+                break;
+            }
+            case 'group': {
+                const descendants = hasPageVisibleDescendant(page)
+                    ? await encodeClientTableOfContents(context, rootPages, page.pages)
+                    : undefined;
+
+                result.push({
+                    id: page.id,
+                    title: page.title,
+                    emoji: page.emoji,
+                    icon: page.icon,
+                    pathnames: [],
+                    descendants,
+                    type: 'group',
+                });
+                break;
+            }
+            default:
+                assertNever(page);
+        }
+    }
+
+    return result;
+}

--- a/packages/gitbook/src/lib/typescript.ts
+++ b/packages/gitbook/src/lib/typescript.ts
@@ -21,7 +21,7 @@ type WithoutUndefined<T> = {
  * This is useful for RSC serialization, as it avoids sending `"$undefined"` values.
  *
  */
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+// biome-ignore lint/suspicious/noExplicitAny: can't avoid for the generic
 export function removeUndefined<T extends Record<string, any>>(obj: T): WithoutUndefined<T> {
     const result: Partial<T> = {};
 

--- a/packages/gitbook/src/lib/typescript.ts
+++ b/packages/gitbook/src/lib/typescript.ts
@@ -11,3 +11,25 @@ export function filterOutNullable<T>(value: T): value is NonNullable<T> {
 export function nullIfNever(_value: never): null {
     return null;
 }
+
+type WithoutUndefined<T> = {
+    [K in keyof T]: T[K] extends undefined ? never : T[K];
+};
+
+/**
+ * Removes `undefined` properties from an object.
+ * This is useful for RSC serialization, as it avoids sending `"$undefined"` values.
+ *
+ */
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export function removeUndefined<T extends Record<string, any>>(obj: T): WithoutUndefined<T> {
+    const result: Partial<T> = {};
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (value !== undefined) {
+            result[key as keyof T] = value;
+        }
+    }
+
+    return result as WithoutUndefined<T>;
+}


### PR DESCRIPTION
## Summary
- make PagesList a client component and simplify props
- transform PageDocumentItem, PageGroupItem and PageLinkItem into client components
- precompute TOC entries in TableOfContents
- add encodeClientTableOfContents helper
- relax PageIcon type

Fix RND-7417

By doing this on https://mariadb.com/docs/release-notes, we can go from a 1.3Mb RSC to a 800Kb one

------
https://chatgpt.com/codex/tasks/task_b_685be68bd9808328be2b79d10dfbed0d