### PR TITLE
OpenAPI: Make empty responses clickable

### DIFF
--- a/.changeset/fuzzy-ravens-fetch.md
+++ b/.changeset/fuzzy-ravens-fetch.md
@@ -1,0 +1,6 @@
+---
+"@gitbook/react-openapi": patch
+"gitbook": patch
+---
+
+OpenAPI: Make responses without objects clickable

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -746,6 +746,10 @@ body:has(.openapi-select-popover) {
     @apply px-3 transition-all;
 }
 
+.openapi-disclosure-group-trigger[aria-expanded="true"] > .openapi-disclosure-group-label {
+    @apply font-medium;
+}
+
 .openapi-disclosure-group-trigger[aria-expanded="true"] > .openapi-disclosure-group-icon > svg {
     @apply rotate-90;
 }

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -565,7 +565,7 @@
 }
 
 .openapi-example-empty {
-    @apply relative text-tint bg-tint min-h-20 flex flex-col justify-center items-center;
+    @apply relative text-tint min-h-20 flex flex-col justify-center items-center text-sm;
 }
 
 /* Common Elements */

--- a/packages/react-openapi/src/OpenAPIResponses.tsx
+++ b/packages/react-openapi/src/OpenAPIResponses.tsx
@@ -50,6 +50,20 @@ export function OpenAPIResponses(props: {
                     ];
                 }
 
+                if (!response.content) {
+                    return [
+                        {
+                            key: 'default',
+                            label: '',
+                            body: (
+                                <pre className="openapi-example-empty">
+                                    <p>{t(context.translation, 'no_content')}</p>
+                                </pre>
+                            ),
+                        },
+                    ];
+                }
+
                 return Object.entries(response.content ?? {}).map(([contentType, mediaType]) => ({
                     key: contentType,
                     label: contentType,


### PR DESCRIPTION
Previously empty (status code only) responses could not be clicked to expand. This was good behaviour, but prevented users from seeing the entire response code description. The only way to see the response description was to choose it from the examples on the right.

<img width="1113" height="503" alt="Screenshot 2025-08-27 at 15 10 04" src="https://github.com/user-attachments/assets/85163d5d-9b42-4a2d-a3f5-39e8e09d38b2" />

Now, each item is expandable, but if a response is empty it uses the same "no content" display that we use in the response example on the right.

<img width="1106" height="607" alt="Screenshot 2025-08-27 at 15 21 32" src="https://github.com/user-attachments/assets/ebe6fd52-9c9c-4675-9f9e-c3a3081d32e3" />


Also made the active response `font-medium` so it stands out slightly more when open.
