### PR TITLE
Handle empty page section search results

### DIFF
--- a/packages/gitbook/src/components/Search/server-actions.tsx
+++ b/packages/gitbook/src/components/Search/server-actions.tsx
@@ -388,17 +388,19 @@ async function transformSitePageResult(
     };
 
     const pageSections = await Promise.all(
-        pageItem.sections?.map<Promise<ComputedSectionResult>>(async (section) => ({
-            type: 'section',
-            id: `${page.id}/${section.id}`,
-            title: section.title,
-            href: spaceURL
-                ? linker.toLinkForContent(joinPathWithBaseURL(spaceURL, section.path))
-                : linker.toPathInSpace(pageItem.path),
-            body: section.body,
-            pageId: pageItem.id,
-            spaceId: spaceItem.id,
-        })) ?? []
+        pageItem.sections
+            ?.filter((section) => section.title || section.body)
+            .map<Promise<ComputedSectionResult>>(async (section) => ({
+                type: 'section',
+                id: `${page.id}/${section.id}`,
+                title: section.title,
+                href: spaceURL
+                    ? linker.toLinkForContent(joinPathWithBaseURL(spaceURL, section.path))
+                    : linker.toPathInSpace(pageItem.path),
+                body: section.body,
+                pageId: pageItem.id,
+                spaceId: spaceItem.id,
+            })) ?? []
     );
 
     return [page, ...pageSections];


### PR DESCRIPTION
In some cases a page doesn't contain indexable content for search to display, but still has a title match. In these cases we should show only the page result instead of a page + section result.

This PR improves the handling of search results that don't have a body nor a title to show.