### PR TITLE
Don't throw on >500 API error

### DIFF
--- a/packages/gitbook/src/lib/data/errors.ts
+++ b/packages/gitbook/src/lib/data/errors.ts
@@ -181,9 +181,6 @@ export function extractCacheControl(error: GitBookAPIError) {
  */
 export function getExposableError(error: Error): DataFetcherErrorData {
     if (error instanceof GitBookAPIError) {
-        if (error.code >= 500) {
-            throw error;
-        }
         const cache = extractCacheControl(error);
 
         return {
@@ -194,10 +191,6 @@ export function getExposableError(error: Error): DataFetcherErrorData {
     }
 
     if (error instanceof DataFetcherError) {
-        if (error.code >= 500) {
-            throw error;
-        }
-
         return {
             code: error.code,
             message: error.message,


### PR DESCRIPTION
We were throwing on api error code > 500, this bypassed some check we did for integration failing.
This is not necessary anymore, as we handle those errors properly now