### PR TITLE
Handle non-defined objectFit on card cover images

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -40,8 +40,8 @@ export async function RecordCard(
     const darkCoverIsSquareOrPortrait = isSquareOrPortrait(darkCover);
     const lightCoverIsSquareOrPortrait = isSquareOrPortrait(lightCover);
 
-    const darkObjectFit = dark.objectFit ? `dark:${getObjectFitClass(dark.objectFit)}` : '';
-    const lightObjectFit = light.objectFit ? getObjectFitClass(light.objectFit) : '';
+    const darkObjectFit = `dark:${getObjectFitClass(dark.objectFit)}`;
+    const lightObjectFit = getObjectFitClass(light.objectFit);
     const objectFits = `${lightObjectFit} ${darkObjectFit}`;
 
     const body = (
@@ -204,7 +204,11 @@ function isSquareOrPortrait(contentRef: ResolvedContentRef | null) {
 /**
  * Get the CSS class for object-fit based on the objectFit value.
  */
-function getObjectFitClass(objectFit: CardsImageObjectFit): string {
+function getObjectFitClass(objectFit: CardsImageObjectFit | undefined): string {
+    if (!objectFit) {
+        return 'object-cover';
+    }
+
     switch (objectFit) {
         case CardsImageObjectFit.Contain:
             return 'object-contain';


### PR DESCRIPTION
We added support for setting objectFit on card covers. But if those were never defined yet, the current logic fell short in that we wouldnt handle a default value. This PR ensures that if no object-fit was set, we default to 'cover' which we always had before.

Before:
<img width="3022" height="1644" alt="CleanShot 2025-09-05 at 10 22 06@2x" src="https://github.com/user-attachments/assets/32b88183-6c40-4dda-92d7-5c79f633a57a" />

After:
<img width="3024" height="1646" alt="CleanShot 2025-09-05 at 10 22 48@2x" src="https://github.com/user-attachments/assets/924bfc02-c7b4-451b-9df7-84a9534173cb" />


~closes https://linear.app/gitbook-x/issue/RND-8043/inconsistent-card-image-rendering-on-published-site
