### PR TITLE
Support site section groups

### DIFF
--- a/.changeset/fluffy-clouds-tap.md
+++ b/.changeset/fluffy-clouds-tap.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Support nested site section groups

--- a/bun.lock
+++ b/bun.lock
@@ -303,7 +303,7 @@
     "react-dom": "^19.0.0",
   },
   "catalog": {
-    "@gitbook/api": "^0.141.0",
+    "@gitbook/api": "^0.142.0",
     "bidc": "^0.0.2",
   },
   "packages": {
@@ -675,7 +675,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@6.6.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "6.6.0" } }, "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg=="],
 
-    "@gitbook/api": ["@gitbook/api@0.141.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-KViAAUUStITbNGqDydUjZhxGdG4lJrS3ll8eQI5Tvs0j+Wvb4x1lxGvnm/LgtrhW+FoEgrFuRKZWVga1bI1Qmg=="],
+    "@gitbook/api": ["@gitbook/api@0.142.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-Lq1IbepAykHNG8y0fBvC7hQj3i/f1XATX58wLYXWCL3W1x6Z9f6Rs5K2qCOONswJh3l2NrX3ujrbxx3D8goRdw=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "workspaces": {
         "packages": ["packages/*"],
         "catalog": {
-            "@gitbook/api": "^0.141.0",
+            "@gitbook/api": "^0.142.0",
             "bidc": "^0.0.2"
         }
     },

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -1,4 +1,5 @@
 import {
+    CustomizationHeaderPreset,
     CustomizationIconsStyle,
     CustomizationSidebarBackgroundStyle,
     CustomizationSidebarListStyle,
@@ -79,6 +80,8 @@ export async function CustomizationRootLayout(props: {
               type: 'default' as const,
               variable: fonts.IBMPlexMono.variable,
           };
+
+    customization.header.preset = CustomizationHeaderPreset.None;
 
     // Preconnect and preload custom fonts if needed
     preloadFont(fontData);

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -1,5 +1,4 @@
 import {
-    CustomizationHeaderPreset,
     CustomizationIconsStyle,
     CustomizationSidebarBackgroundStyle,
     CustomizationSidebarListStyle,
@@ -80,8 +79,6 @@ export async function CustomizationRootLayout(props: {
               type: 'default' as const,
               variable: fonts.IBMPlexMono.variable,
           };
-
-    customization.header.preset = CustomizationHeaderPreset.None;
 
     // Preconnect and preload custom fonts if needed
     preloadFont(fontData);

--- a/packages/gitbook/src/components/SiteSections/SiteSectionList.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionList.tsx
@@ -226,7 +226,6 @@ export function SiteSectionGroupItem(props: {
                                     section={child}
                                     isActive={child.id === currentSection.id}
                                     key={child.id}
-                                    // className="pl-5"
                                 />
                             );
                         }

--- a/packages/gitbook/src/components/SiteSections/SiteSectionList.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionList.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import React from 'react';
 
 import { type ClassValue, tcls } from '@/lib/tailwind';
+import { findSectionInGroup } from '@/lib/utils';
 import { useToggleAnimation } from '../hooks';
 import { Link } from '../primitives';
 import { ScrollContainer } from '../primitives/ScrollContainer';
@@ -260,25 +261,4 @@ function Descendants(props: {
             {children}
         </motion.div>
     );
-}
-
-/**
- * Recursively find a section by ID within a group and its nested children
- */
-function findSectionInGroup(
-    group: ClientSiteSectionGroup,
-    sectionId: string
-): ClientSiteSection | null {
-    for (const child of group.children) {
-        if (child.object === 'site-section' && child.id === sectionId) {
-            return child;
-        }
-        if (child.object === 'site-section-group') {
-            const found = findSectionInGroup(child, sectionId);
-            if (found) {
-                return found;
-            }
-        }
-    }
-    return null;
 }

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -321,7 +321,7 @@ function SectionGroupTile(props: {
                     gridTemplateColumns: `repeat(${Math.ceil(children.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, 1fr))`,
                 }}
             >
-                {children.map((nestedChild: ClientSiteSection | ClientSiteSectionGroup) => (
+                {children.map((nestedChild) => (
                     <SectionGroupTile
                         key={nestedChild.id}
                         child={nestedChild}

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -308,14 +308,19 @@ function SectionGroupTile(props: {
     const { title, icon, children } = child;
 
     return (
-        <li className="flex w-full shrink grow flex-col gap-1 md:w-68">
+        <li className="flex w-full shrink grow flex-col gap-1">
             <div className="mt-3 mb-2 flex gap-2.5 px-3 font-semibold text-tint-subtle text-xs uppercase tracking-wider">
                 {icon && (
                     <SectionIcon className="mt-0.5" isActive={false} icon={icon as IconName} />
                 )}
                 {title}
             </div>
-            <ul className="contents">
+            <ul
+                className="flex grid-flow-row flex-col gap-x-2 gap-y-1 md:grid"
+                style={{
+                    gridTemplateColumns: `repeat(${Math.ceil(children.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, 1fr))`,
+                }}
+            >
                 {children.map((nestedChild: ClientSiteSection | ClientSiteSectionGroup) => (
                     <SectionGroupTile
                         key={nestedChild.id}

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 import { Button, DropdownChevron, Link } from '@/components/primitives';
 import { tcls } from '@/lib/tailwind';
+import { findSectionInGroup } from '@/lib/utils';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { CONTAINER_STYLE } from '../layout';
 import { ScrollContainer } from '../primitives/ScrollContainer';
@@ -331,25 +332,4 @@ function SectionGroupTile(props: {
             </ul>
         </li>
     );
-}
-
-/**
- * Recursively find a section by ID within a group and its nested children
- */
-function findSectionInGroup(
-    group: ClientSiteSectionGroup,
-    sectionId: string
-): ClientSiteSection | null {
-    for (const child of group.children) {
-        if (child.object === 'site-section' && child.id === sectionId) {
-            return child;
-        }
-        if (child.object === 'site-section-group') {
-            const found = findSectionInGroup(child, sectionId);
-            if (found) {
-                return found;
-            }
-        }
-    }
-    return null;
 }

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -1,23 +1,7 @@
 import type { GitBookSiteContext } from '@/lib/context';
 import type { SiteSection, SiteSectionGroup, SiteSpace, SiteStructure } from '@gitbook/api';
 import { joinPath } from './paths';
-
-/**
- * Recursively flatten all sections from nested groups
- */
-function flattenSectionsFromGroup(children: (SiteSection | SiteSectionGroup)[]): SiteSection[] {
-    const sections: SiteSection[] = [];
-
-    for (const child of children) {
-        if (child.object === 'site-section') {
-            sections.push(child);
-        } else if (child.object === 'site-section-group') {
-            sections.push(...flattenSectionsFromGroup(child.children));
-        }
-    }
-
-    return sections;
-}
+import { flattenSectionsFromGroup } from './utils';
 
 /**
  * Get all sections from a site structure.
@@ -40,7 +24,7 @@ export function getSiteStructureSections(
         ? ignoreGroups
             ? siteStructure.structure.flatMap((item) =>
                   item.object === 'site-section-group'
-                      ? flattenSectionsFromGroup(item.children)
+                      ? flattenSectionsFromGroup<SiteSection | SiteSectionGroup>(item.children)
                       : item
               )
             : siteStructure.structure
@@ -60,9 +44,9 @@ export function listAllSiteSpaces(siteStructure: SiteStructure) {
             return section.siteSpaces;
         }
 
-        return flattenSectionsFromGroup(section.children).flatMap(
-            (subSection) => subSection.siteSpaces
-        );
+        return flattenSectionsFromGroup<SiteSection | SiteSectionGroup>(section.children)
+            .filter((subSection): subSection is SiteSection => subSection.object === 'site-section')
+            .flatMap((subSection) => subSection.siteSpaces);
     });
 }
 

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -5,14 +5,14 @@ import { joinPath } from './paths';
 /**
  * Recursively flatten all sections from nested groups
  */
-function flattenGroupChildren(children: (SiteSection | SiteSectionGroup)[]): SiteSection[] {
+function flattenSectionsFromGroup(children: (SiteSection | SiteSectionGroup)[]): SiteSection[] {
     const sections: SiteSection[] = [];
 
     for (const child of children) {
         if (child.object === 'site-section') {
             sections.push(child);
         } else if (child.object === 'site-section-group') {
-            sections.push(...flattenGroupChildren(child.children));
+            sections.push(...flattenSectionsFromGroup(child.children));
         }
     }
 
@@ -39,7 +39,9 @@ export function getSiteStructureSections(
     return siteStructure.type === 'sections'
         ? ignoreGroups
             ? siteStructure.structure.flatMap((item) =>
-                  item.object === 'site-section-group' ? flattenGroupChildren(item.children) : item
+                  item.object === 'site-section-group'
+                      ? flattenSectionsFromGroup(item.children)
+                      : item
               )
             : siteStructure.structure
         : [];
@@ -58,7 +60,7 @@ export function listAllSiteSpaces(siteStructure: SiteStructure) {
             return section.siteSpaces;
         }
 
-        return flattenGroupChildren(section.children).flatMap(
+        return flattenSectionsFromGroup(section.children).flatMap(
             (subSection) => subSection.siteSpaces
         );
     });

--- a/packages/gitbook/src/lib/utils.ts
+++ b/packages/gitbook/src/lib/utils.ts
@@ -78,3 +78,34 @@ export function defaultCustomization(): api.SiteCustomizationSettings {
         socialPreview: {},
     };
 }
+
+/**
+ * Recursively flatten all sections from nested groups
+ */
+export function flattenSectionsFromGroup<T extends { id: string; object: string; children?: T[] }>(
+    children: T[]
+): T[] {
+    const sections: T[] = [];
+
+    for (const child of children) {
+        if (child.object === 'site-section') {
+            sections.push(child);
+        } else if (child.object === 'site-section-group' && child.children) {
+            sections.push(...flattenSectionsFromGroup(child.children));
+        }
+    }
+
+    return sections;
+}
+
+/**
+ * Recursively find a section by ID within a group and its nested children
+ */
+export function findSectionInGroup<T extends { id: string; object: string; children?: T[] }>(
+    group: { children: T[] },
+    sectionId: string
+): T | null {
+    return (
+        flattenSectionsFromGroup(group.children).find((section) => section.id === sectionId) ?? null
+    );
+}


### PR DESCRIPTION
This PR restyles the site section group items and adds support for multiple section groups within a section group.

## Restyle site section group items

Before

<img width="1952" height="820" alt="CleanShot 2025-09-18 at 15 25 11@2x" src="https://github.com/user-attachments/assets/abfb49e4-6fd0-4c81-8a3d-70fbd44b55b5" />

After

<img width="1676" height="844" alt="CleanShot 2025-09-18 at 13 55 34@2x" src="https://github.com/user-attachments/assets/2ae6e6ae-98ca-431b-8575-eb0c07709df8" />

## Improved column support

Before

<img width="1676" height="1258" alt="CleanShot 2025-09-18 at 13 56 35@2x" src="https://github.com/user-attachments/assets/53064116-daa0-4631-9b38-6db779c6117d" />

After
<img width="1676" height="1178" alt="CleanShot 2025-09-18 at 13 56 10@2x" src="https://github.com/user-attachments/assets/28ca9696-0a4b-4fa2-9bcc-e68074ed75fc" />

## Support nested section groups

In Tabs

<img width="1952" height="820" alt="CleanShot 2025-09-18 at 14 35 52@2x" src="https://github.com/user-attachments/assets/16b2be99-3151-49a2-8bb3-ae1ebdc99967" />

Sidebar list also supported

<img width="682" height="704" alt="CleanShot 2025-09-18 at 14 28 55@2x" src="https://github.com/user-attachments/assets/008ad98c-f71a-496e-8a8b-975c0e13fe87" />
