### PR TITLE
Add margin to TOC items after page group

### DIFF
--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -12,7 +12,7 @@ export function PageDocumentItem(props: { page: ClientTOCPageDocument }) {
     const { page } = props;
 
     return (
-        <li className="flex flex-col">
+        <li className="page-document-item flex flex-col [.page-group-item+&]:mt-4">
             <ToggleableLinkItem
                 href={page.href ?? '#'}
                 pathnames={page.pathnames}

--- a/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
@@ -11,7 +11,7 @@ export function PageGroupItem(props: { page: ClientTOCPageGroup; isFirst?: boole
     const { page, isFirst } = props;
 
     return (
-        <li className="flex flex-col">
+        <li className="page-group-item flex flex-col">
             <div
                 className={tcls(
                     '-top-4 sticky z-1 flex items-center gap-3 px-3',

--- a/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
@@ -15,7 +15,7 @@ export function PageLinkItem(props: { page: ClientTOCPageLink }) {
     const isExternal = page.target.kind === 'url';
 
     return (
-        <li className={tcls('flex', 'flex-col')}>
+        <li className="page-link-item flex flex-col [.page-group-item+&]:mt-4">
             <Link
                 href={page.href ?? '#'}
                 classNames={['ToggleableLinkItemStyles']}


### PR DESCRIPTION
TOC items that follow on a page group are visually connected to them, which causes semantic confusion. This adds a bit of margin to any item following a page group.