### PR TITLE
Switch main DocumentView to `flex` layout

### DIFF
--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -105,7 +105,7 @@ export function PageBody(props: {
                         <SuspenseLoadedHint />
                         <DocumentView
                             document={document}
-                            style="grid [&>*+*]:mt-5"
+                            style="flex flex-col [&>*+*]:mt-5"
                             blockStyle="page-api-block:ml-0"
                             context={{
                                 mode: 'default',


### PR DESCRIPTION
Making the main view a flex layout instead of a single-column grid will make content easier to truncate content horizontally. Blocks that need it (like columns) can still use their own grid.