### PR TITLE
Handle markdown errors gracefully

### DIFF
--- a/packages/gitbook/src/routes/markdownPage.ts
+++ b/packages/gitbook/src/routes/markdownPage.ts
@@ -1,5 +1,5 @@
 import type { GitBookSiteContext } from '@/lib/context';
-import { throwIfDataError } from '@/lib/data';
+import { getDataOrNull } from '@/lib/data';
 import { getMarkdownForPage } from '@/lib/markdownPage';
 
 /**
@@ -7,11 +7,29 @@ import { getMarkdownForPage } from '@/lib/markdownPage';
  * Returns a 404 if the page is not found.
  */
 export async function servePageMarkdown(context: GitBookSiteContext, pagePath: string) {
-    const result = await throwIfDataError(getMarkdownForPage(context, pagePath));
+    try {
+        const result = await getDataOrNull(getMarkdownForPage(context, pagePath));
+        if (!result) {
+            return new Response('Page not found', {
+                status: 404,
+                headers: {
+                    'Content-Type': 'text/plain; charset=utf-8',
+                },
+            });
+        }
 
-    return new Response(result, {
-        headers: {
-            'Content-Type': 'text/markdown; charset=utf-8',
-        },
-    });
+        return new Response(result, {
+            headers: {
+                'Content-Type': 'text/markdown; charset=utf-8',
+            },
+        });
+    } catch (error) {
+        console.error('Error serving markdown page:', error);
+        return new Response('Internal Server Error', {
+            status: 500,
+            headers: {
+                'Content-Type': 'text/plain; charset=utf-8',
+            },
+        });
+    }
 }


### PR DESCRIPTION
Avoid throwing an error when serving a markdown page by returning a 404 response for not found pages and a 500 response for internal errors.