### PR TITLE
Add browserslist and improve CSS masks for compatibility

### DIFF
--- a/.changeset/gold-sheep-obey.md
+++ b/.changeset/gold-sheep-obey.md
@@ -1,0 +1,6 @@
+---
+"gitbook": patch
+"@gitbook/icons": patch
+---
+
+add browserlists and fix old browser css-masks

--- a/packages/gitbook/package.json
+++ b/packages/gitbook/package.json
@@ -110,5 +110,8 @@
         "e2e-customers": "playwright test e2e/customers.spec.ts",
         "unit": "bun test {src,packages} --preload ./tests/preload-bun.ts",
         "typecheck": "tsc --noEmit"
-    }
+    },
+    "browserslist": [
+        ">0.3%, chrome >= 64, edge >= 79, firefox >= 67, opera >= 51, safari >= 12 and not dead"
+    ]
 }

--- a/packages/icons/src/Icon.tsx
+++ b/packages/icons/src/Icon.tsx
@@ -58,8 +58,12 @@ export const Icon = React.forwardRef(function Icon(
             {...rest}
             style={{
                 maskImage: `url(${url})`,
+                //@ts-ignore // For compatibility with older browsers
+                '-webkit-mask-image': `url(${url})`,
                 maskRepeat: 'no-repeat',
+                '-webkit-mask-repeat': 'no-repeat',
                 maskPosition: 'center',
+                '-webkit-mask-position': 'center',
                 ...(size ? { width: size, height: size } : {}),
                 ...rest.style,
             }}


### PR DESCRIPTION
Introduce a browserslist configuration to support a wider range of browsers and enhance CSS mask properties for better compatibility with older browsers.

This configuration supports 93.3% of the browser worldwide