### PR TITLE
Stop using deprecated search API param

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -300,7 +300,7 @@
     "react-dom": "^19.0.0",
   },
   "catalog": {
-    "@gitbook/api": "^0.139.0",
+    "@gitbook/api": "^0.140.0",
     "bidc": "^0.0.2",
   },
   "packages": {
@@ -666,7 +666,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@6.6.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "6.6.0" } }, "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg=="],
 
-    "@gitbook/api": ["@gitbook/api@0.139.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-6VqN4BVvOdaRng2xz5wh0gj6NJmJJZwtswKZ6g9RMWedp2UkeMXi+kcO3fBo2VYJsxhIgbtWikqGEePgHTx67g=="],
+    "@gitbook/api": ["@gitbook/api@0.140.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-DBBUwdJOueA8aY/90KLwXJpLeKoX7hGu+PEqERpefiW2kZoFPKEVcmXARDk4txxEjvPgS3EylPSZaxFTi8R+Jg=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "workspaces": {
         "packages": ["packages/*"],
         "catalog": {
-            "@gitbook/api": "^0.139.0",
+            "@gitbook/api": "^0.140.0",
             "bidc": "^0.0.2"
         }
     },

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -123,8 +123,7 @@ export async function streamAskQuestion({
                     },
                     scope: {
                         mode: 'default',
-                        // Include the current site space regardless.
-                        includedSiteSpaces: [context.siteSpace.id],
+                        currentSiteSpace: context.siteSpace.id,
                     },
                 },
                 { format: 'document' }


### PR DESCRIPTION
Uses the new `currentSiteSpace` param instead of the deprecated `includedSiteSpaces` param for search scope.

Once GBO stops using the deprecated param, we'll check the logs to see whether there are any other consumers that use it, and if not, we'll be able to completely get rid of it.