### PR TITLE
Fix block alignment

### DIFF
--- a/packages/gitbook/src/components/DocumentView/utils/textAlignment.ts
+++ b/packages/gitbook/src/components/DocumentView/utils/textAlignment.ts
@@ -9,11 +9,11 @@ export function getTextAlignment(textAlignment: TextAlignment | undefined): Clas
     switch (textAlignment) {
         case undefined:
         case TextAlignment.Start:
-            return ['text-start', 'justify-self-start'];
+            return ['text-start', 'self-start'];
         case TextAlignment.Center:
-            return ['text-center', 'justify-self-center'];
+            return ['text-center', 'self-center'];
         case TextAlignment.End:
-            return ['text-end', 'justify-self-end'];
+            return ['text-end', 'self-end'];
         default:
             return nullIfNever(textAlignment);
     }


### PR DESCRIPTION
As a result of the `grid` → `flex-col` adjustment, some blocks needed to update their alignment class from the grid-specific to the flex-specific one.

# Before
<img width="3262" height="1170" alt="CleanShot 2025-12-18 at 21 09 59@2x" src="https://github.com/user-attachments/assets/1943897a-2b25-4009-9c6d-bd52bad8f1bf" />

# After
<img width="3260" height="1168" alt="CleanShot 2025-12-18 at 21 09 39@2x" src="https://github.com/user-attachments/assets/609e0c2f-478a-4737-80d3-80e3d31be589" />
