### PR TITLE
Make Emoji component synchronous

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Emoji.tsx
+++ b/packages/gitbook/src/components/DocumentView/Emoji.tsx
@@ -4,7 +4,7 @@ import { Emoji as EmojiPrimitive } from '@/components/primitives';
 
 import type { InlineProps } from './Inline';
 
-export async function Emoji(props: InlineProps<DocumentInlineEmoji>) {
+export function Emoji(props: InlineProps<DocumentInlineEmoji>) {
     const { inline } = props;
 
     return <EmojiPrimitive code={inline.data.code} />;

--- a/packages/gitbook/src/components/primitives/Emoji/Emoji.tsx
+++ b/packages/gitbook/src/components/primitives/Emoji/Emoji.tsx
@@ -5,7 +5,7 @@ import { type ClassValue, tcls } from '@/lib/tailwind';
  * Render an emoji by its codepoint.
  * It renders the UTF-8 character and use Emoji font defined in Tailwind CSS.
  */
-export async function Emoji(props: { code: string; style?: ClassValue }) {
+export function Emoji(props: { code: string; style?: ClassValue }) {
     const { code, style } = props;
 
     const fallback = getEmojiForCode(code);


### PR DESCRIPTION
Remove asynchronous behavior from the Emoji component.
This was causing the 404 to fail to render because it was improperly awaiting this component