### PR TITLE
Make the button icon validation safer

### DIFF
--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -144,22 +144,21 @@ export const Button = React.forwardRef<
         };
         let iconElement = null;
         if (icon) {
-            if (React.isValidElement(icon)) {
-                type IconElement = React.ReactElement<React.SVGProps<SVGSVGElement>>;
-                iconElement = React.cloneElement(icon as IconElement, {
-                    className: tcls(
-                        'button-leading-icon shrink-0',
-                        iconSizeClasses[size],
-                        (icon as IconElement).props.className
-                    ),
-                });
-            } else {
+            if (typeof icon === 'string') {
                 iconElement = (
                     <Icon
                         icon={icon as IconName}
                         className={tcls('button-leading-icon shrink-0', iconSizeClasses[size])}
                     />
                 );
+            } else if (React.isValidElement<React.SVGProps<SVGSVGElement>>(icon)) {
+                iconElement = React.cloneElement(icon, {
+                    className: tcls(
+                        'button-leading-icon shrink-0',
+                        iconSizeClasses[size],
+                        icon.props.className
+                    ),
+                });
             }
         }
 


### PR DESCRIPTION
I think Next.js sometimes doesn't recognize the element as valid (not sure why) so we end up with that. In that case it's better to not show any icon than a broken one.