### PR TITLE
Use response.id instead of responseId

### DIFF
--- a/packages/gitbook/src/components/AI/server-actions/api.tsx
+++ b/packages/gitbook/src/components/AI/server-actions/api.tsx
@@ -147,7 +147,7 @@ function parseResponse<T>(
 
                 if (event.type === 'response_finish') {
                     foundResponse = true;
-                    resolveResponse({ responseId: event.response?.id ?? null });
+                    resolveResponse({ responseId: event.response.id ?? null });
                 }
             }
 

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -296,7 +296,7 @@ export function AIChatProvider(props: {
                         case 'response_finish': {
                             globalState.setState((state) => ({
                                 ...state,
-                                responseId: event.response?.id ?? null,
+                                responseId: event.response.id ?? null,
                                 // Mark as not loading when the response is finished
                                 // Even if the stream might continue as we receive 'response_followup_suggestion'
                                 loading: false,


### PR DESCRIPTION
`responseId` is deprecated and soon `response` will be optional (in case of stream aborted).