### PR TITLE
Add end-to-end tests for table of contents navigation

### DIFF
--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -231,7 +231,6 @@ const testCases: TestsCase[] = [
             {
                 name: 'Expandable TOC navigation',
                 url: '',
-                screenshot: false,
                 run: async (page) => {
                     await waitForCookiesDialog(page);
 


### PR DESCRIPTION
Introduce end-to-end tests to verify the visibility and functionality of expandable sections in the table of contents. These tests ensure that navigation links appear as expected when sections are expanded.