### PR TITLE
Generalise keyboard shortcuts, add Cmd+J to AI Chat

### DIFF
--- a/.changeset/weak-turtles-laugh.md
+++ b/.changeset/weak-turtles-laugh.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Generalise keyboard shortcuts, add Cmd+J to AI Chat

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -3,6 +3,7 @@
 import { t, tString, useLanguage } from '@/intl/client';
 import { Icon } from '@gitbook/icons';
 import React from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
 import {
     type AIChatController,
     type AIChatState,
@@ -19,19 +20,31 @@ import AIChatSuggestedQuestions from './AIChatSuggestedQuestions';
 
 export function AIChat() {
     const chat = useAIChatState();
+    const chatController = useAIChatController();
+
+    useHotkeys(
+        'mod+j',
+        (e) => {
+            e.preventDefault();
+            chatController.open();
+        },
+        []
+    );
 
     if (!chat.opened) {
         return null;
     }
 
-    return <AIChatWindow chat={chat} />;
+    return <AIChatWindow chatController={chatController} chat={chat} />;
 }
 
-export function AIChatWindow(props: { chat: AIChatState }) {
-    const { chat } = props;
+export function AIChatWindow(props: {
+    chatController: AIChatController;
+    chat: AIChatState;
+}) {
+    const { chatController, chat } = props;
 
     const [input, setInput] = React.useState('');
-    const chatController = useAIChatController();
 
     const containerRef = React.useRef<HTMLDivElement>(null);
     const scrollContainerRef = React.useRef<HTMLDivElement>(null);

--- a/packages/gitbook/src/components/AIChat/AIChatButton.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatButton.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { tString, useLanguage } from '@/intl/client';
+import { t, useLanguage } from '@/intl/client';
 import { useAIChatController, useAIChatState } from '../AI/useAIChat';
 import { Button } from '../primitives';
+import { KeyboardShortcut } from '../primitives/KeyboardShortcut';
 import AIChatIcon from './AIChatIcon';
 
 /**
@@ -20,7 +21,12 @@ export function AIChatButton() {
             size="default"
             variant="secondary"
             className="!px-3 bg-tint-base py-2.5"
-            label={tString(language, 'ai_chat_assistant_name')}
+            label={
+                <div className="flex items-center gap-2">
+                    {t(language, 'ai_chat_assistant_name')}
+                    <KeyboardShortcut keys={['mod', 'j']} className="border-tint-11 text-tint-1" />
+                </div>
+            }
             onClick={() => {
                 if (chat.opened) {
                     chatController.close();

--- a/packages/gitbook/src/components/AIChat/AIChatInput.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatInput.tsx
@@ -2,7 +2,9 @@ import { t, tString, useLanguage } from '@/intl/client';
 import { tcls } from '@/lib/tailwind';
 import { Icon } from '@gitbook/icons';
 import { useEffect, useRef } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
 import { Button } from '../primitives';
+import { KeyboardShortcut } from '../primitives/KeyboardShortcut';
 import { Tooltip } from '../primitives/Tooltip';
 
 export function AIChatInput(props: {
@@ -38,6 +40,15 @@ export function AIChatInput(props: {
         }
     }, [disabled]);
 
+    useHotkeys(
+        'mod+j',
+        (e) => {
+            e.preventDefault();
+            inputRef.current?.focus();
+        },
+        []
+    );
+
     return (
         <div className="relative flex flex-col overflow-hidden circular-corners:rounded-2xl rounded-corners:rounded-md bg-tint-base/9 ring-1 ring-tint-subtle backdrop-blur-lg transition-all depth-subtle:has-[textarea:focus]:shadow-lg has-[textarea:focus]:ring-2 has-[textarea:focus]:ring-primary-hover contrast-more:bg-tint-base">
             <textarea
@@ -54,6 +65,7 @@ export function AIChatInput(props: {
                     'pb-12',
                     'h-auto',
                     'bg-transparent',
+                    'peer',
                     'max-h-64',
                     'placeholder:text-tint/8',
                     'transition-colors',
@@ -76,6 +88,9 @@ export function AIChatInput(props: {
                     }
                 }}
             />
+            <div className="absolute top-2.5 right-4 animate-[fadeIn_0.2s_0.5s_ease-in-out_both] peer-focus:hidden">
+                <KeyboardShortcut keys={['mod', 'j']} />
+            </div>
             <div className="absolute inset-x-0 bottom-0 flex items-center px-2 py-2">
                 <Tooltip
                     label={

--- a/packages/gitbook/src/components/Search/SearchButton.tsx
+++ b/packages/gitbook/src/components/Search/SearchButton.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { Icon } from '@gitbook/icons';
-import { useEffect, useState } from 'react';
 
 import { tString, useLanguage } from '@/intl/client';
 import { type ClassValue, tcls } from '@/lib/tailwind';
 import { useTrackEvent } from '../Insights';
+import { KeyboardShortcut } from '../primitives/KeyboardShortcut';
 import { useSearch } from './useSearch';
 
 /**
@@ -100,45 +100,10 @@ export function SearchButton(props: { children?: React.ReactNode; style?: ClassV
                 className={tcls('text-tint-subtle', 'shrink-0', 'size-4')}
             />
             <div className={tcls('w-full', 'hidden', 'md:block', 'text-left')}>{children}</div>
-            <Shortcut />
+            <KeyboardShortcut
+                keys={['mod', 'k']}
+                className="theme-bold:border-header-link/5 bg-tint-base theme-bold:bg-header-background"
+            />
         </button>
-    );
-}
-
-function Shortcut() {
-    const [operatingSystem, setOperatingSystem] = useState<string | null>(null);
-
-    useEffect(() => {
-        function getOperatingSystem() {
-            const platform = navigator.platform.toLowerCase();
-
-            if (platform.includes('mac')) return 'mac';
-            if (platform.includes('win')) return 'win';
-
-            return 'win';
-        }
-
-        setOperatingSystem(getOperatingSystem());
-    }, []);
-
-    return (
-        <div
-            aria-busy={operatingSystem === null ? 'true' : undefined}
-            className={tcls(
-                `shortcut -mr-1 hidden justify-end gap-0.5 whitespace-nowrap text-tint text-xs [font-feature-settings:"calt",_"case"] contrast-more:text-tint-strong md:flex`,
-                operatingSystem
-                    ? 'motion-safe:animate-fadeIn motion-reduce:opacity-100'
-                    : 'opacity-0'
-            )}
-        >
-            <kbd
-                className={`flex h-5 min-w-5 items-center justify-center rounded border border-tint-subtle theme-bold:border-header-link/5 bg-tint-base theme-bold:bg-header-background px-1 ${operatingSystem === 'mac' ? 'text-sm' : ''}`}
-            >
-                {operatingSystem === 'mac' ? '⌘' : 'Ctrl'}
-            </kbd>
-            <kbd className="flex size-5 items-center justify-center rounded border border-tint-subtle theme-bold:border-header-link/5 bg-tint-base theme-bold:bg-header-background">
-                K
-            </kbd>
-        </div>
     );
 }

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -16,7 +16,7 @@ type ButtonProps = {
     iconOnly?: boolean;
     size?: 'default' | 'medium' | 'small';
     className?: ClassValue;
-    label?: string;
+    label?: string | React.ReactNode;
 } & LinkInsightsProps &
     HTMLAttributes<HTMLElement>;
 
@@ -81,7 +81,7 @@ export function Button({
                 className={domClassName}
                 classNames={['ButtonStyles']}
                 insights={insights}
-                aria-label={label}
+                aria-label={label?.toString()}
                 target={target}
                 {...rest}
             >
@@ -101,7 +101,7 @@ export function Button({
         <button
             type="button"
             className={tcls(buttonOnlyClassNames, domClassName)}
-            aria-label={label}
+            aria-label={label?.toString()}
             {...rest}
         >
             {icon ? (

--- a/packages/gitbook/src/components/primitives/KeyboardShortcut.tsx
+++ b/packages/gitbook/src/components/primitives/KeyboardShortcut.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { type ClassValue, tcls } from '@/lib/tailwind';
+import * as React from 'react';
+
+export function KeyboardShortcut(props: { keys: string[]; className?: ClassValue }) {
+    const { keys, className } = props;
+
+    const [operatingSystem, setOperatingSystem] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        function getOperatingSystem() {
+            const platform = navigator.platform.toLowerCase();
+
+            if (platform.includes('mac')) return 'mac';
+            if (platform.includes('win')) return 'win';
+
+            return 'win';
+        }
+
+        setOperatingSystem(getOperatingSystem());
+    }, []);
+
+    return (
+        <div
+            aria-busy={operatingSystem === null ? 'true' : undefined}
+            className={tcls(
+                `shortcut -mr-1 hidden justify-end gap-0.5 whitespace-nowrap text-tint text-xs [font-feature-settings:"calt",_"case"] contrast-more:text-tint-strong md:flex`,
+                operatingSystem
+                    ? 'motion-safe:animate-fadeIn motion-reduce:opacity-100'
+                    : 'opacity-0'
+            )}
+        >
+            {keys.map((key) => (
+                <kbd
+                    key={key}
+                    className={tcls(
+                        'flex size-5 items-center justify-center rounded-md border border-tint-subtle',
+                        key === 'mod' ? (operatingSystem === 'mac' ? 'text-sm' : '') : 'uppercase',
+                        className
+                    )}
+                >
+                    {key === 'mod' ? (operatingSystem === 'mac' ? '⌘' : 'Ctrl') : key}
+                </kbd>
+            ))}
+        </div>
+    );
+}


### PR DESCRIPTION
- Add a new generic `KeyboardShortcut` component
- Use it in Search and AIChat
- Add hotkey for Cmd/Ctrl+J to open the Assistant and to refocus the chat input (if unfocused).

<img width="263" alt="Screenshot 2025-07-08 at 17 05 22" src="https://github.com/user-attachments/assets/24cd7c62-b5b1-44e9-8f56-8ccb21f80951" />
<img width="374" alt="Screenshot 2025-07-08 at 17 05 20" src="https://github.com/user-attachments/assets/2424bfcd-cb0c-4411-a59e-d2ac06800117" />
