### PR TITLE
Fix search results cursor not updating

### DIFF
--- a/.changeset/funny-dodos-speak.md
+++ b/.changeset/funny-dodos-speak.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix search results cursor

--- a/packages/gitbook/src/components/Search/useSearchResults.ts
+++ b/packages/gitbook/src/components/Search/useSearchResults.ts
@@ -173,7 +173,11 @@ export function useSearchResults(props: {
                     return;
                 }
 
-                setResultsState({ results, fetching: false, error: false });
+                const aiEnrichedResults = withAI
+                    ? withAskTriggers(results, query, assistants)
+                    : results;
+
+                setResultsState({ results: aiEnrichedResults, fetching: false, error: false });
 
                 trackEvent({
                     type: 'search_type_query',
@@ -194,14 +198,7 @@ export function useSearchResults(props: {
         };
     }, [query, scope, trackEvent, withAI, siteSpaceId, siteSpaceIds, disabled, suggestions]);
 
-    const aiEnrichedResults: ResultType[] = React.useMemo(() => {
-        if (!withAI) {
-            return resultsState.results;
-        }
-        return withAskTriggers(resultsState.results, query, assistants);
-    }, [resultsState.results, query, withAI, assistants]);
-
-    return { ...resultsState, results: aiEnrichedResults };
+    return resultsState;
 }
 
 /**


### PR DESCRIPTION
There's a bug in the search results screen where our method of adding AI assistant items to the list makes it update on every render. This fixes that.