### PR TITLE
Temporarily remove highlighting for PowerShell and C++ in Safari to avoid page crash

### DIFF
--- a/.changeset/four-insects-attack.md
+++ b/.changeset/four-insects-attack.md
@@ -1,5 +1,0 @@
----
-"gitbook": patch
----
-
-Remove highlighting in Safari for PowerShell to avoid page crash until next version with bug fix is released

--- a/.changeset/four-insects-attack.md
+++ b/.changeset/four-insects-attack.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Remove highlighting in Safari for PowerShell to avoid page crash until next version with bug fix is released

--- a/.changeset/sixty-toes-attack.md
+++ b/.changeset/sixty-toes-attack.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Remove highlighting in Safari for PowerShell and C++ to avoid page crash until next version with bug fix is released

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
@@ -34,6 +34,8 @@ export type RenderedInline = {
     body: React.ReactNode;
 };
 
+const isSafari =
+    typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 const theme = createCssVariablesTheme();
 
 const { getSingletonHighlighter } = createSingletonShorthands(
@@ -65,8 +67,12 @@ export async function highlight(
     inlines: RenderedInline[]
 ): Promise<HighlightLine[]> {
     const langName = getBlockLang(block);
-    if (!langName) {
-        // Language not found, fallback to plain highlighting
+    if (!langName || (isSafari && langName === 'powershell')) {
+        // Fallback to plain highlighting if
+        // - language is not found
+        // - TEMP - RND-7772: language is `powershell` and browser is Safari:
+        //   PowerShell commands can trigger complex regex that Safari
+        //   JS engine doesn't support, causing the highlighter to crash.
         return plainHighlight(block, inlines);
     }
 

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
@@ -67,7 +67,7 @@ export async function highlight(
     inlines: RenderedInline[]
 ): Promise<HighlightLine[]> {
     const langName = getBlockLang(block);
-    console.log('CLAIRE langName: ', langName);
+
     if (!langName || (isSafari && ['powershell', 'cpp'].includes(langName))) {
         // Fallback to plain highlighting if
         // - language is not found

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
@@ -71,9 +71,9 @@ export async function highlight(
     if (!langName || (isSafari && ['powershell', 'cpp'].includes(langName))) {
         // Fallback to plain highlighting if
         // - language is not found
-        // - TEMP - RND-7772: language is `powershell` and browser is Safari:
-        //   PowerShell commands can trigger complex regex that Safari
-        //   JS engine doesn't support, causing the highlighter to crash.
+        // - TEMP : language is PowerShell or C++ and browser is Safari:
+        //   RegExp#[Symbol.search] throws TypeError when `lastIndex` isn’t writable
+        //   Fixed in upcoming Safari 18.6, remove when it'll be released - RND-7772
         return plainHighlight(block, inlines);
     }
 

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
@@ -67,7 +67,8 @@ export async function highlight(
     inlines: RenderedInline[]
 ): Promise<HighlightLine[]> {
     const langName = getBlockLang(block);
-    if (!langName || (isSafari && langName === 'powershell')) {
+    console.log('CLAIRE langName: ', langName);
+    if (!langName || (isSafari && ['powershell', 'cpp'].includes(langName))) {
         // Fallback to plain highlighting if
         // - language is not found
         // - TEMP - RND-7772: language is `powershell` and browser is Safari:


### PR DESCRIPTION
Fallback to plain highlighting in Safari for code blocks using PowerShell or C++ language to avoid page crash while waiting for the bug fix to be released in [Safari 18.6](https://developer.apple.com/documentation/safari-release-notes/safari-26-release-notes).