### PR TITLE
Fix link title fallback in ToC item

### DIFF
--- a/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
+++ b/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
@@ -72,7 +72,7 @@ export async function encodeClientTableOfContents(
                 result.push(
                     removeUndefined({
                         id: page.id,
-                        title: page.linkTitle ?? page.title,
+                        title: page.linkTitle || page.title,
                         href,
                         emoji: page.emoji,
                         icon: page.icon,

--- a/packages/gitbook/src/lib/references.tsx
+++ b/packages/gitbook/src/lib/references.tsx
@@ -129,7 +129,7 @@ export async function resolveContentRef(
             const page = resolvePageResult?.page;
             const ancestors =
                 resolvePageResult?.ancestors.map((ancestor) => ({
-                    label: ancestor.linkTitle ?? ancestor.title,
+                    label: ancestor.linkTitle || ancestor.title,
                     icon:
                         ancestor.emoji || ancestor.icon ? (
                             <PageIcon
@@ -177,7 +177,7 @@ export async function resolveContentRef(
                     parentPage && contentRef.page === parentPage.id && parentPage.type === 'group'
                         ? parentPage
                         : page;
-                text = pageOrGroup.linkTitle ?? pageOrGroup.title;
+                text = pageOrGroup.linkTitle || pageOrGroup.title;
                 emoji = isCurrentPage ? undefined : page.emoji;
                 icon = <PageIcon page={pageOrGroup} style={iconStyle} />;
             }


### PR DESCRIPTION
We need to account for the `linkTitle` being an empty string.