### PR TITLE
Fix disabled button from not showing up

### DIFF
--- a/packages/gitbook/src/components/DocumentView/InlineButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineButton.tsx
@@ -26,7 +26,11 @@ export function InlineButton(props: InlineProps<api.DocumentInlineButton>) {
             );
         }
 
-        return <InlineLinkButton {...props} buttonProps={buttonProps} />;
+        if ('ref' in inline.data) {
+            return <InlineLinkButton {...props} buttonProps={buttonProps} />;
+        }
+
+        return <Button {...buttonProps} disabled />;
     };
 
     const inlineElement = (


### PR DESCRIPTION
I returned `null` for all buttons without a `ref` set, but that made disabled buttons (which don't have it set) not render. Instead we use the disabled button as a fall-through.