### PR TITLE
Fix opacity of ScrollContainer buttons on bold themes

### DIFF
--- a/.changeset/two-rocks-cry.md
+++ b/.changeset/two-rocks-cry.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix opacity of ScrollContainer buttons on bold themes

--- a/packages/gitbook/src/components/primitives/ScrollContainer.tsx
+++ b/packages/gitbook/src/components/primitives/ScrollContainer.tsx
@@ -165,7 +165,7 @@ export function ScrollContainer(props: ScrollContainerProps) {
                     orientation === 'horizontal'
                         ? '-translate-y-1/2! top-1/2 left-0 ml-2'
                         : '-translate-x-1/2! top-0 left-1/2 mt-2',
-                    'absolute not-pointer-none:block hidden scale-0 opacity-0 transition-[scale,opacity]',
+                    'absolute not-pointer-none:block hidden scale-0 opacity-0 backdrop-blur-xl transition-[scale,opacity]',
                     scrollPosition > 0
                         ? 'not-pointer-none:group-hover/scroll-container:scale-100 not-pointer-none:group-hover/scroll-container:opacity-11'
                         : 'pointer-events-none'
@@ -183,7 +183,7 @@ export function ScrollContainer(props: ScrollContainerProps) {
                     orientation === 'horizontal'
                         ? '-translate-y-1/2! top-1/2 right-0 mr-2'
                         : '-translate-x-1/2! bottom-0 left-1/2 mb-2',
-                    'absolute not-pointer-none:block hidden scale-0 transition-[scale,opacity]',
+                    'absolute not-pointer-none:block hidden scale-0 backdrop-blur-xl transition-[scale,opacity]',
                     scrollPosition < scrollSize
                         ? 'not-pointer-none:group-hover/scroll-container:scale-100 not-pointer-none:group-hover/scroll-container:opacity-11'
                         : 'pointer-events-none'


### PR DESCRIPTION
<img width="526" height="270" alt="CleanShot 2025-10-27 at 17 25 12@2x" src="https://github.com/user-attachments/assets/725c2086-b934-4192-b808-5b2e8504d51b" />

<img width="566" height="304" alt="CleanShot 2025-10-27 at 17 25 03@2x" src="https://github.com/user-attachments/assets/95341553-1f83-4d2c-80b7-5b4501d28002" />