### PR TITLE
Redirect to space base path on fallback true

### DIFF
--- a/packages/gitbook/src/components/SitePage/SitePage.tsx
+++ b/packages/gitbook/src/components/SitePage/SitePage.tsx
@@ -102,6 +102,9 @@ export async function generateSitePageMetadata(props: SitePageProps): Promise<Me
     });
 
     if (!pageTarget) {
+        if (context.isFallback) {
+            redirect(context.linker.toPathInSpace('/'));
+        }
         notFound();
     }
 
@@ -154,6 +157,10 @@ export async function getSitePageData(props: SitePageProps) {
             // before trying to resolve the page again
             redirect(context.linker.toPathInSpace(pathname));
         } else {
+            // If the page is not found and we are in fallback mode, return a redirect to the basepath
+            if (context.isFallback) {
+                redirect(context.linker.toPathInSpace('/'));
+            }
             notFound();
         }
     } else if (getPagePath(context.revision.pages, pageTarget.page) !== rawPathname) {

--- a/packages/gitbook/src/lib/context.ts
+++ b/packages/gitbook/src/lib/context.ts
@@ -50,6 +50,13 @@ export type SiteURLData = Pick<
      * Identifier used for image resizing.
      */
     imagesContextId: string;
+
+    /**
+     * Whether this request is a fallback rendering.
+     * We use this when switching variant as we don't know if the page exists in the other variant.
+     * By knowing it's a fallback, we can redirect to the space base path instead of returning a 404.
+     */
+    isFallback?: boolean;
 };
 
 /**
@@ -127,6 +134,9 @@ export type GitBookSiteContext = GitBookSpaceContext & {
 
     /** Context ID used by adaptive content. It represents an unique identifier for the authentication context */
     contextId?: string;
+
+    /** Whether this request is a fallback rendering. */
+    isFallback: boolean;
 };
 
 /**
@@ -205,6 +215,7 @@ export async function fetchSiteContextByURLLookup(
         changeRequest: data.changeRequest,
         revision: data.revision,
         contextId: data.contextId,
+        isFallback: data.isFallback ?? false,
     });
 }
 
@@ -223,6 +234,7 @@ export async function fetchSiteContextByIds(
         changeRequest: string | undefined;
         revision: string | undefined;
         contextId?: string;
+        isFallback: boolean;
     }
 ): Promise<GitBookSiteContext> {
     const { dataFetcher } = baseContext;
@@ -321,6 +333,7 @@ export async function fetchSiteContextByIds(
         sections,
         scripts,
         contextId: ids.contextId,
+        isFallback: ids.isFallback,
     };
 }
 

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -298,6 +298,7 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
             apiToken: siteURLData.apiToken,
             imagesContextId: imagesContextId,
             contextId: siteURLData.contextId,
+            isFallback: requestURL.searchParams.get('fallback') === 'true' ? true : undefined,
         };
 
         const requestHeaders = new Headers(request.headers);
@@ -382,7 +383,11 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         ].join('/');
 
         const rewrittenURL = new URL(`/${route}`, request.nextUrl.toString());
-        rewrittenURL.search = request.nextUrl.search; // Preserve the original search params
+        // Preserve the original search params but remove fallback=true if present
+        rewrittenURL.search = request.nextUrl.search;
+        if (rewrittenURL.searchParams.has('fallback')) {
+            rewrittenURL.searchParams.delete('fallback');
+        }
 
         const response = NextResponse.rewrite(rewrittenURL, {
             request: {


### PR DESCRIPTION
Implement a redirect to the space base path instead of returning a 404 when a page is not found and fallback mode is active (i.e. when switching variants)
This change enhances user experience by guiding users to the base path rather than displaying the not found page first and then redirecting.