### PR TITLE
Increase timeout for search answer visibility check

### DIFF
--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -186,7 +186,9 @@ const searchTestCases: Test[] = [
         run: async (page) => {
             await expect(page.getByTestId('search-input')).toBeFocused();
             await expect(page.getByTestId('search-input')).toHaveValue('What is GitBook?');
-            await expect(page.getByTestId('search-ask-answer')).toBeVisible();
+            await expect(page.getByTestId('search-ask-answer')).toBeVisible({
+                timeout: 10_000,
+            });
         },
     },
     {


### PR DESCRIPTION
Extend the timeout for the visibility check of the search answer to improve reliability in tests.