### PR TITLE
Fix: Accessible name mismatch for AI Chat button

### DIFF
--- a/packages/gitbook/src/components/AIChat/AIChatButton.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatButton.tsx
@@ -27,7 +27,8 @@ export function AIChatButton(props: {
             iconOnly={!showLabel || isMobile}
             size="medium"
             variant="header"
-            label={
+            ariaLabel={t(language, 'ai_chat_ask', assistant.label)} // Explicit accessible name string
+            label={ // This 'label' prop is now primarily for the Tooltip content
                 <div className="flex items-center gap-2">
                     {t(language, 'ai_chat_ask', assistant.label)}
                     {withShortcut ? (


### PR DESCRIPTION
## Summary

This PR fixes an accessibility violation on [website doc page](https://gitbook.com/docs/) where the accessible name of the AI Chat button did not match its visible label, as reported by the IBM Equal Access Accessibility Checker.

<img width="2560" height="922" alt="image" src="https://github.com/user-attachments/assets/c5a61c7a-4d3c-4a06-b3f9-51a379b7e25d" />

The issue occurred because the button’s accessible name was implicitly derived from a non-string label prop (a JSX node), which resulted in an incorrect or opaque accessible name (e.g. `[object Object]`). This caused screen readers and a11y tools to report a mismatch between the visible label and the accessible name.

## Solution

Explicitly set a string-based accessible name using the `ariaLabel` prop.

Keep the existing `label` prop for tooltip / visual rendering only.

```diff
<Button
  iconOnly={!showLabel || isMobile}
  size="medium"
  variant="header"
- label={
+ ariaLabel={t(language, 'ai_chat_ask', assistant.label)} // Explicit accessible name string
+ label={ // Used for tooltip / visual content
    <div className="flex items-center gap-2">
      {t(language, 'ai_chat_ask', assistant.label)}
      {withShortcut ? (
```

**This ensures:**

- The accessible name is always a plain string
- It matches the visible label text
- Screen readers and automated checkers can correctly interpret the control

## Testing
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications.  The generated fixes were manually reviewed and validated before submission.

The fix has been manually verified in the following locales:

✅ English
✅ Chinese
✅ French
<img width="1178" height="201" alt="image" src="https://github.com/user-attachments/assets/8e5673a8-d49d-4712-a203-ac8dbb0f1dc3" />

<img width="1205" height="224" alt="image" src="https://github.com/user-attachments/assets/f02fdec4-c31a-4315-b860-7e0d232a1dfe" />

<img width="1280" height="287" alt="image" src="https://github.com/user-attachments/assets/edf7be16-b626-4540-8455-b5764049765e" />

