### PR TITLE
Fix: Accessible name mismatch for AI Chat button

### DIFF
--- a/.changeset/clean-turtles-wonder.md
+++ b/.changeset/clean-turtles-wonder.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix: Accessible name mismatch for AI Chat button

--- a/packages/gitbook/src/components/AIChat/AIChatButton.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatButton.tsx
@@ -27,7 +27,7 @@ export function AIChatButton(props: {
             iconOnly={!showLabel || isMobile}
             size="medium"
             variant="header"
-            aria-label={t(language, 'ai_chat_ask', assistant.label)}
+            aria-label={tString(language, 'ai_chat_ask', assistant.label)}
             label={
                 <div className="flex items-center gap-2">
                     {t(language, 'ai_chat_ask', assistant.label)}


### PR DESCRIPTION
## Summary

This PR fixes an accessibility violation on [website doc page](https://gitbook.com/docs/) where the accessible name of the AI Chat button did not match its visible label, as reported by the IBM Equal Access Accessibility Checker.

<img width="2560" height="922" alt="image" src="https://github.com/user-attachments/assets/c5a61c7a-4d3c-4a06-b3f9-51a379b7e25d" />

The issue occurred because the button’s accessible name was implicitly derived from a non-string label prop (a JSX node), which resulted in an incorrect or opaque accessible name (e.g. `[object Object]`). This caused screen readers and a11y tools to report a mismatch between the visible label and the accessible name.

## Solution

Explicitly set a string-based accessible name using the `aria-label` prop.

Keep the existing `label` prop for tooltip / visual rendering only.

```diff
<Button
  iconOnly={!showLabel || isMobile}
  size="medium"
  variant="header"
  label={
+ aria-label={t(language, 'ai_chat_ask', assistant.label)} // Explicit accessible name string
    <div className="flex items-center gap-2">
      {t(language, 'ai_chat_ask', assistant.label)}
      {withShortcut ? (
```

**This ensures:**

- The accessible name is always a plain string
- It matches the visible label text
- Screen readers and automated checkers can correctly interpret the control

## Testing
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications.  The generated fixes were manually reviewed and validated before submission.

The fix has been manually verified in the following locales:

✅ English
✅ Chinese
✅ French
<img width="1147" height="219" alt="image" src="https://github.com/user-attachments/assets/bb400e26-e82a-453d-b21f-bd65996dd0f7" />
<img width="1153" height="267" alt="image" src="https://github.com/user-attachments/assets/83cf79d6-c370-499f-9d34-7f7edcd8b2f5" />
<img width="1243" height="272" alt="image" src="https://github.com/user-attachments/assets/23611a41-ca30-4ef6-82a5-b3cf4a0ffc03" />
