### PR TITLE
Custom assistants followup

### DIFF
--- a/.changeset/weak-kiwis-type.md
+++ b/.changeset/weak-kiwis-type.md
@@ -1,0 +1,6 @@
+---
+"@gitbook/browser-types": patch
+"gitbook": patch
+---
+
+Custom assistants followup

--- a/packages/browser-types/src/index.ts
+++ b/packages/browser-types/src/index.ts
@@ -71,7 +71,7 @@ export type GitBookGlobal = {
     /**
      * Register a custom assistant to be available on the site.
      */
-    registerAssistant: (assistant: GitBookAssistant) => () => void;
+    registerAssistant: (assistant: GitBookAssistant) => { close: () => void; dispose: () => void };
 };
 
 declare global {

--- a/packages/gitbook/src/components/AI/useAI.tsx
+++ b/packages/gitbook/src/components/AI/useAI.tsx
@@ -35,6 +35,16 @@ export type Assistant = Omit<GitBookAssistant, 'icon'> & {
     mode?: 'overlay' | 'sidebar' | 'search';
 
     /**
+     * Configuration for the in-page action to open the assistant.
+     * The button is only rendered if `ui` and `pageAction` are both set.
+     * Currently not available for custom assistants.
+     */
+    pageAction?: {
+        description: string;
+        open: (query?: string) => void;
+    };
+
+    /**
      * Icon of the assistant displayed in the UI.
      */
     icon: ReactNode;
@@ -89,6 +99,19 @@ export function useAI(): AIContext {
                 if (query) {
                     chatController.postMessage({ message: query });
                 }
+            },
+            pageAction: {
+                description: tString(
+                    language,
+                    'ai_chat_ask_about_page',
+                    getAIChatName(language, config.trademark)
+                ),
+                open: (query?: string) => {
+                    chatController.open();
+                    if (query) {
+                        chatController.postMessage({ message: query });
+                    }
+                },
             },
             ui: true,
             mode: 'sidebar',

--- a/packages/gitbook/src/components/AIActions/AIActions.tsx
+++ b/packages/gitbook/src/components/AIActions/AIActions.tsx
@@ -31,7 +31,7 @@ export function OpenAIAssistant(props: { assistant: Assistant; type: AIActionTyp
             icon={assistant.icon}
             label={assistant.label}
             shortLabel={tString(language, 'ask')}
-            description={tString(language, 'ai_chat_ask_about_page', assistant.label)}
+            description={assistant.pageAction?.description}
             disabled={chat.loading}
             onClick={() => {
                 assistant.open(tString(language, 'ai_chat_suggested_questions_about_this_page'));

--- a/packages/gitbook/src/components/AIActions/AIActionsDropdown.tsx
+++ b/packages/gitbook/src/components/AIActions/AIActionsDropdown.tsx
@@ -25,7 +25,9 @@ interface AIActionsDropdownProps {
  */
 export function AIActionsDropdown(props: AIActionsDropdownProps) {
     const ref = useRef<HTMLDivElement>(null);
-    const assistants = useAI().assistants.filter((assistant) => assistant.ui === true);
+    const assistants = useAI().assistants.filter(
+        (assistant) => assistant.ui === true && assistant.pageAction
+    );
     const language = useLanguage();
 
     return assistants.length > 0 || props.actions.markdown || props.actions.externalAI ? (
@@ -63,7 +65,9 @@ export function AIActionsDropdown(props: AIActionsDropdownProps) {
  */
 function AIActionsDropdownMenuContent(props: AIActionsDropdownProps) {
     const { markdownPageUrl, actions } = props;
-    const assistants = useAI().assistants.filter((assistant) => assistant.ui === true);
+    const assistants = useAI().assistants.filter(
+        (assistant) => assistant.ui === true && assistant.pageAction
+    );
 
     return (
         <>
@@ -103,7 +107,9 @@ function AIActionsDropdownMenuContent(props: AIActionsDropdownProps) {
  */
 function DefaultAction(props: AIActionsDropdownProps) {
     const { markdownPageUrl, actions } = props;
-    const assistants = useAI().assistants.filter((assistant) => assistant.ui === true);
+    const assistants = useAI().assistants.filter(
+        (assistant) => assistant.ui === true && assistant.pageAction
+    );
 
     if (assistants.length) {
         return <OpenAIAssistant assistant={assistants[0]} type="button" />;

--- a/packages/gitbook/src/components/Integrations/LoadIntegrations.tsx
+++ b/packages/gitbook/src/components/Integrations/LoadIntegrations.tsx
@@ -50,14 +50,41 @@ if (typeof window !== 'undefined') {
             integrationAssistants.setState(
                 (state) => [
                     ...state,
-                    { ...assistant, id, ui: assistant.ui ?? true, mode: 'overlay' },
+                    {
+                        ...assistant,
+                        id,
+                        ui: assistant.ui ?? true,
+                        mode: 'overlay',
+                        pageAction: undefined,
+                    },
                 ],
                 true
             );
 
-            return () => {
+            const close = () => {
+                // We don't have access to the search state here, so we need to
+                // manually remove the `ask` query parameter from the URL.
+                try {
+                    const url = new URL(window.location.href);
+                    if (url.searchParams.has('ask')) {
+                        url.searchParams.delete('ask');
+                        window.history.replaceState(
+                            {},
+                            '',
+                            `${url.pathname}${url.search}${url.hash}`
+                        );
+                        window.dispatchEvent(new PopStateEvent('popstate'));
+                    }
+                } catch (error) {
+                    console.error('Failed to remove `ask` query parameter from URL.', error);
+                }
+            };
+
+            const dispose = () => {
                 integrationAssistants.setState((state) => state.filter((a) => a.id !== id), true);
             };
+
+            return { close, dispose };
         },
     };
     window.GitBook = gitbookGlobal;


### PR DESCRIPTION
- Add `.close()` and `.dispose()` methods on assistant registration
- Clean up `?ask=` URL query param on `.close()`.
- Add `pageAction` attributes to internal Assistant object, dictating if and how the page action displays. Only enabled for the GitBook Assistant.