### PR TITLE
Reload page before taking screenshot

### DIFF
--- a/packages/gitbook/e2e/util.ts
+++ b/packages/gitbook/e2e/util.ts
@@ -223,6 +223,7 @@ export function runTestCases(testCases: TestsCase[]) {
                                 threshold: screenshotOptions?.threshold ?? undefined,
                                 fullPage: testEntry.fullPage ?? false,
                                 beforeScreenshot: async ({ runStabilization }) => {
+                                    await page.reload();
                                     await runStabilization();
                                     if (screenshotOptions?.waitForTOCScrolling !== false) {
                                         await waitForTOCScrolling(page);


### PR DESCRIPTION
Stabilization is hard when we switch from viewports, so we try to
stabilize it by reloading the page before taking the screenshot.
