### PR TITLE
Fix regression showing page actions on page without title + description

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Updates.tsx
+++ b/packages/gitbook/src/components/DocumentView/Updates.tsx
@@ -10,7 +10,7 @@ export function Updates(props: BlockProps<DocumentBlockUpdates>) {
             {...contextProps}
             nodes={block.nodes}
             ancestorBlocks={[...ancestorBlocks, block]}
-            style={[style, 'flex flex-col gap-20']}
+            style={[style, 'updates-block flex flex-col gap-20']}
         />
     );
 }

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -32,17 +32,19 @@ export async function PageHeader(props: {
         withRSSFeed,
     ].some(Boolean);
 
-    /* When title and description are hidden, only display the page actions if there are any. */
+    // When title and description are hidden,
+    // only display the page actions if the page contains an update block.
     if (!page.layout.title && !page.layout.description) {
         if (!hasPageActions) {
             return null;
         }
+
         return (
             <PageActionsDropdown
                 siteTitle={context.site.title}
                 urls={getPageActionsURLs({ context, page, withRSSFeed })}
                 actions={context.customization.pageActions}
-                className="absolute top-8 right-0"
+                className="absolute top-8 right-0 page-updates-block:flex hidden"
             />
         );
     }

--- a/packages/gitbook/tailwind.config.ts
+++ b/packages/gitbook/tailwind.config.ts
@@ -678,6 +678,11 @@ const config: Config = {
             addVariant('page-api-block', 'body:has(.openapi-block) &');
 
             /**
+             * Variant when the page contains an Updates block.
+             */
+            addVariant('page-updates-block', 'body:has(.updates-block) &');
+
+            /**
              * Variant when the page is displayed in print mode.
              */
             addVariant('print-mode', 'body:has(.print-mode) &');


### PR DESCRIPTION
We only show it if the page contains an update block.

Note that it is a temporary solution to mitigate the problem but we should be more explicit in settings about that behaviour.
