### PR TITLE
Fix site redirect resolution with length check for source paths

### DIFF
--- a/packages/gitbook/src/components/SitePage/fetch.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.ts
@@ -71,14 +71,17 @@ async function resolvePage(context: GitBookSiteContext, params: PagePathParams |
                 redirectPathname,
             ]);
             for (const source of redirectSources) {
-                const resolvedSiteRedirect = await getDataOrNull(
-                    context.dataFetcher.getSiteRedirectBySource({
-                        organizationId,
-                        siteId: site.id,
-                        source,
-                        siteShareKey: shareKey,
-                    })
-                );
+                // We try to resolve the site redirect
+                const resolvedSiteRedirect =
+                    source.length < 512 &&
+                    (await getDataOrNull(
+                        context.dataFetcher.getSiteRedirectBySource({
+                            organizationId,
+                            siteId: site.id,
+                            source,
+                            siteShareKey: shareKey,
+                        })
+                    ));
                 if (resolvedSiteRedirect) {
                     return redirect(linker.toLinkForContent(resolvedSiteRedirect.target));
                 }


### PR DESCRIPTION
Implement a length check for source paths to ensure proper resolution of site redirects, preventing potential errors with overly long paths.