### PR TITLE
Fix custom assistant keyboard shortcut

### DIFF
--- a/.changeset/nasty-drinks-smell.md
+++ b/.changeset/nasty-drinks-smell.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix custom assistant keyboard shortcut

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -47,17 +47,6 @@ export function AIChat(props: { trademark: boolean }) {
     }, [chat.opened]);
 
     useHotkeys(
-        'mod+i',
-        (e) => {
-            e.preventDefault();
-            chatController.open();
-        },
-        {
-            enableOnFormTags: true,
-        }
-    );
-
-    useHotkeys(
         'esc',
         () => {
             chatController.close();

--- a/packages/gitbook/src/components/AIChat/AIChatButton.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatButton.tsx
@@ -12,8 +12,9 @@ import { KeyboardShortcut } from '../primitives/KeyboardShortcut';
 export function AIChatButton(props: {
     assistant: Assistant;
     showLabel?: boolean;
+    withShortcut?: boolean;
 }) {
-    const { assistant, showLabel = true } = props;
+    const { assistant, showLabel = true, withShortcut = true } = props;
     const language = useLanguage();
 
     return (
@@ -27,7 +28,12 @@ export function AIChatButton(props: {
             label={
                 <div className="flex items-center gap-2">
                     {t(language, 'ai_chat_ask', assistant.label)}
-                    <KeyboardShortcut keys={['mod', 'i']} className="border-tint-11 text-tint-1" />
+                    {withShortcut ? (
+                        <KeyboardShortcut
+                            keys={['mod', 'i']}
+                            className="border-tint-11 text-tint-1"
+                        />
+                    ) : null}
                 </div>
             }
             onClick={() => assistant.open()}

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -88,6 +88,19 @@ export function SearchContainer(props: SearchContainerProps) {
         }
     );
 
+    useHotkeys(
+        'mod+i',
+        (e) => {
+            e.preventDefault();
+            if (assistants) {
+                assistants[0]?.open();
+            }
+        },
+        {
+            enableOnFormTags: true,
+        }
+    );
+
     const onOpen = React.useCallback(() => {
         if (state?.open) {
             return;
@@ -211,10 +224,11 @@ export function SearchContainer(props: SearchContainerProps) {
             </Popover>
             {assistants
                 .filter((assistant) => assistant.ui === true)
-                .map((assistant) => (
+                .map((assistant, index) => (
                     <AIChatButton
                         key={assistant.id}
                         assistant={assistant}
+                        withShortcut={index === 0}
                         showLabel={
                             assistants.filter((assistant) => assistant.ui === true).length === 1 &&
                             style === CustomizationSearchStyle.Prominent


### PR DESCRIPTION
Previously, we advertised the `Mod+I` keyboard combo to open the assistant. This works for the GitBook Assistant but wasn't configured correctly for custom assistants.

- Move the listener to `SearchContainer` and have it open the first assistant in the list
- Only show shortcut on the first assistant's button label.