### PR TITLE
Fix followup & suggested questions overflow

### DIFF
--- a/packages/gitbook/src/components/AIChat/AIChatSuggestedQuestions.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatSuggestedQuestions.tsx
@@ -20,11 +20,12 @@ export default function AIChatSuggestedQuestions(props: {
 
     return (
         <div
-            className="flex flex-col items-start gap-2 self-start"
+            className="flex max-w-full max-w-full flex-col items-start gap-2 self-start"
             data-testid="ai-chat-suggested-questions"
         >
             {suggestions.map((question, index) => (
                 <Button
+                    truncate={false}
                     data-testid="ai-chat-suggested-question"
                     key={question}
                     variant="blank"

--- a/packages/gitbook/src/components/AIChat/AiChatFollowupSuggestions.tsx
+++ b/packages/gitbook/src/components/AIChat/AiChatFollowupSuggestions.tsx
@@ -17,18 +17,19 @@ export function AIChatFollowupSuggestions(props: {
     return (
         <div className="flex grow flex-col">
             <div
-                className="sticky bottom-0 mt-auto flex flex-col items-start gap-2"
+                className="sticky bottom-0 mt-auto flex max-w-full flex-col items-start gap-2"
                 data-testid="ai-chat-followup-suggestions"
             >
                 {chat.followUpSuggestions.map((suggestion, index) => (
                     <Button
+                        truncate={false}
                         data-testid="ai-chat-followup-suggestion"
                         key={index}
                         onClick={() => {
                             chatController.postMessage({ message: suggestion });
                         }}
                         label={suggestion}
-                        className="starting:h-0 max-w-full origin-left animate-blur-in-slow whitespace-normal border-none bg-primary-11/1 starting:py-0 text-left transition-all transition-discrete duration-500 *:whitespace-normal hover:bg-primary-hover"
+                        className="starting:h-0 max-w-full origin-left animate-blur-in-slow border-none bg-primary-11/1 starting:py-0 text-left transition-all transition-discrete duration-500 hover:bg-primary-hover"
                         size="small"
                         variant="blank"
                         style={{

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -21,6 +21,7 @@ export type ButtonProps = {
     children?: React.ReactNode;
     active?: boolean;
     tooltipProps?: TooltipProps;
+    truncate?: boolean;
 } & LinkInsightsProps &
     React.HTMLAttributes<HTMLElement>;
 
@@ -115,6 +116,7 @@ export const Button = React.forwardRef<
             trailing,
             disabled,
             tooltipProps,
+            truncate = true,
             ...rest
         },
         ref
@@ -166,7 +168,14 @@ export const Button = React.forwardRef<
             <>
                 {iconElement}
                 {iconOnly || (!children && !label) ? null : (
-                    <span className="button-content truncate">{children ?? label}</span>
+                    <span
+                        className={tcls(
+                            'button-content',
+                            truncate ? 'truncate' : 'whitespace-normal text-start'
+                        )}
+                    >
+                        {children ?? label}
+                    </span>
                 )}
             </>
         );


### PR DESCRIPTION
Before → After

<img width="776" height="714" alt="CleanShot 2026-02-12 at 13 20 13@2x" src="https://github.com/user-attachments/assets/4bb9c4fb-8291-4d12-8d3c-ffbb00806b7d" />

<img width="776" height="714" alt="CleanShot 2026-02-12 at 13 20 09@2x" src="https://github.com/user-attachments/assets/4ee19fad-267d-4b86-b149-08bbabdbf8ad" />
