### PR TITLE
Fix rounded outline items

### DIFF
--- a/.changeset/mighty-bears-type.md
+++ b/.changeset/mighty-bears-type.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix rounded outline items

--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -110,7 +110,7 @@ export function ScrollSectionsList({ sections }: { sections: DocumentSection[] }
                                 'opacity-8',
                                 'contrast-more:opacity-11',
 
-                                'sidebar-list-default:rounded-l-none',
+                                'sidebar-list-default:rounded-l-none!',
                                 'sidebar-list-default:border-l',
                                 'sidebar-list-default:border-tint',
                             ],


### PR DESCRIPTION
`rounded` was being incorrectly applied to page outline items with `circular-corners` set. This override fixes that.