### PR TITLE
Flatten ToC items left corners if sidebar list style is line

### DIFF
--- a/packages/gitbook/src/components/TableOfContents/styles.ts
+++ b/packages/gitbook/src/components/TableOfContents/styles.ts
@@ -12,6 +12,8 @@ export const PageLinkItemStyles = [
     'rounded-md',
     'straight-corners:rounded-none',
     'circular-corners:rounded-xl',
+    'sidebar-list-line:rounded-l-none',
+    'sidebar-list-line:circular-corners:rounded-l-none',
     'before:content-none',
     'font-normal',
     'hover:bg-tint',
@@ -25,7 +27,7 @@ export const ToggleableLinkItemStyles = [
     'text-balance font-normal text-sm text-tint-strong/7 hover:bg-tint-hover hover:text-tint-strong contrast-more:text-tint-strong',
     'contrast-more:hover:text-tint-strong contrast-more:hover:ring-1 contrast-more:hover:ring-tint-12',
     'before:contents[] before:-left-px before:absolute before:inset-y-0',
-    'sidebar-list-line:rounded-l-none sidebar-list-line:before:w-px [&+div_a]:sidebar-list-default:rounded-l-none [&+div_a]:pl-5 [&+div_a]:sidebar-list-default:before:w-px',
+    'sidebar-list-line:rounded-l-none sidebar-list-line:circular-corners:rounded-l-none sidebar-list-line:before:w-px [&+div_a]:sidebar-list-default:rounded-l-none [&+div_a]:pl-5 [&+div_a]:sidebar-list-default:before:w-px',
 ];
 
 export const ToggleableLinkItemActiveStyles = [


### PR DESCRIPTION
**Before**


**After**
<img width="344" height="116" alt="Screenshot 2025-12-11 at 10 20 13" src="https://github.com/user-attachments/assets/d1ceb06f-2a6b-44e9-89ec-002f4ffdf707" />
