### PR TITLE
Treat pages without visible TOC items as `no-toc`

### DIFF
--- a/.changeset/slow-boxes-go.md
+++ b/.changeset/slow-boxes-go.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Treat pages without visible TOC items as `no-toc`

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -46,6 +46,11 @@ export function PageBody(props: {
     const language = getSpaceLanguage(context);
     const updatedAt = page.updatedAt ?? page.createdAt;
 
+    const hasVisibleTOCItems =
+        context.revision.pages.filter(
+            (page) => page.type !== 'document' || (page.type === 'document' && !page.hidden)
+        ).length > 0;
+
     return (
         <CurrentPageProvider page={{ spaceId: context.space.id, pageId: page.id }}>
             <main
@@ -56,7 +61,9 @@ export function PageBody(props: {
                     'break-anywhere',
                     pageWidthWide ? 'page-width-wide 3xl:px-8' : 'page-width-default',
                     siteWidthWide ? 'site-width-wide' : 'site-width-default',
-                    page.layout.tableOfContents ? 'page-has-toc' : 'page-no-toc'
+                    page.layout.tableOfContents && hasVisibleTOCItems
+                        ? 'page-has-toc'
+                        : 'page-no-toc'
                 )}
             >
                 <PreservePageLayout siteWidthWide={siteWidthWide} />


### PR DESCRIPTION
One example of this is [Nvidia's docs home](https://run-ai-docs.nvidia.com/)