### PR TITLE
Fix logo sizing bug during navigation

### DIFF
--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -65,6 +65,8 @@ export function PageBody(props: {
             (page) => page.type !== 'document' || (page.type === 'document' && !page.hidden)
         ).length > 0;
 
+    const pageHasToc = page.layout.tableOfContents && hasVisibleTOCItems;
+
     return (
         <CurrentPageProvider page={{ spaceId: context.space.id, pageId: page.id }}>
             <main
@@ -76,12 +78,10 @@ export function PageBody(props: {
                     '@container',
                     pageWidthWide ? 'page-width-wide 3xl:px-8' : 'page-width-default',
                     siteWidthWide ? 'site-width-wide' : 'site-width-default',
-                    page.layout.tableOfContents && hasVisibleTOCItems
-                        ? 'page-has-toc'
-                        : 'page-no-toc'
+                    pageHasToc ? 'page-has-toc' : 'page-no-toc'
                 )}
             >
-                <PreservePageLayout siteWidthWide={siteWidthWide} />
+                <PreservePageLayout siteWidthWide={siteWidthWide} pageHasToc={pageHasToc} />
                 {page.cover && page.layout.cover && page.layout.coverSize === 'hero' ? (
                     <PageCover as="hero" page={page} cover={page.cover} context={context} />
                 ) : null}

--- a/packages/gitbook/src/components/PageBody/PreservePageLayout.tsx
+++ b/packages/gitbook/src/components/PageBody/PreservePageLayout.tsx
@@ -11,9 +11,10 @@ import * as React from 'react';
  * 3. Page 2 with full width block: `body:has(.site-width-wide)` is true
  *
  * This component ensures that the layout is preserved while transitioning between the 2 page states (in step 2).
+ * It also preserves the page TOC state (page-has-toc/page-no-toc) to prevent logo sizing issues during navigation.
  */
-export function PreservePageLayout(props: { siteWidthWide: boolean }) {
-    const { siteWidthWide } = props;
+export function PreservePageLayout(props: { siteWidthWide: boolean; pageHasToc: boolean }) {
+    const { siteWidthWide, pageHasToc } = props;
 
     React.useLayoutEffect(() => {
         // We use the header as it's an element preserved between page transitions
@@ -28,7 +29,15 @@ export function PreservePageLayout(props: { siteWidthWide: boolean }) {
         } else {
             header.classList.remove('site-width-wide');
         }
-    }, [siteWidthWide]);
+
+        if (pageHasToc) {
+            header.classList.add('page-has-toc');
+            header.classList.remove('page-no-toc');
+        } else {
+            header.classList.add('page-no-toc');
+            header.classList.remove('page-has-toc');
+        }
+    }, [siteWidthWide, pageHasToc]);
 
     return null;
 }


### PR DESCRIPTION
Slack: https://gitbook.slack.com/archives/C01NXGWJELS/p1769021898721909

This should fix the logo resizing likely caused by using the tailwind variant `lg:site-header-none:page-no-toc:max-w-56` that relies on a `:has()` selector looking for `.page-no-toc` class. 
- yhis class lives on the <main> element which gets replaced during Next.js client-side navigation.
- during the transition, the old <main> is removed before the new one is mounted, causing a timing gap where :has(.page-no-toc) returns false.
- since the <header> (with the logo) is preserved across navigations, it temporarily loses access to the page state and reverts to default sizing.

We already have a similar fix for the same problem in `site-width-wide`, so this pr follows the same pattern by extending PreservePageLayout component to also sync the page-no-toc/page-has-toc class to the <header> element (which persists across navigations), in turn ensuring the Tailwind variant selector always has access to the correct page state during transitions.

### Demo

Before:
Logo shows in 3 different sizes:
<img width="3022" height="1652" alt="CleanShot 2026-01-21 at 20 17 56 2@2x" src="https://github.com/user-attachments/assets/c13c6022-f72d-412e-a742-262b390fc05e" />

<img width="3020" height="1648" alt="CleanShot 2026-01-21 at 20 17 10@2x" src="https://github.com/user-attachments/assets/12c02f8c-d295-4c43-800a-5650d34e8067" />

<img width="3024" height="1648" alt="CleanShot 2026-01-21 at 20 17 35@2x" src="https://github.com/user-attachments/assets/a160b194-6b61-4ed1-8a21-e9b023decb35" />

After (couldnt repro it anymore with the current branch, despite it being easy to repro in prod)

https://github.com/user-attachments/assets/68a0093e-c508-49ad-8c3a-34843705e38b

