### PR TITLE
Header & TOC styling tweaks

### DIFF
--- a/.changeset/late-emus-jog.md
+++ b/.changeset/late-emus-jog.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Header & TOC tweaks

--- a/packages/gitbook/src/components/Header/HeaderLink.tsx
+++ b/packages/gitbook/src/components/Header/HeaderLink.tsx
@@ -115,13 +115,6 @@ function HeaderItemButton(
             href={href}
             variant={variant}
             size="medium"
-            className={tcls(
-                {
-                    'button-primary':
-                        'theme-bold:bg-header-link theme-bold:text-header-background theme-bold:shadow-none hover:theme-bold:bg-header-link hover:theme-bold:text-header-background hover:theme-bold:shadow-none',
-                    'button-secondary': '',
-                }[linkStyle]
-            )}
             insights={{
                 type: 'link_click',
                 link: {

--- a/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
@@ -27,7 +27,7 @@ export function PageGroupItem(props: { page: ClientTOCPageGroup; isFirst?: boole
                     '[html.sidebar-filled.theme-bold.tint_&]:bg-tint-base',
                     'lg:[html.sidebar-default.theme-gradient_&]:bg-gradient-primary',
                     'lg:[html.sidebar-default.theme-gradient.tint_&]:bg-gradient-tint',
-                    isFirst ? '-mt-4' : ''
+                    isFirst ? '-mt-2 -top-2 rounded-t-2xl pt-2' : ''
                 )}
             >
                 <TOCPageIcon page={page} />

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -70,12 +70,12 @@ export const variantClasses = {
         'bg-tint-base text-tint',
         'hover:theme-clean:bg-tint-subtle',
 
-        'theme-bold:bg-header-link/2',
+        'theme-bold:bg-header-link/1',
         'theme-bold:text-header-link',
         'theme-bold:shadow-none!',
         'theme-bold:border-header-link/4',
 
-        'hover:theme-bold:bg-header-link/3',
+        'hover:theme-bold:bg-header-link/2',
         'hover:theme-bold:text-header-link',
         'hover:theme-bold:shadow-none',
         'hover:theme-bold:border-header-link/5',


### PR DESCRIPTION
- Round the corners of TOC items so they don't show outside of the container on circular corner-sites
- Fix broken primary header buttons on bold themes
- Style header buttons on bold themes more in line with the search input on bold themes

# Before
<img width="3186" height="588" alt="CleanShot 2026-01-30 at 11 31 56@2x" src="https://github.com/user-attachments/assets/ec63a6c0-e065-414e-9603-763f70f41300" />

# After
<img width="3188" height="590" alt="CleanShot 2026-01-30 at 11 31 58@2x" src="https://github.com/user-attachments/assets/d7a7f0ee-8f9f-4301-9018-76f6132ce935" />
