### PR TITLE
Fix: Long strings overflow out of message bubble in docs assistant

### DIFF
--- a/.changeset/serious-keys-explain.md
+++ b/.changeset/serious-keys-explain.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix: Long strings overflow out of message bubble in docs assistant

--- a/packages/gitbook/src/components/AI/server-actions/AIToolCallsSummary.tsx
+++ b/packages/gitbook/src/components/AI/server-actions/AIToolCallsSummary.tsx
@@ -167,7 +167,7 @@ async function DescriptionForSearchToolCall(props: {
                     hasResults ? '-my-2 cursor-pointer py-2 hover:bg-primary-hover' : ''
                 )}
             >
-                <div className="flex flex-col leading-snug">
+                <div className="flex min-w-0 flex-col break-words leading-snug">
                     <p>{t(language, 'searched_for', <strong>{toolCall.query}</strong>)}</p>
                     <p className="mt-0.5 text-tint-subtle text-xs">
                         {hasResults

--- a/packages/gitbook/src/components/AIChat/AIChatMessages.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatMessages.tsx
@@ -32,6 +32,7 @@ export function AIChatMessages(props: {
                             'scroll-mt-36',
                             'lg:scroll-mt-0',
                             'flex flex-col gap-6',
+                            'break-words',
                             'group/message',
                             message.role === AIMessageRole.User
                                 ? 'max-w-[80%] self-end circular-corners:rounded-2xl rounded-corners:rounded-md bg-tint px-4 py-2'


### PR DESCRIPTION
<img width="394" height="389" alt="Screenshot 2025-08-22 at 17 29 38" src="https://github.com/user-attachments/assets/0b78548a-e6c6-4e9b-9d31-736ab05b21bd" />
