### PR TITLE
Always display page actions even if there is no toc/title/description

### DIFF
--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -22,10 +22,6 @@ export async function PageHeader(props: {
     const { context, page, ancestors, withRSSFeed } = props;
     const { revision, linker } = context;
 
-    if (!page.layout.title && !page.layout.description) {
-        return null;
-    }
-
     const hasAncestors = ancestors.length > 0;
 
     // Show page actions if *any* of the actions are enabled
@@ -35,6 +31,21 @@ export async function PageHeader(props: {
         context.customization.git.showEditLink,
         withRSSFeed,
     ].some(Boolean);
+
+    /* When title and description are hidden, only display the page actions if there are any. */
+    if (!page.layout.title && !page.layout.description) {
+        if (!hasPageActions) {
+            return null;
+        }
+        return (
+            <PageActionsDropdown
+                siteTitle={context.site.title}
+                urls={getPageActionsURLs({ context, page, withRSSFeed })}
+                actions={context.customization.pageActions}
+                className="absolute top-8 right-0"
+            />
+        );
+    }
 
     return (
         <header
@@ -49,7 +60,7 @@ export async function PageHeader(props: {
                 hasAncestors ? 'page-has-ancestors' : 'page-no-ancestors'
             )}
         >
-            {page.layout.tableOfContents && hasPageActions ? (
+            {hasPageActions ? (
                 <PageActionsDropdown
                     siteTitle={context.site.title}
                     urls={getPageActionsURLs({ context, page, withRSSFeed })}


### PR DESCRIPTION
# Problem
If a page didn't have a title and description or no tableOfContents, we _also_ wouldnt display the page actions dropdown. 

This is problematic because 
1. there's no clear reason to the user why not, we don't communicate it as being dependent on each other, and 
2. **changelogs:** its a reasonable setup to not have title or description yet still need the page actions, as we now also support RSS feeds in there

# Summary
- show page actions dropdown even when title and description are hidden or when toc is hidden
   - in this scenario, position it absolute as to not shift the page's content to the left
- return null only when there's nothing to display (no title, no description, and no page actions)

Screenshots with different setups:
**No title, no description, no toc, no outline**
<img width="4042" height="2406" alt="CleanShot 2026-01-21 at 09 22 23@2x" src="https://github.com/user-attachments/assets/109bf4a4-22fb-4a22-9c99-47fb0b21c0dc" />

**with title, with description, no toc, no outline**
<img width="4052" height="2412" alt="CleanShot 2026-01-21 at 09 23 28@2x" src="https://github.com/user-attachments/assets/df8e78ae-c90c-4201-aba3-2318b7b4e771" />

**with title, with description, with toc, with outline**
<img width="4048" height="2428" alt="CleanShot 2026-01-21 at 09 24 06@2x" src="https://github.com/user-attachments/assets/77db77e5-e120-411c-8b31-7c05df1abeb2" />
