### PR TITLE
Ensure schema.security is always an array

### DIFF
--- a/packages/react-openapi/src/resolveOpenAPIOperation.ts
+++ b/packages/react-openapi/src/resolveOpenAPIOperation.ts
@@ -40,11 +40,12 @@ export async function resolveOpenAPIOperation(
     }
 
     const servers = 'servers' in schema ? (schema.servers ?? []) : [];
-    const schemaSecurity = Array.isArray(schema.security ?? [])
+    const schemaSecurity = Array.isArray(schema.security)
         ? schema.security
-        : [schema.security];
-    const security: OpenAPIV3_1.SecurityRequirementObject[] =
-        operation.security ?? schemaSecurity ?? [];
+        : schema.security
+          ? [schema.security]
+          : [];
+    const security: OpenAPIV3_1.SecurityRequirementObject[] = operation.security ?? schemaSecurity;
 
     // If security includes an empty object, it means that the security is optional
     const isOptionalSecurity = security.some((entry) => Object.keys(entry).length === 0);


### PR DESCRIPTION
Modify the handling of schema.security to guarantee it is treated as an array.