### PR TITLE
Fix content min-height with sections

### DIFF
--- a/.changeset/popular-pots-move.md
+++ b/.changeset/popular-pots-move.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix content min-height with sections

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -109,7 +109,10 @@ export function SpaceLayout(props: {
                                     'site-width-wide:max-w-full',
 
                                     // Ensure the footer is display below the viewport even if the content is not enough
-                                    withFooter && 'min-h-[calc(100vh-64px)]',
+                                    withFooter && [
+                                        'site-header:min-h-[calc(100vh-64px)]',
+                                        'site-header-sections:min-h-[calc(100vh-108px)]',
+                                    ],
                                     withTopHeader ? null : 'lg:min-h-screen'
                                 )}
                             >


### PR DESCRIPTION
Previously we always set the content to have a `min-height` of `calc(100vh-64px)` to subtract the header. With sections the header can be larger, so we need to subtract more.