### PR TITLE
Refactor async usage

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -82,7 +82,8 @@
                 "noControlCharactersInRegex": "warn",
                 "noPrototypeBuiltins": "warn",
                 "noAssignInExpressions": "warn",
-                "noArrayIndexKey": "warn"
+                "noArrayIndexKey": "warn",
+                "useAwait": "error"
             },
             "a11y": {
                 "useSemanticElements": "warn",
@@ -152,6 +153,13 @@
             "include": ["*.test.ts", "packages/gitbook/tests/**/*"],
             "javascript": {
                 "globals": ["Bun"]
+            },
+            "linter": {
+                "rules": {
+                    "suspicious": {
+                        "useAwait": "off"
+                    }
+                }
             }
         },
         {
@@ -169,6 +177,16 @@
                     "Fetcher",
                     "ExportedHandler"
                 ]
+            }
+        },
+        {
+            "include": ["packages/gitbook/openNext/**/*"],
+            "linter": {
+                "rules": {
+                    "suspicious": {
+                        "useAwait": "off"
+                    }
+                }
             }
         }
     ]

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -425,7 +425,7 @@ const testCases: TestsCase[] = [
                 name: 'Text page',
                 url: 'text-page.md',
                 screenshot: false,
-                run: async (_page, response) => {
+                run: (_page, response) => {
                     expect(response?.status()).toBe(200);
                     expect(response?.headers()['content-type']).toContain('text/markdown');
                 },
@@ -441,7 +441,7 @@ const testCases: TestsCase[] = [
                 name: 'llms.txt',
                 url: 'llms.txt',
                 screenshot: false,
-                run: async (_page, response) => {
+                run: (_page, response) => {
                     expect(response?.status()).toBe(200);
                     expect(response?.headers()['content-type']).toContain('text/markdown');
                 },
@@ -457,7 +457,7 @@ const testCases: TestsCase[] = [
                 name: 'llms-full.txt',
                 url: 'llms-full.txt',
                 screenshot: false,
-                run: async (_page, response) => {
+                run: (_page, response) => {
                     expect(response?.status()).toBe(200);
                     expect(response?.headers()['content-type']).toContain('text/markdown');
                 },
@@ -473,7 +473,7 @@ const testCases: TestsCase[] = [
                 name: 'blocks.md',
                 url: 'blocks.md',
                 screenshot: false,
-                run: async (_page, response) => {
+                run: (_page, response) => {
                     expect(response?.status()).toBe(200);
                     expect(response?.headers()['content-type']).toContain('text/markdown');
                 },

--- a/packages/gitbook/e2e/util.ts
+++ b/packages/gitbook/e2e/util.ts
@@ -144,7 +144,7 @@ export async function waitForCookiesDialog(page: Page) {
     await expect(dialog).toBeVisible();
 }
 
-export async function waitForNotFound(_page: Page, response: Response | null) {
+export function waitForNotFound(_page: Page, response: Response | null) {
     expect(response).not.toBeNull();
     expect(response?.status()).toBe(404);
 }

--- a/packages/gitbook/next.config.mjs
+++ b/packages/gitbook/next.config.mjs
@@ -54,7 +54,7 @@ const nextConfig = {
         ],
     },
 
-    async headers() {
+    headers() {
         return [
             {
                 source: '/~gitbook/static/:path*',

--- a/packages/gitbook/openNext/customWorkers/default.js
+++ b/packages/gitbook/openNext/customWorkers/default.js
@@ -22,7 +22,7 @@ export class R2WriteBuffer extends DurableObject {
 }
 
 export default {
-    async fetch(request, env, ctx) {
+    fetch(request, env, ctx) {
         return runWithCloudflareRequestContext(request, env, ctx, async () => {
             // We can't move the handler import to the top level, otherwise the runtime will not be properly initialized
             const { handler } = await import(

--- a/packages/gitbook/openNext/customWorkers/do.js
+++ b/packages/gitbook/openNext/customWorkers/do.js
@@ -26,7 +26,7 @@ export { DOQueueHandler } from '../../.open-next/.build/durable-objects/queue.js
 export { DOShardedTagCache } from '../../.open-next/.build/durable-objects/sharded-tag-cache.js';
 
 export default {
-    async fetch() {
+    fetch() {
         // This worker does not handle any requests, it only provides Durable Objects
         return new Response('This worker is not meant to handle requests directly', {
             status: 400,

--- a/packages/gitbook/openNext/customWorkers/middleware.js
+++ b/packages/gitbook/openNext/customWorkers/middleware.js
@@ -8,7 +8,7 @@ export { DOQueueHandler } from '../../.open-next/.build/durable-objects/queue.js
 export { DOShardedTagCache } from '../../.open-next/.build/durable-objects/sharded-tag-cache.js';
 
 export default class extends WorkerEntrypoint {
-    async fetch(request) {
+    fetch(request) {
         return runWithCloudflareRequestContext(request, this.env, this.ctx, async () => {
             // - `Request`s are handled by the Next server
             const reqOrResp = await middlewareHandler(request, this.env, this.ctx);

--- a/packages/gitbook/openNext/queue/middleware.ts
+++ b/packages/gitbook/openNext/queue/middleware.ts
@@ -5,8 +5,8 @@ import doQueue from '@opennextjs/cloudflare/overrides/queue/do-queue';
 
 export default {
     name: 'GitbookISRQueue',
-    send: async (msg) => {
-        return trace({ operation: 'gitbookISRQueueSend', name: msg.MessageBody.url }, async () => {
+    send: (msg) => {
+        return trace({ operation: 'gitbookISRQueueSend', name: msg.MessageBody.url }, () => {
             const { ctx } = getCloudflareContext();
             ctx.waitUntil(doQueue.send(msg));
         });

--- a/packages/gitbook/openNext/queue/server.ts
+++ b/packages/gitbook/openNext/queue/server.ts
@@ -2,7 +2,7 @@ import type { Queue } from '@opennextjs/aws/types/overrides.js';
 
 export default {
     name: 'GitbookISRQueue',
-    send: async (msg) => {
+    send: (msg) => {
         // We should never reach this point in the server. If that's the case, we should log it.
         console.warn('GitbookISRQueue: send called on server side, this should not happen.', msg);
     },

--- a/packages/gitbook/openNext/tagCache/middleware.ts
+++ b/packages/gitbook/openNext/tagCache/middleware.ts
@@ -20,7 +20,7 @@ const originalTagCache = doShardedTagCache({
 export default {
     name: 'GitbookTagCache',
     mode: 'nextMode',
-    getLastRevalidated: async (tags: string[]) => {
+    getLastRevalidated: (tags: string[]) => {
         const tagsToCheck = tags.filter(softTagFilter);
         if (tagsToCheck.length === 0) {
             // If we reach here, it probably means that there is an issue that we'll need to address.
@@ -40,7 +40,7 @@ export default {
             }
         );
     },
-    hasBeenRevalidated: async (tags: string[], lastModified?: number) => {
+    hasBeenRevalidated: (tags: string[], lastModified?: number) => {
         const tagsToCheck = tags.filter(softTagFilter);
         if (tagsToCheck.length === 0) {
             // If we reach here, it probably means that there is an issue that we'll need to address.
@@ -61,7 +61,7 @@ export default {
             }
         );
     },
-    writeTags: async (tags: string[]) => {
+    writeTags: (tags: string[]) => {
         return trace(
             {
                 operation: 'gitbookTagCacheWriteTags',

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/(content)/[pagePath]/not-found.tsx
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/(content)/[pagePath]/not-found.tsx
@@ -1,5 +1,5 @@
 import { SitePageNotFound } from '@/components/SitePage';
 
-export default async function NotFound() {
+export default function NotFound() {
     return <SitePageNotFound />;
 }

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/[pagePath]/not-found.tsx
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/[pagePath]/not-found.tsx
@@ -1,5 +1,5 @@
 import { SitePageNotFound } from '@/components/SitePage';
 
-export default async function NotFound() {
+export default function NotFound() {
     return <SitePageNotFound />;
 }

--- a/packages/gitbook/src/app/~gitbook/env/route.ts
+++ b/packages/gitbook/src/app/~gitbook/env/route.ts
@@ -19,7 +19,7 @@ import {
 /**
  * Output the public environment variables for this deployment
  */
-export async function GET(_req: NextRequest) {
+export function GET(_req: NextRequest) {
     return NextResponse.json({
         GITBOOK_URL,
         GITBOOK_APP_URL,

--- a/packages/gitbook/src/app/~gitbook/revalidate/route.ts
+++ b/packages/gitbook/src/app/~gitbook/revalidate/route.ts
@@ -11,7 +11,7 @@ interface JsonBody {
  * Revalidate cached data based on tags.
  * The body should be a JSON with { tags: string[] }
  */
-export async function POST(req: NextRequest) {
+export function POST(req: NextRequest) {
     return withVerifySignature<JsonBody>(req, async (body) => {
         if (!body.tags || !Array.isArray(body.tags)) {
             return NextResponse.json(

--- a/packages/gitbook/src/components/AI/useAIPage.tsx
+++ b/packages/gitbook/src/components/AI/useAIPage.tsx
@@ -97,7 +97,7 @@ export function useAIPage(
      * Generate a new page for a query.
      */
     const generate = React.useCallback(
-        async (query: string) => {
+        (query: string) => {
             generateFromStream(
                 streamGenerateAIPage({
                     query,

--- a/packages/gitbook/src/components/DocumentView/InlineIcon.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineIcon.tsx
@@ -3,7 +3,7 @@ import type { DocumentInlineIcon } from '@gitbook/api';
 import { Icon, type IconName } from '@gitbook/icons';
 import type { InlineProps } from './Inline';
 
-export async function InlineIcon(props: InlineProps<DocumentInlineIcon>) {
+export function InlineIcon(props: InlineProps<DocumentInlineIcon>) {
     const { inline } = props;
 
     return <Icon icon={inline.data.icon as IconName} className="inline size-[1em]" />;

--- a/packages/gitbook/src/components/DocumentView/Math.tsx
+++ b/packages/gitbook/src/components/DocumentView/Math.tsx
@@ -9,7 +9,7 @@ import type { InlineProps } from './Inline';
 
 const assetsUrl = getAssetURL('math');
 
-export async function BlockMath(props: BlockProps<DocumentBlockMath>) {
+export function BlockMath(props: BlockProps<DocumentBlockMath>) {
     const { block, style } = props;
 
     return (
@@ -22,7 +22,7 @@ export async function BlockMath(props: BlockProps<DocumentBlockMath>) {
     );
 }
 
-export async function InlineMath(props: InlineProps<DocumentInlineMath>) {
+export function InlineMath(props: InlineProps<DocumentInlineMath>) {
     const { inline } = props;
 
     return <MathFormula formula={inline.data.formula} inline={true} assetsUrl={assetsUrl} />;

--- a/packages/gitbook/src/components/Header/HeaderLinks.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLinks.tsx
@@ -9,7 +9,7 @@ interface HeaderLinksProps {
     style?: ClassValue;
 }
 
-export async function HeaderLinks({ children, style }: HeaderLinksProps) {
+export function HeaderLinks({ children, style }: HeaderLinksProps) {
     return (
         <div
             className={tcls(

--- a/packages/gitbook/src/components/Header/HeaderLogo.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLogo.tsx
@@ -14,7 +14,7 @@ interface HeaderLogoProps {
  * Render the logo for a space using the customization settings.
  */
 
-export async function HeaderLogo(props: HeaderLogoProps) {
+export function HeaderLogo(props: HeaderLogoProps) {
     const { context } = props;
     const { customization, linker } = context;
 

--- a/packages/gitbook/src/components/PDF/PDFRootLayout.tsx
+++ b/packages/gitbook/src/components/PDF/PDFRootLayout.tsx
@@ -6,7 +6,7 @@ import { CustomizationThemeMode } from '@gitbook/api';
 /**
  * Layout to be used for rendering the PDF.
  */
-export async function PDFRootLayout(props: {
+export function PDFRootLayout(props: {
     context: GitBookSpaceContext | GitBookSiteContext;
     children: React.ReactNode;
 }) {

--- a/packages/gitbook/src/components/PageBody/PageFooterNavigation.tsx
+++ b/packages/gitbook/src/components/PageBody/PageFooterNavigation.tsx
@@ -12,7 +12,7 @@ import { Link, type LinkInsightsProps } from '../primitives';
 /**
  * Show cards to go to previous/next pages at the bottom.
  */
-export async function PageFooterNavigation(props: {
+export function PageFooterNavigation(props: {
     context: GitBookSiteContext;
     page: RevisionPageDocument;
 }) {

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -9,7 +9,7 @@ import { tcls } from '@/lib/tailwind';
 import { PageIcon } from '../PageIcon';
 import { StyledLink } from '../primitives';
 
-export async function PageHeader(props: {
+export function PageHeader(props: {
     context: GitBookSiteContext;
     page: RevisionPageDocument;
     ancestors: AncestorRevisionPage[];

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -39,7 +39,7 @@ import { AnnouncementDismissedScript } from '../Announcement';
  * Layout shared between the content and the PDF renderer.
  * It takes care of setting the theme and the language.
  */
-export async function CustomizationRootLayout(props: {
+export function CustomizationRootLayout(props: {
     forcedTheme?: CustomizationThemeMode | null;
     customization: SiteCustomizationSettings;
     children: React.ReactNode;

--- a/packages/gitbook/src/components/primitives/Card.tsx
+++ b/packages/gitbook/src/components/primitives/Card.tsx
@@ -4,7 +4,7 @@ import { type ClassValue, tcls } from '@/lib/tailwind';
 
 import { Link, type LinkInsightsProps } from './Link';
 
-export async function Card(
+export function Card(
     props: {
         href: string;
         leadingIcon?: React.ReactNode;

--- a/packages/gitbook/src/lib/data/pages.ts
+++ b/packages/gitbook/src/lib/data/pages.ts
@@ -5,7 +5,7 @@ import { getDataOrNull } from './errors';
 /**
  * Get the document for a page.
  */
-export async function getPageDocument(
+export function getPageDocument(
     context: GitBookSpaceContext | GitBookSiteContext,
     page: RevisionPageDocument
 ): Promise<JSONDocument | null> {

--- a/packages/gitbook/src/lib/markdown.ts
+++ b/packages/gitbook/src/lib/markdown.ts
@@ -8,7 +8,7 @@ import { unified } from 'unified';
 /**
  * Parse markdown and output HTML.
  */
-export async function parseMarkdown(markdown: string): Promise<string> {
+export function parseMarkdown(markdown: string): Promise<string> {
     const promise = unified()
         .use(remarkParse)
         .use(remarkGfm)

--- a/packages/openapi-parser/src/v2.ts
+++ b/packages/openapi-parser/src/v2.ts
@@ -7,7 +7,7 @@ import { parseOpenAPIV3 } from './v3';
 /**
  * Convert a Swagger 2.0 schema to an OpenAPI 3.0 schema.
  */
-export async function convertOpenAPIV2ToOpenAPIV3(
+export function convertOpenAPIV2ToOpenAPIV3(
     input: ParseOpenAPIInput
 ): Promise<Filesystem<OpenAPIV3xDocument>> {
     const { value, rootURL } = input;

--- a/packages/react-contentkit/src/ElementMarkdown.tsx
+++ b/packages/react-contentkit/src/ElementMarkdown.tsx
@@ -10,9 +10,9 @@ export function ElementMarkdown(props: ContentKitServerElementProps<ContentKitMa
 
     const initialMarkdown = resolveDynamicBinding(state, element.content);
 
-    async function renderMarkdown(markdown: string) {
+    function renderMarkdown(markdown: string) {
         'use server';
-        return <Markdown className="contentkit-markdown" markdown={markdown} />;
+        return Promise.resolve(<Markdown className="contentkit-markdown" markdown={markdown} />);
     }
 
     return (


### PR DESCRIPTION
## Summary
- drop unused async keywords in many React components and utilities
- enforce awaiting async functions via the `useAwait` rule
- wrap server action return in `Promise.resolve`

## Testing
- `bun run format` *(fails: Found 48 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6863fc59b1b883289ca5f4262ea4abc4