### PR TITLE
Fix cache race condition

### DIFF
--- a/packages/gitbook/open-next.config.ts
+++ b/packages/gitbook/open-next.config.ts
@@ -7,7 +7,8 @@ export default {
             converter: 'edge',
             proxyExternalRequest: 'fetch',
             queue: () => import('./openNext/queue/middleware').then((m) => m.default),
-            incrementalCache: () => import('./openNext/incrementalCache/server').then((m) => m.default),
+            incrementalCache: () =>
+                import('./openNext/incrementalCache/server').then((m) => m.default),
             tagCache: () => import('./openNext/tagCache/middleware').then((m) => m.default),
         },
     },
@@ -18,7 +19,8 @@ export default {
             converter: 'edge',
             proxyExternalRequest: 'fetch',
             queue: () => import('./openNext/queue/middleware').then((m) => m.default),
-            incrementalCache: () => import('./openNext/incrementalCache/middleware').then((m) => m.default),
+            incrementalCache: () =>
+                import('./openNext/incrementalCache/middleware').then((m) => m.default),
             tagCache: () => import('./openNext/tagCache/middleware').then((m) => m.default),
         },
     },

--- a/packages/gitbook/openNext/incrementalCache/incrementalCache.ts
+++ b/packages/gitbook/openNext/incrementalCache/incrementalCache.ts
@@ -7,7 +7,6 @@ import type {
 } from '@opennextjs/aws/types/overrides.js';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 
-
 import type { DurableObjectNamespace, Rpc } from '@cloudflare/workers-types';
 
 export const BINDING_NAME = 'NEXT_INC_CACHE_R2_BUCKET';

--- a/packages/gitbook/openNext/incrementalCache/middleware.ts
+++ b/packages/gitbook/openNext/incrementalCache/middleware.ts
@@ -1,6 +1,5 @@
-import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-cache/regional-cache";
-import { GitbookIncrementalCache } from "./incrementalCache";
-
+import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
+import { GitbookIncrementalCache } from './incrementalCache';
 
 export default withRegionalCache(new GitbookIncrementalCache(), {
     mode: 'long-lived',

--- a/packages/gitbook/openNext/incrementalCache/server.ts
+++ b/packages/gitbook/openNext/incrementalCache/server.ts
@@ -1,6 +1,5 @@
-import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-cache/regional-cache";
-import { GitbookIncrementalCache } from "./incrementalCache";
-
+import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
+import { GitbookIncrementalCache } from './incrementalCache';
 
 export default withRegionalCache(new GitbookIncrementalCache(), {
     mode: 'long-lived',


### PR DESCRIPTION
Address a race condition in the cache implementation of GBO 2c.

When revalidating a tag, the middleware could actually repopulate the cache before reaching the server cache and thus cause the tag cache to be bypassed in the server making the cache entry stale.