### PR TITLE
Disable OpenAPI "Try it" when no servers are defined

### DIFF
--- a/.changeset/huge-worms-follow.md
+++ b/.changeset/huge-worms-follow.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Disable OpenAPI "Try it" when no servers are defined

--- a/packages/react-openapi/src/OpenAPICodeSample.tsx
+++ b/packages/react-openapi/src/OpenAPICodeSample.tsx
@@ -220,7 +220,7 @@ function OpenAPICodeSampleFooter(props: {
         return null;
     }
 
-    if (!validateHttpMethod(method)) {
+    if (!validateHttpMethod(method) || (!hasMultipleMediaTypes && servers.length === 0)) {
         return null;
     }
 
@@ -237,7 +237,7 @@ function OpenAPICodeSampleFooter(props: {
             ) : (
                 <span />
             )}
-            {!hideTryItPanel && (
+            {!hideTryItPanel && servers.length > 0 && (
                 <ScalarApiButton
                     context={getOpenAPIClientContext(context)}
                     method={method}


### PR DESCRIPTION
When no server is defined in the OpenAPI spec, clicking the Try it button causes Scalar to fall back to the R2 storage URL. This leads to requests being sent to an unintended endpoint.

To prevent this, this PR removes the Try it feature when no servers are defined in the spec.