### PR TITLE
Fix unexpected error thrown when using the embed in standalone mode

### DIFF
--- a/.changeset/giant-views-move.md
+++ b/.changeset/giant-views-move.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/embed": patch
+---
+
+Fix unexpected error thrown when using the embed in standalone mode

--- a/packages/embed/src/standalone/index.ts
+++ b/packages/embed/src/standalone/index.ts
@@ -193,5 +193,3 @@ const precalls = (window.GitBook as GitBookStandalone | undefined)?.q ?? [];
 // @ts-expect-error - GitBook is not defined in the global scope
 window.GitBook = GitBook;
 precalls.forEach((call) => GitBook(...call));
-
-GitBook('configure', {});


### PR DESCRIPTION
The `GitBook(configure, {})` was potentially called before initialization
