### PR TITLE
Support "objectivec" as alias for Objective C syntax

### DIFF
--- a/.changeset/chatty-rivers-move.md
+++ b/.changeset/chatty-rivers-move.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Support "objectivec" as alias for Objective C syntax

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/highlight.ts
@@ -136,6 +136,9 @@ const syntaxAliases: Record<string, BundledLanguage> = {
     // "Parser" language does not exist in Shiki, but it's used in GitBook
     // The closest language is "Blade"
     parser: 'blade',
+
+    // From GitBook App we receive "objectivec" instead of "objective-c"
+    objectivec: 'objective-c',
 };
 
 function checkIsBundledLanguage(lang: string): lang is BundledLanguage {


### PR DESCRIPTION
The block model from GitBook uses "objectivec" instead of "objective-c",
so we support it.
