### PR TITLE
Fix section group dropdown offset on big screens

### DIFF
--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -128,7 +128,7 @@ export function SiteSectionTabs(props: {
             {children}
 
             <div
-                className="absolute top-full left-0 z-20 flex w-full"
+                className="fixed top-full left-0 z-20 flex w-full"
                 style={{
                     padding: `0 ${SCREEN_OFFSET}px 0 ${SCREEN_OFFSET}px`,
                 }}


### PR DESCRIPTION
I introduced a layout bug in #3655, this fixes it.

We calculate the trigger's position on the screen and set the dropdown menu to be below that. But because of `position: absolute` it'll be constrained to the nearest `relative` parent, which is the site's container. This is not an issue when the viewport is smaller than the max container width, but introduces offset from the trigger on bigger displays.

<img width="4236" height="678" alt="CleanShot 2025-09-17 at 18 03 34@2x" src="https://github.com/user-attachments/assets/9914dd41-7820-484f-81f8-ac638e1730c5" />

Setting the position to `fixed` solves this.

<img width="4236" height="678" alt="CleanShot 2025-09-17 at 18 03 20@2x" src="https://github.com/user-attachments/assets/7f249705-5712-459f-a397-d65929b3cb24" />
