### PR TITLE
Support for OpenAPI Array request body

### DIFF
--- a/.changeset/witty-forks-sell.md
+++ b/.changeset/witty-forks-sell.md
@@ -1,0 +1,6 @@
+---
+'@gitbook/react-openapi': patch
+'gitbook': patch
+---
+
+Support for OpenAPI Array request body

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -358,6 +358,11 @@
 
 .openapi-requestbody-header-content {
     /* unstyled */
+    @apply flex flex-row items-center gap-2.5;
+}
+
+.openapi-requestbody-header-type {
+    @apply text-tint select-text text-[0.813rem] font-mono font-normal [word-spacing:-0.25rem];
 }
 
 .openapi-requestbody-description.openapi-markdown {

--- a/packages/react-openapi/src/OpenAPIRequestBody.tsx
+++ b/packages/react-openapi/src/OpenAPIRequestBody.tsx
@@ -1,8 +1,8 @@
 import type { OpenAPIV3 } from '@gitbook/openapi-parser';
 import { InteractiveSection } from './InteractiveSection';
+import { OpenAPIRequestBodyHeader } from './OpenAPIRequestBodyHeader';
 import { OpenAPIRootSchema } from './OpenAPISchemaServer';
 import type { OpenAPIClientContext } from './context';
-import { t } from './translate';
 import type { OpenAPIOperationData, OpenAPIWebhookData } from './types';
 import { checkIsReference, createStateKey } from './utils';
 
@@ -20,11 +20,21 @@ export function OpenAPIRequestBody(props: {
         return null;
     }
 
+    const stateKey = createStateKey('request-body-media-type', context.blockKey);
+
     return (
         <InteractiveSection
-            header={t(context.translation, 'name' in data ? 'payload' : 'body')}
+            header={
+                <OpenAPIRequestBodyHeader
+                    requestBody={requestBody}
+                    context={context}
+                    data={data}
+                    stateKey={stateKey}
+                    key={stateKey}
+                />
+            }
             className="openapi-requestbody"
-            stateKey={createStateKey('request-body-media-type', context.blockKey)}
+            stateKey={stateKey}
             selectIcon={context.icons.chevronDown}
             tabs={Object.entries(requestBody.content ?? {}).map(
                 ([contentType, mediaTypeObject]) => {
@@ -35,6 +45,7 @@ export function OpenAPIRequestBody(props: {
                             <OpenAPIRootSchema
                                 schema={mediaTypeObject.schema ?? {}}
                                 context={context}
+                                key={contentType}
                             />
                         ),
                     };

--- a/packages/react-openapi/src/OpenAPIRequestBodyHeader.tsx
+++ b/packages/react-openapi/src/OpenAPIRequestBodyHeader.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { OpenAPIV3 } from '@gitbook/openapi-parser';
+import { getSchemaTitle } from './OpenAPISchema';
+import { useSelectState } from './OpenAPISelect';
+import type { OpenAPIClientContext } from './context';
+import { t } from './translate';
+import type { OpenAPIOperationData, OpenAPIWebhookData } from './types';
+
+/**
+ * Display the header of a request body.
+ */
+export function OpenAPIRequestBodyHeader(props: {
+    requestBody: OpenAPIV3.RequestBodyObject;
+    context: OpenAPIClientContext;
+    data: OpenAPIOperationData | OpenAPIWebhookData;
+    stateKey: string;
+}) {
+    const { requestBody, context, data, stateKey } = props;
+    const state = useSelectState(stateKey, context.blockKey);
+
+    const [, selectedContentMediaType] =
+        Object.entries(requestBody.content ?? {}).find(
+            ([contentType]) => contentType === state.key
+        ) ?? [];
+
+    return (
+        <>
+            <span>{t(context.translation, 'name' in data ? 'payload' : 'body')}</span>
+
+            {/** If the selected content is an array, We display the type next to the label */}
+            {selectedContentMediaType?.schema?.type === 'array' ? (
+                <span className="openapi-requestbody-header-type">
+                    {`${getSchemaTitle(selectedContentMediaType.schema)}`}
+                </span>
+            ) : null}
+        </>
+    );
+}

--- a/packages/react-openapi/src/OpenAPISchema.tsx
+++ b/packages/react-openapi/src/OpenAPISchema.tsx
@@ -653,7 +653,7 @@ function mergeRequiredFields(
     );
 }
 
-function getSchemaTitle(schema: OpenAPIV3.SchemaObject): string {
+export function getSchemaTitle(schema: OpenAPIV3.SchemaObject): string {
     // Otherwise try to infer a nice title
     let type = 'any';
 


### PR DESCRIPTION
This PR adds the request body type next to the label if this is an Array, this is because we made the choice to render the array properties directly.

![CleanShot 2025-07-02 at 10 21 09@2x](https://github.com/user-attachments/assets/d1019176-f91b-439b-ba36-41d47ebe66d0)