### PR TITLE
Fix Search results are not clickable

### DIFF
--- a/.changeset/slimy-pumpkins-type.md
+++ b/.changeset/slimy-pumpkins-type.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix Search results are not clickable on sites without header

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -122,7 +122,7 @@ export function Header(props: {
                                     isMultiVariants={siteSpaces.length > 1}
                                     spaceTitle={siteSpace.title}
                                     siteSpaceId={siteSpace.id}
-                                    visibility={!withTopHeader ? 'mobile' : undefined}
+                                    viewport={!withTopHeader ? 'mobile' : undefined}
                                 />
                             </div>
 

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import type { GitBookSiteContext } from '@/lib/context';
 import { CONTAINER_STYLE, HEADER_HEIGHT_DESKTOP } from '@/components/layout';
 import { getSpaceLanguage, t } from '@/intl/server';
 import { tcls } from '@/lib/tailwind';
+import { SearchContainer } from '../Search';
 import { SiteSectionTabs, encodeClientSiteSections } from '../SiteSections';
 import { HeaderLink } from './HeaderLink';
 import { HeaderLinkMore } from './HeaderLinkMore';
@@ -17,9 +18,8 @@ import { SpacesDropdown } from './SpacesDropdown';
 export function Header(props: {
     context: GitBookSiteContext;
     withTopHeader?: boolean;
-    search?: React.ReactNode;
 }) {
-    const { context, withTopHeader, search } = props;
+    const { context, withTopHeader } = props;
     const { siteSpace, siteSpaces, sections, customization } = context;
 
     return (
@@ -117,7 +117,13 @@ export function Header(props: {
                                         : ['order-last']
                                 )}
                             >
-                                {search}
+                                <SearchContainer
+                                    style={customization.styling.search}
+                                    isMultiVariants={siteSpaces.length > 1}
+                                    spaceTitle={siteSpace.title}
+                                    siteSpaceId={siteSpace.id}
+                                    visibility={!withTopHeader ? 'mobile' : undefined}
+                                />
                             </div>
 
                             {customization.header.links.length > 0 && (

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -23,14 +23,14 @@ interface SearchContainerProps {
     isMultiVariants: boolean;
     style: CustomizationSearchStyle;
     className?: string;
-    visibility?: 'desktop' | 'mobile';
+    viewport?: 'desktop' | 'mobile';
 }
 
 /**
  * Client component to render the search input and results.
  */
 export function SearchContainer(props: SearchContainerProps) {
-    const { siteSpaceId, spaceTitle, isMultiVariants, style, className, visibility } = props;
+    const { siteSpaceId, spaceTitle, isMultiVariants, style, className, viewport } = props;
 
     const { assistants } = useAI();
 
@@ -146,11 +146,7 @@ export function SearchContainer(props: SearchContainerProps) {
 
     const showAsk = withSearchAI && normalizedAsk; // withSearchAI && normalizedAsk;
 
-    const visible = React.useMemo(() => {
-        if (visibility === 'desktop') return !isMobile; // only show on desktop
-        if (visibility === 'mobile') return isMobile; // only show on mobile
-        return true; // default to visible
-    }, [visibility, isMobile]);
+    const visible = viewport === 'desktop' ? !isMobile : viewport === 'mobile' ? isMobile : true;
 
     return (
         <SearchAskProvider value={searchAsk}>

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -23,13 +23,14 @@ interface SearchContainerProps {
     isMultiVariants: boolean;
     style: CustomizationSearchStyle;
     className?: string;
+    visibility?: 'desktop' | 'mobile';
 }
 
 /**
  * Client component to render the search input and results.
  */
 export function SearchContainer(props: SearchContainerProps) {
-    const { siteSpaceId, spaceTitle, isMultiVariants, style, className } = props;
+    const { siteSpaceId, spaceTitle, isMultiVariants, style, className, visibility } = props;
 
     const { assistants } = useAI();
 
@@ -145,6 +146,12 @@ export function SearchContainer(props: SearchContainerProps) {
 
     const showAsk = withSearchAI && normalizedAsk; // withSearchAI && normalizedAsk;
 
+    const visible = React.useMemo(() => {
+        if (visibility === 'desktop') return !isMobile; // only show on desktop
+        if (visibility === 'mobile') return isMobile; // only show on mobile
+        return true; // default to visible
+    }, [visibility, isMobile]);
+
     return (
         <SearchAskProvider value={searchAsk}>
             <Popover
@@ -168,7 +175,7 @@ export function SearchContainer(props: SearchContainerProps) {
                     ) : null
                 }
                 rootProps={{
-                    open: state?.open ?? false,
+                    open: visible && (state?.open ?? false),
                     onOpenChange: (open) => {
                         open ? onOpen() : onClose();
                     },

--- a/packages/gitbook/src/components/Search/SearchInput.tsx
+++ b/packages/gitbook/src/components/Search/SearchInput.tsx
@@ -46,7 +46,7 @@ export const SearchInput = React.forwardRef<HTMLDivElement, SearchInputProps>(
         }, [isOpen, value]);
 
         return (
-            <div className="relative flex size-9 grow">
+            <div className={tcls('relative flex size-9 grow', className)}>
                 {/* biome-ignore lint/a11y/useKeyWithClickEvents: this div needs an onClick to show the input on mobile, where it's normally hidden.
                 Normally you'd also need to add a keyboard trigger to do the same without a pointer, but in this case the input already be focused on its own. */}
                 <div
@@ -62,8 +62,7 @@ export const SearchInput = React.forwardRef<HTMLDivElement, SearchInputProps>(
                         'theme-bold:border-header-link/3 has-[input:focus-visible]:theme-bold:border-header-link/5 has-[input:focus-visible]:theme-bold:bg-header-link/3 has-[input:focus-visible]:theme-bold:ring-header-link/5',
                         'theme-bold:before:absolute theme-bold:before:inset-0 theme-bold:before:bg-header-background/7 theme-bold:before:backdrop-blur-xl ', // Special overlay to make the transparent colors of theme-bold visible.
                         'relative z-30 shrink grow justify-start max-md:absolute max-md:right-0',
-                        isOpen ? 'max-md:w-56' : 'max-md:w-[38px]',
-                        className
+                        isOpen ? 'max-md:w-56' : 'max-md:w-[38px]'
                     )}
                 >
                     {value && isOpen ? (

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -124,7 +124,7 @@ export function SpaceLayout(props: {
                                                     isMultiVariants={siteSpaces.length > 1}
                                                     spaceTitle={siteSpace.title}
                                                     siteSpaceId={siteSpace.id}
-                                                    className="my-4 max-lg:hidden"
+                                                    className="max-lg:hidden"
                                                     visibility="desktop"
                                                 />
                                             )}

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -4,7 +4,7 @@ import {
     CustomizationHeaderPreset,
     CustomizationSearchStyle,
 } from '@gitbook/api';
-import React from 'react';
+import type React from 'react';
 
 import { Footer } from '@/components/Footer';
 import { Header, HeaderLogo } from '@/components/Header';
@@ -52,23 +52,6 @@ export function SpaceLayout(props: {
         customization.footer.logo ||
         customization.footer.groups?.length;
 
-    const search = (
-        <div className="flex grow items-center gap-2">
-            <React.Suspense fallback={null}>
-                <SearchContainer
-                    style={
-                        customization.header.preset === CustomizationHeaderPreset.None
-                            ? CustomizationSearchStyle.Subtle
-                            : customization.styling.search
-                    }
-                    isMultiVariants={siteSpaces.length > 1}
-                    spaceTitle={siteSpace.title}
-                    siteSpaceId={siteSpace.id}
-                />
-            </React.Suspense>
-        </div>
-    );
-
     const eventUrl = new URL(
         context.linker.toAbsoluteURL(context.linker.toPathInSite('/~gitbook/__evt'))
     );
@@ -94,7 +77,7 @@ export function SpaceLayout(props: {
                     visitorCookieTrackingEnabled={customization.insights?.trackingCookie}
                 >
                     <Announcement context={context} />
-                    <Header withTopHeader={withTopHeader} context={context} search={search} />
+                    <Header withTopHeader={withTopHeader} context={context} />
                     {customization.ai?.mode === CustomizationAIMode.Assistant ? (
                         <AIChat trademark={customization.trademark.enabled} />
                     ) : null}
@@ -121,7 +104,7 @@ export function SpaceLayout(props: {
                                                 className={tcls(
                                                     'hidden',
                                                     'pr-4',
-                                                    'md:flex',
+                                                    'lg:flex',
                                                     'grow-0',
                                                     'flex-wrap',
                                                     'dark:shadow-light/1',
@@ -135,7 +118,16 @@ export function SpaceLayout(props: {
                                     innerHeader={
                                         // displays the search button and/or the space dropdown in the ToC according to the header/variant settings. E.g if there is no header, the search button will be displayed in the ToC.
                                         <>
-                                            {!withTopHeader && search}
+                                            {!withTopHeader && (
+                                                <SearchContainer
+                                                    style={CustomizationSearchStyle.Subtle}
+                                                    isMultiVariants={siteSpaces.length > 1}
+                                                    spaceTitle={siteSpace.title}
+                                                    siteSpaceId={siteSpace.id}
+                                                    className="my-4 max-lg:hidden"
+                                                    visibility="desktop"
+                                                />
+                                            )}
                                             {!withTopHeader && withSections && sections && (
                                                 <SiteSectionList
                                                     className={tcls('hidden', 'lg:block')}

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -125,7 +125,7 @@ export function SpaceLayout(props: {
                                                     spaceTitle={siteSpace.title}
                                                     siteSpaceId={siteSpace.id}
                                                     className="max-lg:hidden"
-                                                    visibility="desktop"
+                                                    viewport="desktop"
                                                 />
                                             )}
                                             {!withTopHeader && withSections && sections && (

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -96,7 +96,7 @@ export async function TableOfContents(props: {
                         'page-has-toc:[html.sidebar-filled.circular-corners_&]:rounded-3xl'
                     )}
                 >
-                    {innerHeader && <div className="flex px-5">{innerHeader}</div>}
+                    {innerHeader && <div className="flex px-5 *:my-4">{innerHeader}</div>}
                     <TOCScrollContainer // The scrollview inside the sidebar
                         className={tcls(
                             'flex grow flex-col p-2',

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -96,7 +96,7 @@ export async function TableOfContents(props: {
                         'page-has-toc:[html.sidebar-filled.circular-corners_&]:rounded-3xl'
                     )}
                 >
-                    {innerHeader && <div className="px-5 *:my-4">{innerHeader}</div>}
+                    {innerHeader && <div className="flex grow px-5">{innerHeader}</div>}
                     <TOCScrollContainer // The scrollview inside the sidebar
                         className={tcls(
                             'flex grow flex-col p-2',

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -96,7 +96,7 @@ export async function TableOfContents(props: {
                         'page-has-toc:[html.sidebar-filled.circular-corners_&]:rounded-3xl'
                     )}
                 >
-                    {innerHeader && <div className="flex grow px-5">{innerHeader}</div>}
+                    {innerHeader && <div className="flex px-5">{innerHeader}</div>}
                     <TOCScrollContainer // The scrollview inside the sidebar
                         className={tcls(
                             'flex grow flex-col p-2',

--- a/packages/gitbook/src/components/hooks/useIsMobile.tsx
+++ b/packages/gitbook/src/components/hooks/useIsMobile.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-export function useIsMobile(breakpoint = 640): boolean {
+export function useIsMobile(breakpoint = 1024): boolean {
     const [isMobile, setIsMobile] = React.useState(false);
 
     React.useEffect(() => {


### PR DESCRIPTION
The root cause for this was that we instantiated two search popovers on sites without a header, since these sites still have a mobile header with its own search popover in addition to the sidebar search popover.

Add a `viewport` check to only render the popover when appropriate.

Also cleans up the mobile sidebar to not repeat the logo & search button unncessarily.