### PR TITLE
Add nosnippet to announcement banner.

### DIFF
--- a/packages/gitbook/src/components/Announcement/AnnouncementBanner.tsx
+++ b/packages/gitbook/src/components/Announcement/AnnouncementBanner.tsx
@@ -29,7 +29,11 @@ export function AnnouncementBanner(props: {
     const style = BANNER_STYLES[announcement.style];
 
     return (
-        <div id="announcement-banner" className="theme-bold:bg-header-background pt-4 pb-2">
+        <div
+            id="announcement-banner"
+            className="theme-bold:bg-header-background pt-4 pb-2"
+            data-nosnippet=""
+        >
             <div className="scroll-nojump">
                 <div className="transition-all duration-300 lg:chat-open:pr-80 xl:chat-open:pr-96">
                     <div className={tcls('relative', CONTAINER_STYLE)}>


### PR DESCRIPTION
Pages with little content (e.g. index pages) can sometimes have the announcement banner shown in Google snippets. As the announcement banner displays temporary information, we don't want to include it in the snippet.
