### PR TITLE
Remove motion animations from ScrollSectionList

### DIFF
--- a/packages/gitbook/src/components/PageAside/AsideSectionHighlight.tsx
+++ b/packages/gitbook/src/components/PageAside/AsideSectionHighlight.tsx
@@ -1,47 +1,41 @@
 'use client';
 
-import { type Transition, motion, useReducedMotion } from 'framer-motion';
-
 import { type ClassValue, tcls } from '@/lib/tailwind';
+import React from 'react';
 
-export function AsideSectionHighlight({
-    transition,
-    className,
-}: {
-    transition?: Transition;
-    className?: ClassValue;
-}) {
-    const prefersReducedMotion = useReducedMotion();
+export const AsideSectionHighlight = React.memo(
+    ({
+        className,
+    }: {
+        className?: ClassValue;
+    }) => {
+        return (
+            <div
+                className={tcls([
+                    'border-primary-9',
+                    'tint:border-primary-11',
+                    'sidebar-list-line:border-l-2',
 
-    return (
-        <motion.div
-            layout
-            layoutId="sections-line"
-            className={tcls([
-                'border-primary-9',
-                'tint:border-primary-11',
-                'sidebar-list-line:border-l-2',
+                    'inset-0',
+                    'pointer-events-none',
+                    'absolute',
+                    'z-0',
+                    'sidebar-list-line:-left-px',
 
-                'inset-0',
-                'pointer-events-none',
-                'absolute',
-                'z-0',
-                'sidebar-list-line:-left-px',
+                    'rounded-md',
+                    'straight-corners:rounded-none',
+                    'circular-corners:rounded-2xl',
+                    'sidebar-list-line:rounded-l-none',
 
-                'rounded-md',
-                'straight-corners:rounded-none',
-                'circular-corners:rounded-2xl',
-                'sidebar-list-line:rounded-l-none',
+                    'sidebar-list-pill:bg-primary',
+                    '[html.theme-muted.sidebar-list-pill_&]:bg-primary-hover',
+                    '[html.theme-gradient.sidebar-list-pill_&]:bg-primary-active',
 
-                'sidebar-list-pill:bg-primary',
-                '[html.theme-muted.sidebar-list-pill_&]:bg-primary-hover',
-                '[html.theme-gradient.sidebar-list-pill_&]:bg-primary-active',
-
-                'contrast-more:border',
-                'contrast-more:bg-primary',
-                className,
-            ])}
-            transition={prefersReducedMotion ? { duration: 0 } : transition}
-        />
-    );
-}
+                    'contrast-more:border',
+                    'contrast-more:bg-primary',
+                    className,
+                ])}
+            />
+        );
+    }
+);

--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { motion } from 'framer-motion';
 import React from 'react';
 
 import { useScrollActiveId } from '@/components/hooks';
@@ -14,13 +13,6 @@ import { AsideSectionHighlight } from './AsideSectionHighlight';
  * The threshold at which we consider a section as intersecting the viewport.
  */
 const SECTION_INTERSECTING_THRESHOLD = 0.9;
-
-const springCurve = {
-    type: 'spring',
-    stiffness: 700,
-    damping: 50,
-    mass: 0.8,
-};
 
 export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
     const { sections } = props;
@@ -42,7 +34,7 @@ export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
     return (
         <ul className="flex flex-col border-tint-subtle sidebar-list-line:border-l">
             {sections.map((section) => (
-                <motion.li
+                <li
                     key={section.id}
                     className={tcls(
                         'flex',
@@ -55,9 +47,8 @@ export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
                         section.depth > 1 && ['ml-3', 'my-0', 'sidebar-list-line:ml-0']
                     )}
                 >
-                    {activeId === section.id ? (
+                    {activeId === section.id && (
                         <AsideSectionHighlight
-                            transition={springCurve}
                             className={tcls(
                                 'sidebar-list-default:hidden',
                                 section?.depth > 1
@@ -71,7 +62,7 @@ export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
                                       ]
                             )}
                         />
-                    ) : null}
+                    )}
                     <a
                         href={`#${section.id}`}
                         className={tcls(
@@ -148,7 +139,7 @@ export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
                             {section.title}
                         </span>
                     </a>
-                </motion.li>
+                </li>
             ))}
         </ul>
     );


### PR DESCRIPTION
motion animations on ScrollSectionList can block the main thread by performing too much calculations. 
It happens when you scroll too fast on a page with a lot of headings close to each other, making it rerender ScrollSectionList too often.