### PR TITLE
Make sure to use the correct version for adaptive content

### DIFF
--- a/packages/gitbook/next.config.mjs
+++ b/packages/gitbook/next.config.mjs
@@ -14,6 +14,9 @@ const nextConfig = {
             dynamic: 3600, // 1 hour
             static: 3600, // 1 hour
         },
+
+        // Since content is fully static, we don't want to fetch on hover again
+        optimisticClientCache: false,
     },
 
     env: {

--- a/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
@@ -3,6 +3,7 @@
 import type { CustomizationThemeMode, SiteExternalLinksTarget } from '@gitbook/api';
 import { ThemeProvider } from 'next-themes';
 import type React from 'react';
+import { RouterCacheClearer } from '../hooks/useClearRouterCache';
 import { LinkSettingsContext } from '../primitives';
 
 export function ClientContexts(props: {
@@ -26,6 +27,7 @@ export function ClientContexts(props: {
     return (
         <ThemeProvider nonce={nonce} attribute="class" enableSystem forcedTheme={forcedTheme}>
             <LinkSettingsContext.Provider value={{ externalLinksTarget, adaptiveContentHash }}>
+                <RouterCacheClearer />
                 {children}
             </LinkSettingsContext.Provider>
         </ThemeProvider>

--- a/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
@@ -9,9 +9,10 @@ export function ClientContexts(props: {
     nonce?: string;
     forcedTheme: CustomizationThemeMode | undefined;
     externalLinksTarget: SiteExternalLinksTarget;
+    adaptiveContentHash?: string;
     children: React.ReactNode;
 }) {
-    const { children, forcedTheme, externalLinksTarget } = props;
+    const { children, forcedTheme, externalLinksTarget, adaptiveContentHash } = props;
 
     /**
      * A bug in ThemeProvider is causing the nonce to be included incorrectly
@@ -24,7 +25,7 @@ export function ClientContexts(props: {
 
     return (
         <ThemeProvider nonce={nonce} attribute="class" enableSystem forcedTheme={forcedTheme}>
-            <LinkSettingsContext.Provider value={{ externalLinksTarget }}>
+            <LinkSettingsContext.Provider value={{ externalLinksTarget, adaptiveContentHash }}>
                 {children}
             </LinkSettingsContext.Provider>
         </ThemeProvider>

--- a/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
@@ -4,7 +4,7 @@ import type { CustomizationThemeMode, SiteExternalLinksTarget } from '@gitbook/a
 import { ThemeProvider } from 'next-themes';
 import type React from 'react';
 import { RouterCacheClearer } from '../hooks/useClearRouterCache';
-import { Link, LinkSettingsContext } from '../primitives';
+import { LinkSettingsContext } from '../primitives';
 
 export function ClientContexts(props: {
     nonce?: string;
@@ -24,16 +24,9 @@ export function ClientContexts(props: {
      */
     const nonce = typeof window === 'undefined' || !props.nonce ? props.nonce : '';
 
-    //TODO: Don't forget to remove these Links
     return (
         <ThemeProvider nonce={nonce} attribute="class" enableSystem forcedTheme={forcedTheme}>
             <LinkSettingsContext.Provider value={{ externalLinksTarget, contextId }}>
-                <Link prefetch={false} href="?visitor.isDeveloper=true">
-                    Is dev true
-                </Link>
-                <Link prefetch={false} href="?visitor.isDeveloper=false">
-                    Is dev false
-                </Link>
                 <RouterCacheClearer />
                 {children}
             </LinkSettingsContext.Provider>

--- a/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
@@ -24,11 +24,16 @@ export function ClientContexts(props: {
      */
     const nonce = typeof window === 'undefined' || !props.nonce ? props.nonce : '';
 
+    //TODO: Don't forget to remove these Links
     return (
         <ThemeProvider nonce={nonce} attribute="class" enableSystem forcedTheme={forcedTheme}>
             <LinkSettingsContext.Provider value={{ externalLinksTarget, contextId }}>
-                <Link href="?visitor.isDeveloper=true">Is dev true</Link>
-                <Link href="?visitor.isDeveloper=false">Is dev false</Link>
+                <Link prefetch={false} href="?visitor.isDeveloper=true">
+                    Is dev true
+                </Link>
+                <Link prefetch={false} href="?visitor.isDeveloper=false">
+                    Is dev false
+                </Link>
                 <RouterCacheClearer />
                 {children}
             </LinkSettingsContext.Provider>

--- a/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
@@ -3,17 +3,19 @@
 import type { CustomizationThemeMode, SiteExternalLinksTarget } from '@gitbook/api';
 import { ThemeProvider } from 'next-themes';
 import type React from 'react';
-import { RouterCacheClearer } from '../hooks/useClearRouterCache';
+import { useClearRouterCache } from '../hooks/useClearRouterCache';
 import { LinkSettingsContext } from '../primitives';
 
 export function ClientContexts(props: {
     nonce?: string;
     forcedTheme: CustomizationThemeMode | undefined;
     externalLinksTarget: SiteExternalLinksTarget;
-    contextId?: string;
+    contextId: string | undefined;
     children: React.ReactNode;
 }) {
     const { children, forcedTheme, externalLinksTarget, contextId } = props;
+
+    useClearRouterCache(contextId);
 
     /**
      * A bug in ThemeProvider is causing the nonce to be included incorrectly
@@ -26,8 +28,7 @@ export function ClientContexts(props: {
 
     return (
         <ThemeProvider nonce={nonce} attribute="class" enableSystem forcedTheme={forcedTheme}>
-            <LinkSettingsContext.Provider value={{ externalLinksTarget, contextId }}>
-                <RouterCacheClearer />
+            <LinkSettingsContext.Provider value={{ externalLinksTarget }}>
                 {children}
             </LinkSettingsContext.Provider>
         </ThemeProvider>

--- a/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/ClientContexts.tsx
@@ -4,16 +4,16 @@ import type { CustomizationThemeMode, SiteExternalLinksTarget } from '@gitbook/a
 import { ThemeProvider } from 'next-themes';
 import type React from 'react';
 import { RouterCacheClearer } from '../hooks/useClearRouterCache';
-import { LinkSettingsContext } from '../primitives';
+import { Link, LinkSettingsContext } from '../primitives';
 
 export function ClientContexts(props: {
     nonce?: string;
     forcedTheme: CustomizationThemeMode | undefined;
     externalLinksTarget: SiteExternalLinksTarget;
-    adaptiveContentHash?: string;
+    contextId?: string;
     children: React.ReactNode;
 }) {
-    const { children, forcedTheme, externalLinksTarget, adaptiveContentHash } = props;
+    const { children, forcedTheme, externalLinksTarget, contextId } = props;
 
     /**
      * A bug in ThemeProvider is causing the nonce to be included incorrectly
@@ -26,7 +26,9 @@ export function ClientContexts(props: {
 
     return (
         <ThemeProvider nonce={nonce} attribute="class" enableSystem forcedTheme={forcedTheme}>
-            <LinkSettingsContext.Provider value={{ externalLinksTarget, adaptiveContentHash }}>
+            <LinkSettingsContext.Provider value={{ externalLinksTarget, contextId }}>
+                <Link href="?visitor.isDeveloper=true">Is dev true</Link>
+                <Link href="?visitor.isDeveloper=false">Is dev false</Link>
                 <RouterCacheClearer />
                 {children}
             </LinkSettingsContext.Provider>

--- a/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
+++ b/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
@@ -12,6 +12,7 @@ import { SpaceLayout } from '@/components/SpaceLayout';
 import { buildVersion } from '@/lib/build';
 import { isSiteIndexable } from '@/lib/seo';
 
+import { hash } from 'node:crypto';
 import type { VisitorAuthClaims } from '@/lib/adaptive';
 import { GITBOOK_API_PUBLIC_URL, GITBOOK_ASSETS_URL, GITBOOK_ICONS_URL } from '@/lib/env';
 import { getResizedImageURL } from '@/lib/images';
@@ -46,10 +47,17 @@ export async function SiteLayout(props: {
         });
     });
 
+    // Set the adaptive content hash to the current version of the content.
+    const adaptiveContentHash =
+        Object.keys(visitorAuthClaims).length > 0
+            ? hash('sha256', JSON.stringify(visitorAuthClaims))
+            : undefined;
+
     return (
         <NuqsAdapter>
             <ClientContexts
                 nonce={nonce}
+                adaptiveContentHash={adaptiveContentHash}
                 forcedTheme={
                     forcedTheme ??
                     (customization.themes.toggeable ? undefined : customization.themes.default)

--- a/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
+++ b/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
@@ -9,13 +9,11 @@ import { AdminToolbar } from '@/components/AdminToolbar';
 import { CookiesToast } from '@/components/Cookies';
 import { LoadIntegrations } from '@/components/Integrations';
 import { SpaceLayout } from '@/components/SpaceLayout';
-import { buildVersion } from '@/lib/build';
-import { isSiteIndexable } from '@/lib/seo';
-
-import { hash } from 'node:crypto';
 import type { VisitorAuthClaims } from '@/lib/adaptive';
+import { buildVersion } from '@/lib/build';
 import { GITBOOK_API_PUBLIC_URL, GITBOOK_ASSETS_URL, GITBOOK_ICONS_URL } from '@/lib/env';
 import { getResizedImageURL } from '@/lib/images';
+import { isSiteIndexable } from '@/lib/seo';
 import { ClientContexts } from './ClientContexts';
 import { RocketLoaderDetector } from './RocketLoaderDetector';
 
@@ -47,17 +45,11 @@ export async function SiteLayout(props: {
         });
     });
 
-    // Set the adaptive content hash to the current version of the content.
-    const adaptiveContentHash =
-        Object.keys(visitorAuthClaims).length > 0
-            ? hash('sha256', JSON.stringify(visitorAuthClaims))
-            : undefined;
-
     return (
         <NuqsAdapter>
             <ClientContexts
                 nonce={nonce}
-                adaptiveContentHash={adaptiveContentHash}
+                contextId={context.contextId}
                 forcedTheme={
                     forcedTheme ??
                     (customization.themes.toggeable ? undefined : customization.themes.default)

--- a/packages/gitbook/src/components/hooks/useClearRouterCache.tsx
+++ b/packages/gitbook/src/components/hooks/useClearRouterCache.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { useContext, useEffect } from 'react';
-import { LinkSettingsContext } from '../primitives';
+import { useEffect } from 'react';
 
 // We cannot use a ref here because the contextId gets reset on navigation
 // Probably because of this bug https://github.com/vercel/next.js/issues/67542
@@ -11,8 +10,7 @@ let previousContextId: string | undefined;
  * A custom hook that clears the router cache on contextId change.
  * This is useful for ensuring that the router does not cache stale data for adaptive content.
  */
-export function useClearRouterCache() {
-    const { contextId } = useContext(LinkSettingsContext);
+export function useClearRouterCache(contextId: string | undefined) {
     const router = useRouter();
     useEffect(() => {
         if (previousContextId === undefined) {
@@ -30,8 +28,3 @@ export function useClearRouterCache() {
         }
     }, [contextId, router]);
 }
-
-export const RouterCacheClearer = () => {
-    useClearRouterCache();
-    return null; // This component does not render anything, it just runs the hook
-};

--- a/packages/gitbook/src/components/hooks/useClearRouterCache.tsx
+++ b/packages/gitbook/src/components/hooks/useClearRouterCache.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useRouter } from 'next/navigation';
 import { useContext, useEffect } from 'react';
 import { LinkSettingsContext } from '../primitives';
 
@@ -12,6 +13,7 @@ let previousContextId: string | undefined;
  */
 export function useClearRouterCache() {
     const { contextId } = useContext(LinkSettingsContext);
+    const router = useRouter();
     useEffect(() => {
         if (previousContextId === undefined) {
             // On the first run, we set the previousContextId to the current contextId
@@ -23,9 +25,10 @@ export function useClearRouterCache() {
         // This prevents unnecessary cache clearing on the first render.
         if (contextId !== previousContextId && previousContextId !== undefined) {
             previousContextId = contextId;
-            window.location.reload(); // We want to trigger a full reload to clear the in memory cache
+            // Trigger a full reload to clear the in-memory cache
+            router.refresh(); // This will clear the cache and re-fetch the data
         }
-    }, [contextId]);
+    }, [contextId, router]);
 }
 
 export const RouterCacheClearer = () => {

--- a/packages/gitbook/src/components/hooks/useClearRouterCache.tsx
+++ b/packages/gitbook/src/components/hooks/useClearRouterCache.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useContext, useEffect, useState } from 'react';
+import { LinkSettingsContext } from '../primitives';
+
+/**
+ * A custom hook that clears the router cache on contextId change.
+ * This is useful for ensuring that the router does not cache stale data for adaptive content.
+ */
+export function useClearRouterCache() {
+    const { adaptiveContentHash } = useContext(LinkSettingsContext);
+    const previousAdaptiveContentHash = usePrevious(adaptiveContentHash);
+    const router = useRouter();
+
+    useEffect(() => {
+        if (adaptiveContentHash !== previousAdaptiveContentHash) {
+            router.refresh(); // This will clear the router cache
+        }
+    }, [adaptiveContentHash, previousAdaptiveContentHash, router]);
+}
+
+export function usePrevious<T>(value: T): T | null {
+    const [current, setCurrent] = useState(value);
+    const [previous, setPrevious] = useState<T | null>(null);
+
+    if (value !== current) {
+        setPrevious(current);
+        setCurrent(value);
+    }
+
+    return previous;
+}
+
+export function RouterCacheClearer() {
+    useClearRouterCache();
+    return null; // This component does not render anything, it just runs the hook
+}

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -37,10 +37,6 @@ export type LinkProps = Omit<BaseLinkProps, 'href'> &
  */
 export const LinkSettingsContext = React.createContext<{
     externalLinksTarget: SiteExternalLinksTarget;
-    /**
-     * Context ID used by adaptive content. It is used to clear the router cache.
-     */
-    contextId?: string;
 }>({
     externalLinksTarget: SiteExternalLinksTarget.Self,
 });

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -131,11 +131,15 @@ export const Link = React.forwardRef(function Link(
         ? `${href}${href.includes('?') ? '&' : '?'}ach=${adaptiveContentHash}`
         : href;
 
+    // Not sure why yet, but it seems necessary to force prefetch to true
+    // default behavior doesn't seem to properly use the client router cache.
+    const _prefetch = prefetch === null || prefetch === undefined ? true : prefetch;
+
     return (
         <NextLink
             ref={ref}
             href={newHref}
-            prefetch={prefetch}
+            prefetch={_prefetch}
             className={tcls(...forwardedClassNames, className)}
             {...domProps}
             onClick={onClick}

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -38,9 +38,9 @@ export type LinkProps = Omit<BaseLinkProps, 'href'> &
 export const LinkSettingsContext = React.createContext<{
     externalLinksTarget: SiteExternalLinksTarget;
     /**
-     * Adaptive content hash used to determine the version of the content that should be displayed.
+     * Context ID used by adaptive content. It is used to clear the router cache.
      */
-    adaptiveContentHash?: string;
+    contextId?: string;
 }>({
     externalLinksTarget: SiteExternalLinksTarget.Self,
 });

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -74,7 +74,7 @@ export const Link = React.forwardRef(function Link(
     ref: React.Ref<HTMLAnchorElement>
 ) {
     const { href, prefetch, children, insights, classNames, className, ...domProps } = props;
-    const { externalLinksTarget, adaptiveContentHash } = React.useContext(LinkSettingsContext);
+    const { externalLinksTarget } = React.useContext(LinkSettingsContext);
     const trackEvent = useTrackEvent();
     const forwardedClassNames = useClassnames(classNames || []);
     const isExternal = isExternalLink(href);
@@ -127,10 +127,6 @@ export const Link = React.forwardRef(function Link(
         );
     }
 
-    const newHref = adaptiveContentHash
-        ? `${href}${href.includes('?') ? '&' : '?'}ach=${adaptiveContentHash}`
-        : href;
-
     // Not sure why yet, but it seems necessary to force prefetch to true
     // default behavior doesn't seem to properly use the client router cache.
     const _prefetch = prefetch === null || prefetch === undefined ? true : prefetch;
@@ -138,7 +134,7 @@ export const Link = React.forwardRef(function Link(
     return (
         <NextLink
             ref={ref}
-            href={newHref}
+            href={href}
             prefetch={_prefetch}
             className={tcls(...forwardedClassNames, className)}
             {...domProps}

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -37,6 +37,10 @@ export type LinkProps = Omit<BaseLinkProps, 'href'> &
  */
 export const LinkSettingsContext = React.createContext<{
     externalLinksTarget: SiteExternalLinksTarget;
+    /**
+     * Adaptive content hash used to determine the version of the content that should be displayed.
+     */
+    adaptiveContentHash?: string;
 }>({
     externalLinksTarget: SiteExternalLinksTarget.Self,
 });
@@ -70,7 +74,7 @@ export const Link = React.forwardRef(function Link(
     ref: React.Ref<HTMLAnchorElement>
 ) {
     const { href, prefetch, children, insights, classNames, className, ...domProps } = props;
-    const { externalLinksTarget } = React.useContext(LinkSettingsContext);
+    const { externalLinksTarget, adaptiveContentHash } = React.useContext(LinkSettingsContext);
     const trackEvent = useTrackEvent();
     const forwardedClassNames = useClassnames(classNames || []);
     const isExternal = isExternalLink(href);
@@ -123,10 +127,14 @@ export const Link = React.forwardRef(function Link(
         );
     }
 
+    const newHref = adaptiveContentHash
+        ? `${href}${href.includes('?') ? '&' : '?'}ach=${adaptiveContentHash}`
+        : href;
+
     return (
         <NextLink
             ref={ref}
-            href={href}
+            href={newHref}
             prefetch={prefetch}
             className={tcls(...forwardedClassNames, className)}
             {...domProps}

--- a/packages/gitbook/src/lib/context.ts
+++ b/packages/gitbook/src/lib/context.ts
@@ -44,6 +44,7 @@ export type SiteURLData = Pick<
     | 'siteSection'
     | 'siteBasePath'
     | 'basePath'
+    | 'contextId'
 > & {
     /**
      * Identifier used for image resizing.
@@ -123,6 +124,9 @@ export type GitBookSiteContext = GitBookSpaceContext & {
 
     /** Scripts to load for the site. */
     scripts: SiteIntegrationScript[];
+
+    /** Context ID used by adaptive content. It is used to clear the router cache */
+    contextId?: string;
 };
 
 /**
@@ -200,6 +204,7 @@ export async function fetchSiteContextByURLLookup(
         shareKey: data.shareKey,
         changeRequest: data.changeRequest,
         revision: data.revision,
+        contextId: data.contextId,
     });
 }
 
@@ -217,6 +222,7 @@ export async function fetchSiteContextByIds(
         shareKey: string | undefined;
         changeRequest: string | undefined;
         revision: string | undefined;
+        contextId?: string;
     }
 ): Promise<GitBookSiteContext> {
     const { dataFetcher } = baseContext;
@@ -314,6 +320,7 @@ export async function fetchSiteContextByIds(
         structure: siteStructure,
         sections,
         scripts,
+        contextId: ids.contextId,
     };
 }
 

--- a/packages/gitbook/src/lib/context.ts
+++ b/packages/gitbook/src/lib/context.ts
@@ -125,7 +125,7 @@ export type GitBookSiteContext = GitBookSpaceContext & {
     /** Scripts to load for the site. */
     scripts: SiteIntegrationScript[];
 
-    /** Context ID used by adaptive content. It is used to clear the router cache */
+    /** Context ID used by adaptive content. It represents an unique identifier for the authentication context */
     contextId?: string;
 };
 

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -249,6 +249,7 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
             shareKey: siteURLData.shareKey,
             apiToken: siteURLData.apiToken,
             imagesContextId: imagesContextId,
+            contextId: siteURLData.contextId,
         };
 
         const requestHeaders = new Headers(request.headers);

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -330,6 +330,7 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         response.headers.set('x-gitbook-route-site', siteURLWithoutProtocol);
 
         // When we use adaptive content, we want to ensure that the cache is not used at all on the client side.
+        // Vercel already set this header, this is needed in OpenNext.
         if (siteURLData.contextId) {
             response.headers.set('cache-control', 'public, max-age=0, must-revalidate');
         }

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -328,6 +328,11 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         response.headers.set('x-gitbook-route-type', routeType);
         response.headers.set('x-gitbook-route-site', siteURLWithoutProtocol);
 
+        // When we use adaptive content, we want to ensure that the cache is not used at all on the client side.
+        if (siteURLData.contextId) {
+            response.headers.set('cache-control', 'public, max-age=0, must-revalidate');
+        }
+
         return writeResponseCookies(response, cookies);
     };
 


### PR DESCRIPTION
Use contextId from `PublishedContentSite` to force refresh RSC data based on it.
When the claims change, the whole RSC data would get refreshed.