### PR TITLE
Optimize cache retrieval performance and reduce costs on 2C

### DIFF
--- a/packages/gitbook/openNext/incrementalCache.ts
+++ b/packages/gitbook/openNext/incrementalCache.ts
@@ -48,7 +48,13 @@ class GitbookIncrementalCache implements IncrementalCache {
                 const result = (await localCacheEntry.json()) as WithLastModified<
                     CacheValue<CacheType>
                 >;
-                return this.returnNullOn404(result);
+                return this.returnNullOn404({
+                    ...result,
+                    // Because we use tag cache and also invalidate them every time,
+                    // if we get a cache hit, we don't need to check the tag cache as we already know it's not been revalidated
+                    // this should improve performance even further, and reduce costs
+                    shouldBypassTagCache: true,
+                });
             }
 
             const r2Object = await r2.get(cacheKey);


### PR DESCRIPTION
Bypassing the tag cache on incremental cache hits improves performance and reduces costs by eliminating unnecessary checks when a cache hit occurs.

This one will need to be tested on staging before a deployment.
Also needs some testing on preview to ensure it won't break our e2e test