### PR TITLE
Update tooltip labels in docs sites toolbars

### DIFF
--- a/packages/gitbook/src/components/AdminToolbar/AdminToolbarClient.tsx
+++ b/packages/gitbook/src/components/AdminToolbar/AdminToolbarClient.tsx
@@ -71,7 +71,7 @@ function ChangeRequestToolbar(props: AdminToolbarClientProps) {
     });
 
     return (
-        <Toolbar>
+        <Toolbar label="Site preview">
             <ToolbarBody>
                 <ToolbarTitle
                     prefix="Change request"
@@ -145,7 +145,7 @@ function RevisionToolbar(props: AdminToolbarClientProps) {
     const gitProvider = isGitHub ? 'GitHub' : 'GitLab';
 
     return (
-        <Toolbar>
+        <Toolbar label="Site preview">
             <ToolbarBody>
                 <ToolbarTitle prefix="Site version" suffix={context.site.title} />
                 <ToolbarSubtitle
@@ -218,7 +218,7 @@ function AuthenticatedUserToolbar(props: AdminToolbarClientProps) {
     });
 
     return (
-        <Toolbar>
+        <Toolbar label="Only visible to your GitBook organization">
             <ToolbarBody>
                 <ToolbarTitle prefix="Site" suffix={context.site.title} />
                 <ToolbarSubtitle

--- a/packages/gitbook/src/components/AdminToolbar/Toolbar.tsx
+++ b/packages/gitbook/src/components/AdminToolbar/Toolbar.tsx
@@ -12,7 +12,13 @@ import { useMagnificationEffect } from './useMagnificationEffect';
 const DURATION_LOGO_APPEARANCE = 2000;
 const DELAY_BETWEEN_LOGO_AND_CONTENT = 100;
 
-export function Toolbar(props: { children: React.ReactNode }) {
+interface ToolbarProps {
+    children: React.ReactNode;
+    label: React.ReactNode;
+}
+
+export function Toolbar(props: ToolbarProps) {
+    const { children, label } = props;
     const [minified, setMinified] = React.useState(true);
     const [showToolbarControls, setShowToolbarControls] = React.useState(false);
     const [isReady, setIsReady] = React.useState(false);
@@ -48,7 +54,7 @@ export function Toolbar(props: { children: React.ReactNode }) {
     }
 
     return (
-        <Tooltip label="Only visible to you">
+        <Tooltip label={label}>
             <motion.div
                 onMouseEnter={() => setShowToolbarControls(true)}
                 onMouseLeave={() => setShowToolbarControls(false)}
@@ -98,7 +104,7 @@ export function Toolbar(props: { children: React.ReactNode }) {
                             <AnimatedLogo />
                         </motion.div>
 
-                        {!minified ? props.children : null}
+                        {!minified ? children : null}
 
                         {!minified && showToolbarControls && (
                             <MinifyButton setMinified={setMinified} />


### PR DESCRIPTION
This PR tweaks the labels in the tooltip shown when hovering the toolbar. Depending on which of the 3 toolbars is shown, we say:

- "Site preview" for toolbar on a change request preview url
- "Site preview" for toolbar on revision (i.e. a prior site version) preview urls
- "Only visible to your GitBook organization" when toolbar is on prod site but when we detect a team member is signed into GitBook in the browser


https://github.com/user-attachments/assets/da49e56b-6011-4af1-82f7-69ef5f701782



