### PR TITLE
Remove corner radius of hint block with heading

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -32,10 +32,9 @@ export function Hint({
             className={tcls(
                 'hint',
                 'transition-colors',
-                'rounded-md',
-                hasHeading ? 'rounded-l-none!' : null,
-                'straight-corners:rounded-none',
+                'rounded-corners:rounded-md',
                 'circular-corners:rounded-xl',
+                hasHeading ? 'circular-corners:rounded-l-none rounded-corners:rounded-l-none' : '',
                 'overflow-hidden',
                 hasHeading ? ['border-l-2', hintStyle.containerWithHeader] : hintStyle.container,
 


### PR DESCRIPTION
# Before
<img width="1792" height="462" alt="CleanShot 2025-12-03 at 10 36 57@2x" src="https://github.com/user-attachments/assets/5be44336-6c13-469b-81d9-9ab839d3bfa4" />


# After
<img width="1710" height="500" alt="CleanShot 2025-12-03 at 10 36 45@2x" src="https://github.com/user-attachments/assets/f7311c60-10e1-4eaa-8637-0d6d389c6d9f" />
