### PR TITLE
Expose "Best match" when site has translations

### DIFF
--- a/.changeset/selfish-ravens-drop.md
+++ b/.changeset/selfish-ravens-drop.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Expose "Best match" when site has translations

--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -124,10 +124,7 @@ export function Header(props: {
                                 withSiteVariants={
                                     sections?.list.some(
                                         (s) =>
-                                            s.object === 'site-section' &&
-                                            s.siteSpaces.filter(
-                                                (s) => s.space.language === siteSpace.space.language
-                                            ).length > 1
+                                            s.object === 'site-section' && s.siteSpaces.length > 1
                                     ) ?? false
                                 }
                                 withSections={!!sections}

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -185,11 +185,7 @@ export function SpaceLayout(props: SpaceLayoutProps) {
                                                 sections?.list.some(
                                                     (s) =>
                                                         s.object === 'site-section' &&
-                                                        s.siteSpaces.filter(
-                                                            (s) =>
-                                                                s.space.language ===
-                                                                siteSpace.space.language
-                                                        ).length > 1
+                                                        s.siteSpaces.length > 1
                                                 ) ?? false
                                             }
                                             withSections={withSections}


### PR DESCRIPTION
Previously we filtered out translations when checking if site sections have multiple variants. 
This resulted in not giving a user the choice between "Best match" (which also filters out translations) and "Everything" (which always shows every space, including translations).

This fixes that.