### PR TITLE
Always show placeholder while generating

### DIFF
--- a/packages/gitbook/src/components/AIChat/AIChatMessages.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatMessages.tsx
@@ -44,7 +44,7 @@ export function AIChatMessages(props: {
                         {message.content ? message.content : null}
 
                         {isLastMessage && chat.loading ? (
-                            <div className="flex w-full animate-fade-in-slow flex-wrap gap-2 group-has-[.has-content]/message:hidden">
+                            <div className="flex w-full animate-fade-in-slow flex-wrap gap-2">
                                 {Array.from({ length: 7 }).map((_, index) => (
                                     <div
                                         key={index}


### PR DESCRIPTION
Previously, as soon as the AI was done calling tools it would start generating a response so we could remove the placeholder. Now it does tool preambles so it immediately outputs text which would hide the placeholder. So instead we only hide the placeholder once text generation has finished.