### PR TITLE
Fix pageaside height on pages with hero cover

### DIFF
--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -78,8 +78,8 @@ export function PageAside(props: {
                 'lg:site-header-sections:max-h-[calc(100vh-6.75rem)]',
 
                 // Client-side dynamic positioning (CSS vars applied by script)
-                'lg:[html[style*="--toc-top-offset"]_&]:top-(--toc-top-offset)!',
-                'lg:[html[style*="--toc-height"]_&]:max-h-(--toc-height)!',
+                'lg:[html[style*="--outline-top-offset"]_&]:top-(--outline-top-offset)!',
+                'lg:[html[style*="--outline-height"]_&]:max-h-(--outline-height)!',
 
                 // When in api page mode, we display it as an overlay on non-large resolutions
                 'xl:max-2xl:page-api-block:z-10',

--- a/packages/gitbook/src/components/PageBody/PageCover.tsx
+++ b/packages/gitbook/src/components/PageBody/PageCover.tsx
@@ -76,6 +76,8 @@ export async function PageCover(props: {
 
     return (
         <div
+            id="page-cover"
+            data-full={as === 'full' ? 'true' : 'false'}
             className={tcls(
                 'overflow-hidden',
                 // Negative margin to balance the container padding

--- a/packages/gitbook/src/components/PageBody/PageCover.tsx
+++ b/packages/gitbook/src/components/PageBody/PageCover.tsx
@@ -77,7 +77,7 @@ export async function PageCover(props: {
     return (
         <div
             id="page-cover"
-            data-full={as === 'full' ? 'true' : 'false'}
+            data-full={String(as === 'full')}
             className={tcls(
                 'overflow-hidden',
                 // Negative margin to balance the container padding

--- a/packages/gitbook/src/components/TableOfContents/TableOfContentsScript.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContentsScript.tsx
@@ -15,6 +15,7 @@ export function TableOfContentsScript() {
             const header = document.getElementById('site-header');
             const banner = document.getElementById('announcement-banner');
             const footer = document.getElementById('site-footer');
+            const pageCover = document.getElementById('page-cover');
 
             // Set sticky top position based on header
             const headerHeight = header?.offsetHeight ?? 0;
@@ -43,6 +44,28 @@ export function TableOfContentsScript() {
             // Update height
             root.style.setProperty('--toc-height', `${height}px`);
             root.style.setProperty('--toc-top-offset', `${offset}px`);
+
+            // Subtract visible pageCover (if any)
+            if (
+                pageCover &&
+                pageCover.dataset.full === 'true' &&
+                window.getComputedStyle(pageCover).display !== 'none'
+            ) {
+                const coverRect = pageCover.getBoundingClientRect();
+                if (coverRect.height > 0 && coverRect.bottom > 0) {
+                    height -= Math.min(
+                        coverRect.height,
+                        Math.max(coverRect.bottom - headerHeight, 0)
+                    );
+                    offset += Math.min(
+                        coverRect.height,
+                        Math.max(coverRect.bottom - headerHeight, 0)
+                    );
+                }
+            }
+
+            root.style.setProperty('--outline-height', `${height}px`);
+            root.style.setProperty('--outline-top-offset', `${offset}px`);
         };
 
         // Initial update


### PR DESCRIPTION
This PR adds a check on the page cover to the TOC's height calculation script, which the pageaside also uses, to make sure the aside does not stretch beyond the screen when the page cover is present.

### Before

<img width="458" height="929" alt="Screenshot 2025-08-21 at 10 25 39" src="https://github.com/user-attachments/assets/35f1baa5-de0f-4c4d-8ddb-4d15435e65bc" />

### After

<img width="458" height="929" alt="Screenshot 2025-08-21 at 10 26 01" src="https://github.com/user-attachments/assets/74cf8833-4849-422e-bb33-e11148e56aa5" />
