### PR TITLE
Don't track events if a special middleware header is set.

### DIFF
--- a/.changeset/kind-bulldogs-draw.md
+++ b/.changeset/kind-bulldogs-draw.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+All tracking is now disabled for dynamic routes such as the site preview.

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/(content)/layout.tsx
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/(content)/layout.tsx
@@ -5,8 +5,9 @@ import {
     generateSiteLayoutMetadata,
     generateSiteLayoutViewport,
 } from '@/components/SiteLayout';
-import { GITBOOK_DISABLE_TRACKING } from '@/lib/env';
 import { getThemeFromMiddleware } from '@/lib/middleware';
+import { shouldTrackEvents } from '@/lib/tracking';
+import { headers } from 'next/headers';
 
 interface SiteDynamicLayoutProps {
     params: Promise<RouteLayoutParams>;
@@ -18,13 +19,14 @@ export default async function SiteDynamicLayout({
 }: React.PropsWithChildren<SiteDynamicLayoutProps>) {
     const { context, visitorAuthClaims } = await getDynamicSiteContext(await params);
     const forcedTheme = await getThemeFromMiddleware();
+    const withTracking = shouldTrackEvents(await headers());
 
     return (
         <CustomizationRootLayout forcedTheme={forcedTheme} customization={context.customization}>
             <SiteLayout
                 context={context}
                 forcedTheme={forcedTheme}
-                withTracking={!GITBOOK_DISABLE_TRACKING}
+                withTracking={withTracking}
                 visitorAuthClaims={visitorAuthClaims}
             >
                 {children}

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/layout.tsx
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/layout.tsx
@@ -5,7 +5,7 @@ import {
     generateSiteLayoutMetadata,
     generateSiteLayoutViewport,
 } from '@/components/SiteLayout';
-import { GITBOOK_DISABLE_TRACKING } from '@/lib/env';
+import { shouldTrackEvents } from '@/lib/tracking';
 
 interface SiteStaticLayoutProps {
     params: Promise<RouteLayoutParams>;
@@ -16,12 +16,13 @@ export default async function SiteStaticLayout({
     children,
 }: React.PropsWithChildren<SiteStaticLayoutProps>) {
     const { context, visitorAuthClaims } = await getStaticSiteContext(await params);
+    const withTracking = shouldTrackEvents();
 
     return (
         <CustomizationRootLayout customization={context.customization}>
             <SiteLayout
                 context={context}
-                withTracking={!GITBOOK_DISABLE_TRACKING}
+                withTracking={withTracking}
                 visitorAuthClaims={visitorAuthClaims}
             >
                 {children}

--- a/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
+++ b/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
@@ -30,7 +30,9 @@ export async function SiteLayout(props: {
 }) {
     const { context, nonce, forcedTheme, withTracking, visitorAuthClaims, children } = props;
 
-    const { scripts, customization } = context;
+    const { customization } = context;
+    // Scripts are disabled when tracking is disabled
+    const scripts = withTracking ? context.scripts : [];
 
     ReactDOM.preconnect(GITBOOK_API_PUBLIC_URL);
     ReactDOM.preconnect(GITBOOK_ICONS_URL);

--- a/packages/gitbook/src/lib/tracking.ts
+++ b/packages/gitbook/src/lib/tracking.ts
@@ -1,16 +1,21 @@
-import { headers } from 'next/headers';
+import type { headers as nextHeaders } from 'next/headers';
+import { GITBOOK_DISABLE_TRACKING } from './env';
 
 /**
  * Return true if events should be tracked on the site.
+ * Can be called from the static context or the dynamic context.
+ * In the static context, only an env variable is checked.
+ * In the dynamic context, the request headers are checked - this allows the middleware
+ * to disable tracking for preview requests.
  */
-export async function shouldTrackEvents(): Promise<boolean> {
-    const headersList = await headers();
+export function shouldTrackEvents(headers?: Awaited<ReturnType<typeof nextHeaders>>): boolean {
+    if (GITBOOK_DISABLE_TRACKING) {
+        return false;
+    }
 
-    if (
-        process.env.NODE_ENV === 'development' ||
-        (process.env.GITBOOK_BLOCK_PAGE_VIEWS_TRACKING &&
-            !headersList.has('x-gitbook-track-page-views'))
-    ) {
+    const disableTrackingHeader = headers?.get('x-gitbook-disable-tracking');
+
+    if (disableTrackingHeader === 'true') {
         return false;
     }
 

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -143,6 +143,10 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
 
     const withAPIToken = async (
         apiToken: string | null,
+
+        /**
+         * Optionally pass headers that will be included in the response.
+         */
         responseHeaders?: Record<string, string>
     ) => {
         const siteURLData = await throwIfDataError(


### PR DESCRIPTION
In order to prevent inflated values on tracking whilst users view sites through previews, we will disable all tracking for dynamic routes when a specific middleware is set.
