### PR TITLE
Add end-to-end test for repositioned cover

### DIFF
--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -733,6 +733,11 @@ const testCases: TestsCase[] = [
                 },
             },
             {
+                name: 'With repositioned cover',
+                url: 'page-options/page-with-repositioned-cover',
+                run: waitForCookiesDialog,
+            },
+            {
                 name: 'With icon',
                 url: 'page-options/page-with-icon',
                 run: waitForCookiesDialog,


### PR DESCRIPTION
Introduce an end-to-end test case for the page with a repositioned cover to ensure proper functionality.