### PR TITLE
Clear AI chat stream properly

### DIFF
--- a/.changeset/soft-bikes-warn.md
+++ b/.changeset/soft-bikes-warn.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Clear AI chat properly

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -187,6 +187,8 @@ export function useAIChatController(): AIChatController {
                 for await (const data of stream) {
                     if (!data) continue;
 
+                    if (globalState.getState().state.query !== input.message) break; // Chat was cleared, stop processing the stream
+
                     const event = data.event;
 
                     switch (event.type) {


### PR DESCRIPTION
When an AI response was streaming, it would always continue even if the chat was cleared. Now it checks while streaming if the original query is still set, otherwise it stops.