### PR TITLE
Fix error on parameters being an object instead of an array

### DIFF
--- a/packages/react-openapi/src/OpenAPICodeSample.tsx
+++ b/packages/react-openapi/src/OpenAPICodeSample.tsx
@@ -66,7 +66,11 @@ function generateCodeSamples(props: {
     const searchParams = new URLSearchParams();
     const headersObject: { [k: string]: string } = {};
 
-    data.operation.parameters?.forEach((param) => {
+    // The parser can sometimes returns invalid parameters (an object instead of an array).
+    // It should get fixed in scalar, but in the meantime we just ignore the parameters in that case.
+    const params = Array.isArray(data.operation.parameters) ? data.operation.parameters : [];
+
+    params.forEach((param) => {
         if (!param) {
             return;
         }

--- a/packages/react-openapi/src/OpenAPISpec.tsx
+++ b/packages/react-openapi/src/OpenAPISpec.tsx
@@ -117,19 +117,22 @@ function getParameterGroupName(paramIn: string, context: OpenAPIClientContext): 
 /** Deduplicate parameters by name and in.
  * Some specs have both parameters define at path and operation level.
  * We only want to display one of them.
+ * Parameters can have the wrong type (object instead of array) sometimes, we just return an empty array in that case.
  */
 function deduplicateParameters(parameters: OpenAPI.Parameters): OpenAPI.Parameters {
     const seen = new Set();
 
-    return parameters.filter((param) => {
-        const key = `${param.name}:${param.in}`;
+    return Array.isArray(parameters)
+        ? parameters.filter((param) => {
+              const key = `${param.name}:${param.in}`;
 
-        if (seen.has(key)) {
-            return false;
-        }
+              if (seen.has(key)) {
+                  return false;
+              }
 
-        seen.add(key);
+              seen.add(key);
 
-        return true;
-    });
+              return true;
+          })
+        : [];
 }


### PR DESCRIPTION
Fix an error for OpenAPI where `operation.parameters` is incorrectly provided by the validate function from scalar.
Parameters are supposed to be an Array, but for some invalid schema, it will be an object causing the rendering to crash.