### PR TITLE
Fix NavigationLoader on search and cmd/click

### DIFF
--- a/packages/gitbook/src/components/hooks/useHash.tsx
+++ b/packages/gitbook/src/components/hooks/useHash.tsx
@@ -59,6 +59,11 @@ export const NavigationStatusProvider: React.FC<React.PropsWithChildren> = ({ ch
     }, []);
 
     const onNavigationClick = React.useCallback((href: string) => {
+        // We need to skip it for search like params (i.e. ?ask= or ?q=) because they don't really trigger a navigation
+        // Search may trigger a navigation whenn clicking on the ask ai for example, this is not something we want to track here
+        if (href.startsWith('?') || href.startsWith('#')) {
+            return;
+        }
         const url = new URL(
             href,
             typeof window !== 'undefined' ? window.location.origin : 'http://localhost'

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -80,7 +80,8 @@ export const Link = React.forwardRef(function Link(
 
     const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
         const isExternalWithOrigin = isExternalLink(href, window.location.origin);
-        if (!isExternal) {
+        // Only trigger navigation context for internal links without modifier keys (i.e. open in new tab).
+        if (!isExternal && !event.ctrlKey && !event.metaKey) {
             onNavigationClick(href);
         }
 


### PR DESCRIPTION
Improve navigation tracking by ignoring search parameters and external links when modifier keys are pressed. This change ensures that only relevant internal navigations are tracked.