### PR TITLE
Add page breadcrumbs to search results

### DIFF
--- a/.changeset/busy-weeks-add.md
+++ b/.changeset/busy-weeks-add.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add breadcrumbs to search results

--- a/bun.lock
+++ b/bun.lock
@@ -343,7 +343,7 @@
     "react-dom": "catalog:",
   },
   "catalog": {
-    "@gitbook/api": "0.146.0",
+    "@gitbook/api": "0.147.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -724,7 +724,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@6.6.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "6.6.0" } }, "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg=="],
 
-    "@gitbook/api": ["@gitbook/api@0.146.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-gWcSCbN+9Zc/XOEk4t8v70kKyaVJQytHMnnstArr8av1YpHzZWEpVQCeQ20SnJvkvO5y+P7TCVxJCLG2ciT9SQ=="],
+    "@gitbook/api": ["@gitbook/api@0.147.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-ON32kqr9ID6td9h26bmmPflpoKZZ3+Z0W5URjc/YIDfk+YFb7/rVrOGzYf3NV9R+uZuxVzIKRJ9Yq8v0WLVwNQ=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
-            "@gitbook/api": "0.146.0",
+            "@gitbook/api": "0.147.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -54,13 +54,13 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
                         'transition-colors',
                         'font-normal',
                         'uppercase',
-                        'leading-none',
+                        'leading-snug',
                         'tracking-wider',
                         'mb-1',
                         'flex',
                         'flex-wrap',
                         'gap-x-2',
-                        'gap-y-1',
+                        'gap-y-0',
                         'items-center'
                     )}
                 >

--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -413,11 +413,21 @@ async function transformSitePageResult(
                 icon: siteSection?.icon as IconName,
                 label: siteSection.title,
             },
-            (!siteSection || siteSection?.siteSpaces.length > 1) && siteSpace
+            (siteSection?.siteSpaces?.filter(
+                // If a space is the only one in its langauge, it's a translation variant and we don't want to show it.
+                (space) =>
+                    siteSection?.siteSpaces?.filter(
+                        // Check if there are other spaces in the same language within the section.
+                        (s) => s.space.language === space.space.language
+                    ).length > 1 // We only want to show the space if there are other spaces in the same language within the section.
+            ).length ?? 0) > 1 && siteSpace
                 ? {
                       label: siteSpace.title,
                   }
                 : undefined,
+            ...pageItem.ancestors.map((ancestor) => ({
+                label: ancestor.title,
+            })),
         ].filter((item) => item !== undefined),
     };
 


### PR DESCRIPTION
- Add the newly-available page ancestor information to search results in the form of page breadcrumbs.
- If there are too many breadcrumbs, we only show the 1st, 2nd, and last crumb.
- Also filtered out translation variants from taking up a breadcrumb.
- Cleaned up the display of breadcrumbs a bit.