### PR TITLE
Fix OpenAPI basic auth placeholder

### DIFF
--- a/.changeset/ready-ducks-burn.md
+++ b/.changeset/ready-ducks-burn.md
@@ -1,0 +1,5 @@
+---
+'@gitbook/react-openapi': patch
+---
+
+Fix OpenAPI basic auth placeholder

--- a/packages/react-openapi/src/OpenAPICodeSample.tsx
+++ b/packages/react-openapi/src/OpenAPICodeSample.tsx
@@ -315,11 +315,12 @@ function getSecurityHeaders(args: {
         switch (security.type) {
             case 'http': {
                 let scheme = security.scheme;
+                const defaultPlaceholderValue = scheme?.toLowerCase()?.includes('basic')
+                    ? 'username:password'
+                    : 'YOUR_SECRET_TOKEN';
                 const format = resolvePrefillCodePlaceholderFromSecurityScheme({
                     security: security,
-                    defaultPlaceholderValue: scheme?.includes('basic')
-                        ? 'username:password'
-                        : 'YOUR_SECRET_TOKEN',
+                    defaultPlaceholderValue,
                 });
 
                 if (scheme?.includes('bearer')) {


### PR DESCRIPTION
Properly use `username:password` instead of `YOUR_SECRET_TOKEN`