### PR TITLE
Allow to pass a token to the embed script

### DIFF
--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/script.js/route.ts
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/script.js/route.ts
@@ -25,15 +25,16 @@ export async function GET(
   const w = window;
   const gb = w.GitBook;
 
-  function getScriptToken() {
+  function getScriptSearchParams() {
     const script = document.currentScript;
-    if (!script) {
-      return null;
-    }
-    return script.getAttribute('data-jwt-token');
+    if (!script) return new URLSearchParams();
+
+    const url = new URL(script.src);
+    return url.searchParams;
   }
 
-  const token = getScriptToken()
+  const searchParams = getScriptSearchParams()
+  const token = searchParams.get('jwt_token');
   const initOptions = window.gitbookSettings || ${JSON.stringify(initOptions)};
   const initFrameOptions = token ? { visitor: { token } } : undefined;
 


### PR DESCRIPTION
Also linked to https://app.gitbook.com/o/d8f63b60-89ae-11e7-8574-5927d48c4877/s/NkEGS7hzeqa35sMXQZ4X/~/changes/947/publishing-documentation/embedding/implementation/script

~Why do we use a data attribute and not a query parameter? Because query parameters travels through networks, logs, etc. So using a data parameter is better for security.~

We need to use `?jwt_token` to access the site behind VA anyway.