### PR TITLE
Don't show toolbar when rendering within GitBook app preview

### DIFF
--- a/packages/gitbook/src/components/AdminToolbar/AdminToolbar.tsx
+++ b/packages/gitbook/src/components/AdminToolbar/AdminToolbar.tsx
@@ -2,9 +2,9 @@ import type { GitBookSiteContext } from '@/lib/context';
 import { Icon } from '@gitbook/icons';
 import React from 'react';
 
-import { isPreviewRequest } from '@/lib/preview';
 import { tcls } from '@/lib/tailwind';
 import { DateRelative } from '../primitives';
+import { IframeWrapper } from './IframeWrapper';
 import { RefreshChangeRequestButton } from './RefreshChangeRequestButton';
 import { Toolbar, ToolbarBody, ToolbarButton, ToolbarButtonGroups } from './Toolbar';
 
@@ -47,23 +47,20 @@ function ToolbarLayout(props: { children: React.ReactNode }) {
 export async function AdminToolbar(props: AdminToolbarProps) {
     const { context } = props;
 
-    // Get the current URL from the linker (which accounts for both static and dynamic routes)
-    const currentURL = new URL(context.linker.toAbsoluteURL('/'));
-
-    // Check if this url is opened within the GitBook app's in-editor preview tab.
-    const isInAppPreview = isPreviewRequest(currentURL);
-
-    // Don't show admin toolbar for preview requests
-    if (isInAppPreview) {
-        return null;
-    }
-
     if (context.changeRequest) {
-        return <ChangeRequestToolbar context={context} />;
+        return (
+            <IframeWrapper>
+                <ChangeRequestToolbar context={context} />
+            </IframeWrapper>
+        );
     }
 
     if (context.revisionId !== context.space.revision) {
-        return <RevisionToolbar context={context} />;
+        return (
+            <IframeWrapper>
+                <RevisionToolbar context={context} />
+            </IframeWrapper>
+        );
     }
 
     return null;

--- a/packages/gitbook/src/components/AdminToolbar/IframeWrapper.tsx
+++ b/packages/gitbook/src/components/AdminToolbar/IframeWrapper.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+
+interface IframeWrapperProps {
+    children: React.ReactNode;
+}
+
+/**
+ * Client component that detects if we're in an iframe and conditionally renders children
+ */
+export function IframeWrapper({ children }: IframeWrapperProps) {
+    const [isInIframe, setIsInIframe] = React.useState(false);
+
+    React.useEffect(() => {
+        // Check if we're running inside an iframe
+        const inIframe = window !== window.parent;
+        setIsInIframe(inIframe);
+    }, []);
+
+    // Don't render children if we're in an iframe (GitBook app preview)
+    if (isInIframe) {
+        return null;
+    }
+
+    return children;
+}

--- a/packages/gitbook/src/components/AdminToolbar/index.ts
+++ b/packages/gitbook/src/components/AdminToolbar/index.ts
@@ -1,1 +1,2 @@
 export * from './AdminToolbar';
+export * from './IframeWrapper';


### PR DESCRIPTION
When a preview link for a change-request or revision is opened, we show a toolbar with helpful info and actions. However, we don't want to show this toolbar if the site is rendered in an iframe in the GitBook web-app editor, under the preview tab.

This behaviour likely broke when the 'multi-id' functionality became obsolete with the move to gbo v2.
- this pr removes that old logic
- and replaces it with a new check using the existing `isPreviewRequest` util

## Examples
Toolbar no longer shows when previewing in-app:
<img width="3016" height="1642" alt="CleanShot 2025-09-09 at 11 28 24@2x" src="https://github.com/user-attachments/assets/dc7dd5a7-6077-462d-9350-f69041017bc7" />

Toolbar still shows when visiting a change-request or revision preview link:
<img width="3022" height="1352" alt="CleanShot 2025-09-09 at 11 32 20@2x" src="https://github.com/user-attachments/assets/e3567ed2-7673-4258-9aa7-97b410338101" />


