### PR TITLE
Fix OpenAPISecurities and code sample not using operation security requirements

### DIFF
--- a/packages/react-openapi/src/OpenAPISecurities.tsx
+++ b/packages/react-openapi/src/OpenAPISecurities.tsx
@@ -6,20 +6,23 @@ import { OpenAPISchemaName } from './OpenAPISchemaName';
 import type { OpenAPIClientContext } from './context';
 import { t } from './translate';
 import type { OpenAPIOperationData, OpenAPISecurityWithRequired } from './types';
-import { createStateKey, resolveDescription } from './utils';
+import { createStateKey, extractOperationSecurityInfo, resolveDescription } from './utils';
 
 /**
  * Present securities authorization that can be used for this operation.
  */
 export function OpenAPISecurities(props: {
+    securityRequirement: OpenAPIV3.OperationObject['security'];
     securities: OpenAPIOperationData['securities'];
     context: OpenAPIClientContext;
 }) {
-    const { securities, context } = props;
+    const { securityRequirement, securities, context } = props;
 
-    if (securities.length === 0) {
+    if (!securities || securities.length === 0) {
         return null;
     }
+
+    const tabsData = extractOperationSecurityInfo({ securityRequirement, securities });
 
     return (
         <InteractiveSection
@@ -30,27 +33,31 @@ export function OpenAPISecurities(props: {
             toggleIcon={context.icons.chevronRight}
             selectIcon={context.icons.chevronDown}
             className="openapi-securities"
-            tabs={securities.map(([key, security]) => {
-                const description = resolveDescription(security);
-                return {
-                    key: key,
-                    label: key,
-                    body: (
-                        <div className="openapi-schema">
-                            <div className="openapi-schema-presentation">
-                                {getLabelForType(security, context)}
-
-                                {description ? (
-                                    <Markdown
-                                        source={description}
-                                        className="openapi-securities-description"
-                                    />
-                                ) : null}
-                            </div>
-                        </div>
-                    ),
-                };
-            })}
+            tabs={tabsData.map(({ key, label, schemes }) => ({
+                key,
+                label,
+                body: (
+                    <div className="openapi-schema">
+                        {schemes.map((security, index) => {
+                            const description = resolveDescription(security);
+                            return (
+                                <div
+                                    key={`${key}-${index}`}
+                                    className="openapi-schema-presentation"
+                                >
+                                    {getLabelForType(security, context)}
+                                    {description ? (
+                                        <Markdown
+                                            source={description}
+                                            className="openapi-securities-description"
+                                        />
+                                    ) : null}
+                                </div>
+                            );
+                        })}
+                    </div>
+                ),
+            }))}
         />
     );
 }

--- a/packages/react-openapi/src/OpenAPISpec.tsx
+++ b/packages/react-openapi/src/OpenAPISpec.tsx
@@ -26,7 +26,12 @@ export function OpenAPISpec(props: {
     return (
         <>
             {securities.length > 0 ? (
-                <OpenAPISecurities key="securities" securities={securities} context={context} />
+                <OpenAPISecurities
+                    key="securities"
+                    securityRequirement={operation.security}
+                    securities={securities}
+                    context={context}
+                />
             ) : null}
 
             {parameterGroups.map((group) => {


### PR DESCRIPTION
We were using/displaying all security schemes instead of considering it there was a [security requirement](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.4.md#security-requirement-object) applied for the operation.