### PR TITLE
Limit MAX_DPR to 3 in Image component

### DIFF
--- a/packages/gitbook/src/components/utils/Image.tsx
+++ b/packages/gitbook/src/components/utils/Image.tsx
@@ -37,7 +37,7 @@ export type ImageResponsiveSize = {
  * Maximum device pixel ratio (DPR) to generate in srcSet.
  * Limit to 3 to align with routes/image.ts
  */
-const MAX_DPR = 2;
+const MAX_DPR = 3;
 
 interface ImageCommonProps {
     /**


### PR DESCRIPTION
Reduces the maximum device pixel ratio (DPR) from 4 to 3 in the Image component to align with the configuration in routes/image.ts.