### PR TITLE
Fix corner radius of active section on "Line" sidebar style

### DIFF
--- a/.changeset/chilled-files-unite.md
+++ b/.changeset/chilled-files-unite.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix corner radius of active section on "Line" sidebar style

--- a/packages/gitbook/src/components/PageAside/AsideSectionHighlight.tsx
+++ b/packages/gitbook/src/components/PageAside/AsideSectionHighlight.tsx
@@ -25,7 +25,7 @@ export const AsideSectionHighlight = React.memo(
                     'rounded-md',
                     'straight-corners:rounded-none',
                     'circular-corners:rounded-2xl',
-                    'sidebar-list-line:rounded-l-none',
+                    'sidebar-list-line:rounded-l-none!',
 
                     'sidebar-list-pill:bg-primary',
                     '[html.theme-muted.sidebar-list-pill_&]:bg-primary-hover',

--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -101,7 +101,7 @@ export function ScrollSectionsList(props: { sections: DocumentSection[] }) {
                             'rounded-md',
                             'straight-corners:rounded-none',
                             'circular-corners:rounded-2xl',
-                            'sidebar-list-line:rounded-l-none',
+                            'sidebar-list-line:rounded-l-none!',
 
                             'hover:bg-tint-hover',
                             'theme-gradient:hover:bg-tint-12/1',


### PR DESCRIPTION
Before

<img width="418" height="456" alt="Screenshot 2025-08-27 at 10 10 53" src="https://github.com/user-attachments/assets/fe2496ca-8c17-4ae8-8bd7-80ccd504a85e" />

After

<img width="418" height="456" alt="Screenshot 2025-08-27 at 10 11 07" src="https://github.com/user-attachments/assets/5b2385f1-0eec-409e-828d-a6eb553380f4" />
