### PR TITLE
Language selector fixes

### DIFF
--- a/.changeset/serious-actors-sing.md
+++ b/.changeset/serious-actors-sing.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Language selector edge cases

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -80,13 +80,14 @@ export function Header(props: {
                         >
                             <HeaderMobileMenu
                                 className={tcls(
-                                    'lg:hidden',
                                     '-ml-2',
                                     'text-tint-strong',
                                     'theme-bold:text-header-link',
                                     'hover:bg-tint-hover',
                                     'hover:theme-bold:bg-header-link/3',
-                                    withVariants === 'generic' ? '' : 'page-no-toc:hidden'
+                                    withVariants === 'generic'
+                                        ? 'xl:hidden'
+                                        : 'page-no-toc:hidden lg:hidden'
                                 )}
                             />
                             <HeaderLogo context={context} />

--- a/packages/gitbook/src/components/Integrations/LoadIntegrations.tsx
+++ b/packages/gitbook/src/components/Integrations/LoadIntegrations.tsx
@@ -67,6 +67,7 @@ if (typeof window !== 'undefined') {
         },
     };
     window.GitBook = gitbookGlobal;
+        name: 'send_email',
 }
 
 /**

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -20,7 +20,7 @@ import type { RenderAIMessageOptions } from '../AI';
 import { AIChat } from '../AIChat';
 import { AdaptiveVisitorContextProvider } from '../Adaptive';
 import { Announcement } from '../Announcement';
-import { SpacesDropdown } from '../Header/SpacesDropdown';
+import { SpacesDropdown, TranslationsDropdown } from '../Header/SpacesDropdown';
 import { InsightsProvider } from '../Insights';
 import { SearchContainer } from '../Search';
 import { SiteSectionList, encodeClientSiteSections } from '../SiteSections';
@@ -156,12 +156,20 @@ export function SpaceLayout(props: SpaceLayoutProps) {
                                         'pr-4',
                                         'lg:flex',
                                         'grow-0',
-                                        'flex-wrap',
                                         'dark:shadow-light/1',
-                                        'text-base/tight'
+                                        'text-base/tight',
+                                        'items-center'
                                     )}
                                 >
                                     <HeaderLogo context={context} />
+                                    {!withTopHeader && (
+                                        <TranslationsDropdown
+                                            context={context}
+                                            siteSpace={siteSpace}
+                                            siteSpaces={siteSpaces}
+                                            className="[&_.button-leading-icon]:block! ml-auto py-2 [&_.button-content]:hidden"
+                                        />
+                                    )}
                                 </div>
                             )
                         }


### PR DESCRIPTION
1. Fix unreachable language selector on `no-toc` pages on `lg`-`xl` screen sizes by enabling the mobile in those cases
2. Add a language dropdown to the sidebar-only layout, next to the site logo.

<img width="844" height="860" alt="CleanShot 2025-09-08 at 16 38 27@2x" src="https://github.com/user-attachments/assets/bdfa5bbf-ab60-4eec-9a92-9b2c5d434bae" />
