### PR TITLE
Fix z-index of search highlight

### DIFF
--- a/.changeset/spicy-baboons-buy.md
+++ b/.changeset/spicy-baboons-buy.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix bug in search highlight in GBO

--- a/packages/gitbook/src/components/Search/HighlightQuery.tsx
+++ b/packages/gitbook/src/components/Search/HighlightQuery.tsx
@@ -15,6 +15,8 @@ export function HighlightQuery(props: {
         query,
         text,
         highlight = [
+            '-z-1',
+            'relative',
             'text-bold',
             'bg-primary',
             'text-contrast-primary',
@@ -33,7 +35,7 @@ export function HighlightQuery(props: {
     const matches = matchString(text, query);
 
     return (
-        <span className={tcls('whitespace-break-spaces')}>
+        <span className={tcls('relative z-2 whitespace-break-spaces')}>
             {matches.map((entry, index) => (
                 <span key={index} className={tcls(entry.match ? highlight : null)}>
                     {entry.text}


### PR DESCRIPTION
# Before
<img width="778" height="288" alt="CleanShot 2025-08-01 at 15 34 10@2x" src="https://github.com/user-attachments/assets/98d51af4-a4f1-4ebe-8d1a-a48e0769bcd1" />

# After
<img width="533" height="115" alt="Screenshot 2025-08-05 at 13 19 14" src="https://github.com/user-attachments/assets/524fcf50-18d7-4669-bf32-5ac85e49f441" />
