### PR TITLE
Fix rounded corners on `list-line` TOC style

### DIFF
--- a/packages/gitbook/src/components/TableOfContents/styles.ts
+++ b/packages/gitbook/src/components/TableOfContents/styles.ts
@@ -25,7 +25,7 @@ export const ToggleableLinkItemStyles = [
     'text-balance font-normal text-sm text-tint-strong/7 hover:bg-tint-hover hover:text-tint-strong contrast-more:text-tint-strong',
     'contrast-more:hover:text-tint-strong contrast-more:hover:ring-1 contrast-more:hover:ring-tint-12',
     'before:contents[] before:-left-px before:absolute before:inset-y-0',
-    'sidebar-list-line:rounded-l-none sidebar-list-line:before:w-px [&+div_a]:sidebar-list-default:rounded-l-none [&+div_a]:pl-5 [&+div_a]:sidebar-list-default:before:w-px',
+    'sidebar-list-line:rounded-l-none! sidebar-list-line:before:w-px [&+div_a]:sidebar-list-default:rounded-l-none [&+div_a]:pl-5 [&+div_a]:sidebar-list-default:before:w-px',
 ];
 
 export const ToggleableLinkItemActiveStyles = [


### PR DESCRIPTION
On the `line` sidebar style, TOC items would round their corners unnecessarily.

<img width="1690" height="676" alt="image" src="https://github.com/user-attachments/assets/55bbed23-e2cd-47e6-ab84-31fc0a61f96d" />
