### PR TITLE
fix(pdf): keep headings together across page breaks

### DIFF
--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -24,6 +24,7 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
             className={tcls(
                 textStyle.textSize,
                 'heading',
+                'pdf-heading',
                 'flex',
                 'items-baseline',
                 'scroll-mt-(--content-scroll-margin)',
@@ -32,6 +33,7 @@ export function Heading(props: BlockProps<DocumentBlockHeading>) {
                 style,
                 textStyle.marginTop
             )}
+            data-pdf-heading
         >
             <HashLinkButton
                 id={id}

--- a/packages/gitbook/src/components/PDF/pdf.css
+++ b/packages/gitbook/src/components/PDF/pdf.css
@@ -6,3 +6,53 @@
         content: counter(page);
     }
 }
+
+/* --- Print-safe rules: avoid cutting headings/step headings --- */
+@media print {
+    /* Ensure headings act like blocks in print and aren't split */
+    .pdf-heading,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        display: block !important;
+        break-inside: avoid !important;
+        page-break-inside: avoid !important;
+        -webkit-column-break-inside: avoid !important;
+        widows: 2;
+        orphans: 2;
+    }
+
+    /* Keep heading with the immediate following block */
+    .pdf-heading {
+        break-after: avoid !important;
+        page-break-after: avoid !important;
+        -webkit-column-break-after: avoid !important;
+    }
+
+    .pdf-heading + * {
+        break-before: avoid !important;
+        page-break-before: avoid !important;
+    }
+
+    /* Treat each step as its own printable block so headings in steps don't orphan */
+    .stepper-step,
+    .stepper .step,
+    .stepper-step__wrapper {
+        display: block !important;
+        break-inside: avoid !important;
+        page-break-inside: avoid !important;
+        -webkit-column-break-inside: avoid !important;
+        /* Small breathing room to avoid visible cutting when browser is tight */
+        padding-bottom: 6mm !important;
+    }
+
+    /* If the stepper was flex/grid on screen, simplify layout in print */
+    .stepper,
+    .Stepper,
+    .stepper-root {
+        display: block !important;
+    }
+}


### PR DESCRIPTION
### Motivation
- Headings (notably stepper step headings) were getting cut or orphaned at PDF page boundaries because on-screen flex/grid wrappers can cause browsers to ignore print `break-*` rules. The goal is to prevent visible heading splits with minimal, print-scoped changes.

### Description
- Add a stable print hook by appending `pdf-heading` to the heading class list and adding a `data-pdf-heading` attribute in `packages/gitbook/src/components/DocumentView/Heading.tsx` so print CSS/exporter heuristics can reliably target headings.
- Append a print-only ruleset to `packages/gitbook/src/components/PDF/pdf.css` that forces headings to act like blocks and avoid `break-inside`, prevents breaks immediately after a heading and before its next sibling, and applies stepper-specific `break-inside: avoid` and gentle `padding-bottom` to reduce orphaning.
- All changes are scoped to `@media print` and use non-visual hooks so on-screen rendering is unchanged.

### Testing
- Ran targeted formatter/linter on the modified TSX file with `bunx biome check --diagnostic-level=error packages/gitbook/src/components/DocumentView/Heading.tsx`, which completed successfully.
- A full repo format check (`bun run format:check`) surfaced unrelated formatting errors in other files (for example `packages/fonts/src/data/fonts.json`) and did not pass, so only targeted checks were used for validation.
- Attempted automated runtime validation with Playwright to capture a screenshot, but the local app was not reachable (`ERR_EMPTY_RESPONSE`), and an external web lookup (`curl` to MDN) returned `403`, so no runtime PDF export screenshot was produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69944f5ca620832a829c13662b8baf32)