### PR TITLE
Use siteSpace title instead of space title in search

### DIFF
--- a/.changeset/few-elephants-carry.md
+++ b/.changeset/few-elephants-carry.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Use sitespace title instead of space title in search

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -14,6 +14,7 @@ import type {
     SearchSpaceResult,
     SiteSection,
     SiteSectionGroup,
+    SiteSpace,
     Space,
 } from '@gitbook/api';
 import { createStreamableValue } from 'ai/rsc';
@@ -296,6 +297,7 @@ async function searchSiteContent(
                         transformSitePageResult(context, {
                             pageItem,
                             spaceItem,
+                            siteSpace: found?.siteSpace,
                             space: found?.siteSpace.space,
                             spaceURL: found?.siteSpace.urls.published,
                             siteSection: siteSection ?? undefined,
@@ -384,12 +386,13 @@ async function transformSitePageResult(
         pageItem: SearchPageResult;
         spaceItem: SearchSpaceResult;
         space?: Space;
+        siteSpace?: SiteSpace;
         spaceURL?: string;
         siteSection?: SiteSection;
         siteSectionGroup?: SiteSectionGroup;
     }
 ): Promise<OrderedComputedResult[]> {
-    const { pageItem, spaceItem, space, spaceURL, siteSection, siteSectionGroup } = args;
+    const { pageItem, spaceItem, spaceURL, siteSection, siteSectionGroup, siteSpace } = args;
     const { linker } = context;
 
     const page: ComputedPageResult = {
@@ -410,9 +413,9 @@ async function transformSitePageResult(
                 icon: siteSection?.icon as IconName,
                 label: siteSection.title,
             },
-            (!siteSection || siteSection?.siteSpaces.length > 1) && space
+            (!siteSection || siteSection?.siteSpaces.length > 1) && siteSpace
                 ? {
-                      label: space?.title,
+                      label: siteSpace.title,
                   }
                 : undefined,
         ].filter((item) => item !== undefined),


### PR DESCRIPTION
We were exposing the space's internal title in search instead of the variant/siteSpace title.

<img width="1180" height="966" alt="CleanShot 2025-09-22 at 16 29 36@2x" src="https://github.com/user-attachments/assets/0dffc67d-ceb3-49ae-83f2-2e0ac66bc340" />
<img width="1180" height="966" alt="CleanShot 2025-09-22 at 16 29 19@2x" src="https://github.com/user-attachments/assets/ce3da793-1790-4c82-ac54-b9cedda56dd6" />
