### PR TITLE
Fix rendering of Expandables within Update blocks

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Update.tsx
+++ b/packages/gitbook/src/components/DocumentView/Update.tsx
@@ -60,8 +60,7 @@ export function Update(props: BlockProps<DocumentBlockUpdate>) {
                 {...contextProps}
                 nodes={block.nodes}
                 ancestorBlocks={[...ancestorBlocks, block]}
-                // Remove padding-top from headings when they're the first child (similar to column-first-of-type pattern)
-                style="[&>*:first-child]:!pt-0 flex-1 space-y-4"
+                style="[&>*:first-child]:!pt-0 flex flex-1 flex-col [&>*+*]:mt-5"
             />
         </div>
     );


### PR DESCRIPTION
The issue was that expandables inside Update blocks had gaps between them, while they are supposed to 'snap' together.

Root cause: Update.tsx was using space-y-4 for spacing, which sets both margin-top AND margin-bottom (via CSS variables). This interfered with the expandable's built-in margin-bottom selectors in Details.tsx.

Solution: Changed Update.tsx to use the same spacing approach as PageBody.tsx:

Before: `space-y-4` (sets both margin-top and margin-bottom)
After: `[&>*+*]:mt-5` (only sets margin-top)

This allows the expandable's self-contained spacing logic (mt-0! to override parent margin, [&:not(:has(+_&))]:mb-5 for last-in-group margin) to work correctly - just like it already does at the page level.

closes https://linear.app/gitbook-x/issue/RND-8681/expandable-blocks-rendering-is-off-inside-of-new-updates-block

After:

<img width="1898" height="1268" alt="CleanShot 2026-01-27 at 17 18 19@2x" src="https://github.com/user-attachments/assets/c6f0242c-75bc-414c-a7f7-9b61b42f50f0" />

<img width="2096" height="930" alt="CleanShot 2026-01-27 at 17 25 12@2x" src="https://github.com/user-attachments/assets/85dbaafa-2e75-46cf-99a1-4e0ea6fc46d8" />
