### PR TITLE
Move inline expression evaluation from API to GBO

### DIFF
--- a/.changeset/mean-starfishes-promise.md
+++ b/.changeset/mean-starfishes-promise.md
@@ -1,0 +1,5 @@
+---
+"gitbook": minor
+---
+
+Move inline expression evaluation from API to GBO

--- a/bun.lock
+++ b/bun.lock
@@ -304,7 +304,7 @@
     "react-dom": "^19.0.0",
   },
   "catalog": {
-    "@gitbook/api": "^0.142.0",
+    "@gitbook/api": "0.143.1",
     "bidc": "^0.0.2",
   },
   "packages": {
@@ -676,7 +676,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@6.6.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "6.6.0" } }, "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg=="],
 
-    "@gitbook/api": ["@gitbook/api@0.142.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-Lq1IbepAykHNG8y0fBvC7hQj3i/f1XATX58wLYXWCL3W1x6Z9f6Rs5K2qCOONswJh3l2NrX3ujrbxx3D8goRdw=="],
+    "@gitbook/api": ["@gitbook/api@0.143.1", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-5k7PnMe9W8EhmSejqayCbAIIJDGB4C2m+o6+dD+asmlv+6jE/LqoxuAvbP8o+kG83tMnbsr5I5d73B/9cAYbag=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "workspaces": {
         "packages": ["packages/*"],
         "catalog": {
-            "@gitbook/api": "^0.142.0",
+            "@gitbook/api": "0.143.1",
             "bidc": "^0.0.2"
         }
     },

--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -344,7 +344,7 @@ const getRevisionPageDocument = cache(
                         params.revisionId,
                         params.pageId,
                         {
-                            evaluated: true,
+                            evaluated: 'deterministic-only',
                         },
                         {
                             ...noCacheFetchOptions,
@@ -377,7 +377,7 @@ const getRevisionReusableContentDocument = cache(
                         params.revisionId,
                         params.reusableContentId,
                         {
-                            evaluated: true,
+                            evaluated: 'deterministic-only',
                         },
                         {
                             ...noCacheFetchOptions,


### PR DESCRIPTION
After the changes in GBX https://github.com/GitbookIO/gitbook-x/pull/19639 switch the space content API calls to return only deterministic expr blocks (i.e if block) so that inline expression can be evaluated in GBO using dynamic expression.

Fix RND-8169