### PR TITLE
CVE-2025-55182

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
             "bidc": "^0.0.2",
             "bun-types": "^1.1.20",
             "classnames": "^2.5.1",
-            "react": "^19.0.0",
-            "react-dom": "^19.0.0",
+            "react": "^19.0.1",
+            "react-dom": "^19.0.1",
             "tsdown": "^0.15.6",
             "typescript": "^5.5.3",
             "usehooks-ts": "^3.1.1"

--- a/packages/gitbook/package.json
+++ b/packages/gitbook/package.json
@@ -50,7 +50,7 @@
         "micromark-extension-frontmatter": "^2.0.0",
         "micromark-extension-gfm": "^3.0.0",
         "motion": "^12.23.24",
-        "next": "15.4.0",
+        "next": "15.4.8",
         "next-themes": "^0.4.6",
         "nuqs": "^2.2.3",
         "object-hash": "^3.0.0",


### PR DESCRIPTION
[Summary by Vercel](https://vercel.com/changelog/cve-2025-55182)

TL;DR:
A critical-severity vulnerability in React Server Components ([CVE-2025-55182](https://www.cve.org/CVERecord?id=CVE-2025-55182)) affects React 19 and frameworks that use it, including Next.js ([CVE-2025-66478](https://github.com/vercel/next.js/security/advisories/GHSA-9qr9-h5gf-34mp)). Under certain conditions, specially crafted requests could lead to unintended remote code execution.

**Recommended action**  
Update to:
React: 19.0.1, 19.1.2, 19.2.1
Next.js: 15.0.5, 15.1.9, 15.2.6, 15.3.6, 15.4.8, 15.5.7, 16.0.7

**Why?**  
The company I work for use GitBook and would like to stay secure.  
This pr attempts to handle `cve-2025-55182` by updating  
`Next.js:` `15.4.0` -> `15.4.8`
`React`: `19.0.0` -> `19.0.1`
These versions was selected because they were the closest to the existing versions which hopefully reduces the risk of breaking changes.