### PR TITLE
Make semantic text colors more vibrant

### DIFF
--- a/packages/gitbook/src/components/DocumentView/utils/colors.ts
+++ b/packages/gitbook/src/components/DocumentView/utils/colors.ts
@@ -3,17 +3,17 @@ import type { DocumentMarkColor } from '@gitbook/api';
 
 export const textColorToStyle: { [color in DocumentMarkColor['data']['text']]: ClassValue } = {
     default: [],
-    blue: ['text-blue-500'],
-    red: ['text-red-500'],
-    green: ['text-green-500'],
-    yellow: ['text-yellow-600'],
-    purple: ['text-purple-500'],
-    orange: ['text-orange-500'],
-    $primary: ['text-primary'],
-    $info: ['text-info'],
-    $success: ['text-success'],
-    $warning: ['text-warning'],
-    $danger: ['text-danger'],
+    blue: ['text-blue-500 contrast-more:text-blue-800'],
+    red: ['text-red-500 contrast-more:text-red-800'],
+    green: ['text-green-500 contrast-more:text-green-800'],
+    yellow: ['text-yellow-600 contrast-more:text-yellow-800'],
+    purple: ['text-purple-500 contrast-more:text-purple-800'],
+    orange: ['text-orange-500 contrast-more:text-orange-800'],
+    $primary: ['text-primary-subtle contrast-more:text-primary'],
+    $info: ['text-info-subtle contrast-more:text-info'],
+    $success: ['text-success-subtle contrast-more:text-success'],
+    $warning: ['text-warning-subtle contrast-more:text-warning'],
+    $danger: ['text-danger-subtle contrast-more:text-danger'],
 };
 
 export const backgroundColorToStyle: {


### PR DESCRIPTION
The semantic text colors are more dull than the normal ones, which hampers their use somewhat. Let's make them more vibrant and add a contrast-check so we can fallback to readable text if the browser requests it.

# Before, After
<img width="200" height="1826" alt="CleanShot 2025-12-03 at 10 24 25@2x" src="https://github.com/user-attachments/assets/31c5eb41-39e0-4351-b2aa-1b077a940cfe" />
<img width="200" height="1826" alt="CleanShot 2025-12-03 at 10 24 05@2x" src="https://github.com/user-attachments/assets/4f4f6e2d-2553-4318-bedb-37485bbb2302" />
