### PR TITLE
Fix embed tab button size regression

### DIFF
--- a/.changeset/spotty-monkeys-nail.md
+++ b/.changeset/spotty-monkeys-nail.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix embed tab button size regression

--- a/packages/gitbook/src/components/Embeddable/EmbeddableFrame.tsx
+++ b/packages/gitbook/src/components/Embeddable/EmbeddableFrame.tsx
@@ -92,7 +92,7 @@ export function EmbeddableFrameSidebar(props: { children: React.ReactNode }) {
     const { children } = props;
 
     return (
-        <div className="flex w-13 shrink-0 origin-top not-hydrated:animate-blur-in-slow flex-col gap-2 overflow-hidden border-tint-solid/3 border-r bg-tint-solid/1 p-2 transition-all transition-discrete duration-300 empty:hidden empty:w-0 empty:px-0">
+        <div className="flex w-15 shrink-0 origin-top not-hydrated:animate-blur-in-slow flex-col gap-2 overflow-hidden border-tint-solid/3 border-r bg-tint-solid/1 p-2 transition-all transition-discrete duration-300 empty:hidden empty:w-0 empty:px-0">
             {children}
         </div>
     );

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -120,7 +120,7 @@ export const Button = React.forwardRef<
         ref
     ) => {
         const sizes = {
-            large: ['text-base font-semibold py-3', iconOnly ? 'px-3' : 'px-[1.5em]ÛŸ'],
+            large: ['text-base font-semibold py-3', iconOnly ? 'px-3' : 'px-[1.5em]'],
             medium: ['py-2', iconOnly ? 'text-base px-2' : 'px-[1em]'],
             small: ['text-sm py-1.5', iconOnly ? 'px-1.5' : 'px-[.75em]'],
             xsmall: [


### PR DESCRIPTION
The new buttons caused a visual regression in the buttons in the embed.

<img width="358" height="298" alt="CleanShot 2026-01-05 at 13 41 03@2x" src="https://github.com/user-attachments/assets/09ea0437-75b3-4038-86be-b19e0d9e7865" />
<img width="358" height="298" alt="CleanShot 2026-01-05 at 13 39 32@2x" src="https://github.com/user-attachments/assets/dbc38557-a1af-41a2-b229-53e8e383ff6d" />
