### PR TITLE
Fix headings overflowing in hint block

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -46,6 +46,8 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
                     'flex-1',
                     'z-[1]',
                     'justify-self-start',
+                    'max-w-full',
+                    'break-words',
                     getTextAlignment(block.data.align),
                     textStyle.lineHeight
                 )}

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -52,8 +52,11 @@ export function Hint(props: BlockProps<DocumentBlockHint>) {
             {hasHeading ? (
                 <Block
                     style={tcls(
-                        'flip-heading-hash !py-4 items-start px-4 pl-3 text-[1em] *:flex-none',
-                        hasHeading ? hintStyle.header : null
+                        '!py-4 items-start pl-3 text-[1em] *:flex-none',
+                        // Heading hash styles
+                        // [&_.hash]:relative [&_.hash]:right-0
+                        'flip-heading-hash pr-8',
+                        hintStyle.header
                     )}
                     ancestorBlocks={[...ancestorBlocks, block]}
                     {...contextProps}


### PR DESCRIPTION
The `break-words` property was set on the hint content container which works for paragraphs but doesn't work for headings because headings include 2 children: the heading text and their hash link button.