### PR TITLE
Catch OpenAPI validation errors

### DIFF
--- a/.changeset/happy-vans-work.md
+++ b/.changeset/happy-vans-work.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/openapi-parser': patch
+---
+
+Catch OpenAPI validation errors

--- a/packages/openapi-parser/src/v3.ts
+++ b/packages/openapi-parser/src/v3.ts
@@ -10,7 +10,14 @@ import type { ParseOpenAPIInput, ParseOpenAPIResult } from './parse';
  */
 export async function parseOpenAPIV3(input: ParseOpenAPIInput): Promise<ParseOpenAPIResult> {
     const { value, rootURL, options = {} } = input;
-    const result = await validate(value);
+
+    const result = await validate(value).catch((error) => {
+        throw new OpenAPIParseError('Invalid OpenAPI document', {
+            code: 'invalid',
+            rootURL,
+            cause: error,
+        });
+    });
 
     // If there is no version, we consider it invalid instantely.
     if (!result.version) {


### PR DESCRIPTION
This pull request improves error handling in the OpenAPI parser by ensuring validation errors are properly caught and reported. The main change is to wrap the OpenAPI validation step in a try-catch block, so that any errors are thrown as a custom `OpenAPIParseError` with relevant details.