### PR TITLE
Update Stepper styling for theme-muted

### DIFF
--- a/packages/gitbook/src/components/DocumentView/StepperStep.tsx
+++ b/packages/gitbook/src/components/DocumentView/StepperStep.tsx
@@ -36,13 +36,13 @@ export function StepperStep(props: BlockProps<DocumentBlockStepperStep>) {
             <div className="relative select-none">
                 <div
                     className={tcls(
-                        'can-override-bg can-override-text flex size-[calc(1.75rem+1px)] items-center justify-center rounded-full bg-primary-original theme-muted:bg-primary-subtle tabular-nums contrast-more:bg-primary-solid',
-                        'font-medium text-contrast-primary-original theme-muted:text-primary contrast-more:text-contrast-primary-solid'
+                        'can-override-bg can-override-text flex size-[calc(1.75rem+1px)] items-center justify-center rounded-full bg-primary-solid theme-muted:bg-tint-base tabular-nums contrast-more:bg-primary-11',
+                        'font-medium text-contrast-primary-solid theme-muted:text-tint contrast-more:text-contrast-primary-11'
                     )}
                 >
                     {index + 1}
                 </div>
-                <div className="can-override-bg absolute top-9 bottom-2 left-3.5 w-px bg-primary-7 theme-muted:bg-primary-subtle" />
+                <div className="can-override-bg absolute top-9 bottom-2 left-3.5 w-px bg-primary-7 theme-muted:bg-tint-6" />
             </div>
             <Blocks
                 {...contextProps}


### PR DESCRIPTION
# Before
<img width="1792" height="1658" alt="CleanShot 2025-12-03 at 12 56 53@2x" src="https://github.com/user-attachments/assets/8f0ddaf1-9ed0-478d-a56d-d3c7fe8a9fbc" />

# After
<img width="1792" height="1658" alt="CleanShot 2025-12-03 at 12 56 30@2x" src="https://github.com/user-attachments/assets/823f797e-67d7-405b-8f45-fabf978c6019" />
