### PR TITLE
Fix flaky Updates blocks in visual tests

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Update.tsx
+++ b/packages/gitbook/src/components/DocumentView/Update.tsx
@@ -44,8 +44,8 @@ export function Update(props: BlockProps<DocumentBlockUpdate>) {
         >
             <div
                 className={tcls(
-                    // Date is only sticky on larger screens when we use flex-row layout
-                    'h-fit w-40 min-w-40 shrink-0 md:sticky md:top-[calc(var(--toc-top-offset)+8px)]!'
+                    // Date is only sticky on larger screens when we use flex-row layout, with 0px fallback to prevent flicker and flaky tests before JS sets the variable
+                    'h-fit w-40 min-w-40 shrink-0 md:sticky md:top-[calc(var(--toc-top-offset,0px)+8px)]!'
                 )}
             >
                 <time


### PR DESCRIPTION
Fixes flaky Update blocks in e2e tests, like this one: https://app.argos-ci.com/GitbookIO/gitbook/builds/19369/249245745

The sticky date positioning in the Updates block relies on --toc-top-offset, a CSS variable set by JavaScript after hydration. Without a fallback value, screenshots taken before JS execution would show dates in different positions than after, causing inconsistent visual diffs in Argos. Adding 0px as the fallback ensures consistent rendering regardless of JS timing.

closes https://linear.app/gitbook-x/issue/RND-9528/flaky-display-issue-on-update-block