### PR TITLE
Fix code block with PowerShell crashing published pages in Safari

### DIFF
--- a/.changeset/wet-wolves-provide.md
+++ b/.changeset/wet-wolves-provide.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix code block with PowerShell crashing page in Safari

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
@@ -34,6 +34,9 @@ export type RenderedInline = {
     body: React.ReactNode;
 };
 
+const isSafari =
+    typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
 const theme = createCssVariablesTheme();
 
 const { getSingletonHighlighter } = createSingletonShorthands(
@@ -65,8 +68,12 @@ export async function highlight(
     inlines: RenderedInline[]
 ): Promise<HighlightLine[]> {
     const langName = getBlockLang(block);
-    if (!langName) {
-        // Language not found, fallback to plain highlighting
+    if (!langName || (isSafari && langName === 'powershell')) {
+        // Fallback to plain highlighting if
+        // - language is not found
+        // - language is `powershell` and browser is Safari:
+        //   PowerShell commands can trigger complex regex that Safari
+        //   JS engine doesn't support, causing the highlighter to crash.
         return plainHighlight(block, inlines);
     }
 


### PR DESCRIPTION
Fallback to plain highlighting on Safari for code blocks using PowerShell language. 

PowerShell commands can trigger complex regex that Safari JS engine doesn't support, causing the highlighter to crash.