### PR TITLE
Use new API to fetch the reusable content document

### DIFF
--- a/packages/gitbook/src/components/DocumentView/ReusableContent.tsx
+++ b/packages/gitbook/src/components/DocumentView/ReusableContent.tsx
@@ -26,18 +26,15 @@ export async function ReusableContent(props: BlockProps<DocumentBlockReusableCon
     }
 
     const { reusableContent } = resolved;
-    if (
-        !reusableContent ||
-        !('document' in reusableContent.revisionReusableContent) ||
-        !reusableContent.revisionReusableContent.document
-    ) {
+    if (!reusableContent) {
         return null;
     }
 
     const document = await getDataOrNull(
-        dataFetcher.getDocument({
+        dataFetcher.getRevisionReusableContentDocument({
             spaceId: reusableContent.context.space.id,
-            documentId: reusableContent.revisionReusableContent.document,
+            revisionId: reusableContent.context.revisionId,
+            reusableContentId: reusableContent.revisionReusableContent.id,
         })
     );
 

--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -92,6 +92,13 @@ export function createDataFetcher(
                 pageId: params.pageId,
             });
         },
+        getRevisionReusableContentDocument(params) {
+            return getRevisionReusableContentDocument(input, {
+                spaceId: params.spaceId,
+                revisionId: params.revisionId,
+                reusableContentId: params.reusableContentId,
+            });
+        },
         getLatestOpenAPISpecVersionContent(params) {
             return getLatestOpenAPISpecVersionContent(input, {
                 organizationId: params.organizationId,
@@ -336,6 +343,39 @@ const getRevisionPageDocument = cache(
                         params.spaceId,
                         params.revisionId,
                         params.pageId,
+                        {
+                            evaluated: true,
+                        },
+                        {
+                            ...noCacheFetchOptions,
+                        }
+                    );
+
+                    cacheTag(...getCacheTagsFromResponse(res));
+                    cacheLifeFromResponse(res, 'max');
+
+                    return res.data;
+                }
+            );
+        });
+    }
+);
+
+const getRevisionReusableContentDocument = cache(
+    async (
+        input: DataFetcherInput,
+        params: { spaceId: string; revisionId: string; reusableContentId: string }
+    ) => {
+        'use cache';
+        return wrapCacheDataFetcherError(async () => {
+            return trace(
+                `getRevisionReusableContentDocument(${params.spaceId}, ${params.revisionId}, ${params.reusableContentId})`,
+                async () => {
+                    const api = apiClient(input);
+                    const res = await api.spaces.getReusableContentDocumentInRevisionById(
+                        params.spaceId,
+                        params.revisionId,
+                        params.reusableContentId,
                         {
                             evaluated: true,
                         },

--- a/packages/gitbook/src/lib/data/types.ts
+++ b/packages/gitbook/src/lib/data/types.ts
@@ -101,6 +101,15 @@ export interface GitBookDataFetcher {
     }): Promise<DataFetcherResponse<api.JSONDocument>>;
 
     /**
+     * Get the document of a reusable content by its space ID and reusable content ID.
+     */
+    getRevisionReusableContentDocument(params: {
+        spaceId: string;
+        revisionId: string;
+        reusableContentId: string;
+    }): Promise<DataFetcherResponse<api.JSONDocument>>;
+
+    /**
      * Get a document by its space ID and document ID.
      */
     getDocument(params: { spaceId: string; documentId: string }): Promise<


### PR DESCRIPTION
This will make sure reusable content works within translated content or can contain dynamic expressions.