### PR TITLE
Fixes to search modal

### DIFF
--- a/.changeset/few-bobcats-bake.md
+++ b/.changeset/few-bobcats-bake.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Small fixes to search modal

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -170,7 +170,7 @@ export function SearchContainer(props: SearchContainerProps) {
                 rootProps={{
                     open: state?.open ?? false,
                     onOpenChange: (open) => {
-                        open === true ? onOpen() : onClose();
+                        open ? onOpen() : onClose();
                     },
                     modal: isMobile,
                 }}

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -150,7 +150,7 @@ export function SearchContainer(props: SearchContainerProps) {
             <Popover
                 content={
                     // Only show content if there's a query or Ask is enabled
-                    state?.query || withSearchAI ? (
+                    state?.query || withAI ? (
                         <React.Suspense fallback={null}>
                             {isMultiVariants && !showAsk ? (
                                 <SearchScopeToggle spaceTitle={spaceTitle} />
@@ -170,7 +170,7 @@ export function SearchContainer(props: SearchContainerProps) {
                 rootProps={{
                     open: state?.open ?? false,
                     onOpenChange: (open) => {
-                        setSearchState((prev) => (prev ? { ...prev, open } : null));
+                        open === true ? onOpen() : onClose();
                     },
                     modal: isMobile,
                 }}


### PR DESCRIPTION
Two small fixes after inspecting staging:
1. Recommended questions did not show up properly when an AI Assistant was defined
2. The `onClose` did not properly fire when closing the modal, causing `?q=` to remain in the URL.