### PR TITLE
Fix links handling in embedded Assistant

### DIFF
--- a/packages/gitbook/src/components/Embeddable/EmbeddableAIChat.tsx
+++ b/packages/gitbook/src/components/Embeddable/EmbeddableAIChat.tsx
@@ -10,8 +10,9 @@ import {
 } from '@/components/AIChat';
 import { useLanguage } from '@/intl/client';
 import * as api from '@gitbook/api';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTrackEvent } from '../Insights';
+import { LinkContext, type LinkContextType } from '../primitives';
 import {
     EmbeddableFrame,
     EmbeddableFrameBody,
@@ -63,6 +64,14 @@ export function EmbeddableAIChat(props: EmbeddableAIChatProps) {
     }, [trackEvent]);
 
     const tabsRef = React.useRef<HTMLDivElement>(null);
+    const hasDocsTab = configuration.tabs.includes('docs');
+    const linkContext: LinkContextType = useMemo(
+        () =>
+            hasDocsTab
+                ? { externalTarget: '_blank' }
+                : { isExternal: () => true, externalTarget: '_blank' },
+        [hasDocsTab]
+    );
 
     return (
         <EmbeddableFrame>
@@ -94,12 +103,14 @@ export function EmbeddableAIChat(props: EmbeddableAIChatProps) {
                     </EmbeddableFrameButtons>
                 </EmbeddableFrameHeader>
                 <EmbeddableFrameBody>
-                    <AIChatBody
-                        chatController={chatController}
-                        chat={chat}
-                        suggestions={configuration.suggestions}
-                        greeting={configuration.greeting}
-                    />
+                    <LinkContext value={linkContext}>
+                        <AIChatBody
+                            chatController={chatController}
+                            chat={chat}
+                            suggestions={configuration.suggestions}
+                            greeting={configuration.greeting}
+                        />
+                    </LinkContext>
                 </EmbeddableFrameBody>
             </EmbeddableFrameMain>
         </EmbeddableFrame>

--- a/packages/gitbook/src/components/SiteLayout/SiteLayoutClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/SiteLayoutClientContexts.tsx
@@ -4,9 +4,10 @@ import type { CustomizationThemeMode, SiteExternalLinksTarget } from '@gitbook/a
 import { ThemeProvider } from 'next-themes';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 import type React from 'react';
+import { useMemo } from 'react';
 import { SearchContextProvider } from '../Search';
 import { useClearRouterCache } from '../hooks/useClearRouterCache';
-import { LinkSettingsContext } from '../primitives';
+import { LinkContext, type LinkContextType } from '../primitives';
 
 /**
  * Client component context providers for the site layout.
@@ -21,6 +22,15 @@ export function SiteLayoutClientContexts(props: {
 
     useClearRouterCache(contextId);
 
+    const linkContext: LinkContextType = useMemo(
+        () => ({
+            externalTarget: { self: '_self' as const, blank: '_blank' as const }[
+                externalLinksTarget
+            ],
+        }),
+        [externalLinksTarget]
+    );
+
     return (
         <ThemeProvider
             attribute="class"
@@ -29,9 +39,9 @@ export function SiteLayoutClientContexts(props: {
             forcedTheme={forcedTheme}
         >
             <NuqsAdapter>
-                <LinkSettingsContext.Provider value={{ externalLinksTarget }}>
+                <LinkContext.Provider value={linkContext}>
                     <SearchContextProvider>{children}</SearchContextProvider>
-                </LinkSettingsContext.Provider>
+                </LinkContext.Provider>
             </NuqsAdapter>
         </ThemeProvider>
     );


### PR DESCRIPTION
Several things here:

- If the docs tab is omitted, all links are considered as external
- Fix external links pointing to the agent by switching the href
- Prepare the ground to use the proxy config to detect external links (still using the origin)