### PR TITLE
Fix search field clear button

### DIFF
--- a/packages/gitbook/src/components/Search/SearchInput.tsx
+++ b/packages/gitbook/src/components/Search/SearchInput.tsx
@@ -68,9 +68,7 @@ export const SearchInput = React.forwardRef<HTMLDivElement, SearchInputProps>(
                             className="size-text-lg shrink-0 text-tint theme-bold:text-header-link/8"
                         />
                     }
-                    onChange={(event) => {
-                        onChange(event.target.value);
-                    }}
+                    onValueChange={onChange}
                     value={value}
                     maxLength={512}
                     autoComplete="off"


### PR DESCRIPTION
If the input has controls like a clear button, the only way to do it cleanly is to pass a `onValueChange` that can be used to control the value because `onChange` is too low level.