### PR TITLE
Make OpenAPI Response structure clearer

### DIFF
--- a/.changeset/silly-paws-show.md
+++ b/.changeset/silly-paws-show.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/react-openapi": patch
+---
+
+Make OpenAPI Response structure clearer

--- a/packages/react-openapi/src/OpenAPIResponse.tsx
+++ b/packages/react-openapi/src/OpenAPIResponse.tsx
@@ -1,7 +1,7 @@
 import type { OpenAPIV3 } from '@gitbook/openapi-parser';
 import { OpenAPIDisclosure } from './OpenAPIDisclosure';
 import { OpenAPISchemaPresentation } from './OpenAPISchema';
-import { OpenAPISchemaProperties } from './OpenAPISchemaServer';
+import { OpenAPIRootSchema, OpenAPISchemaProperties } from './OpenAPISchemaServer';
 import type { OpenAPIClientContext } from './context';
 import { tString } from './translate';
 import { parameterToProperty, resolveDescription } from './utils';
@@ -64,17 +64,21 @@ export function OpenAPIResponse(props: {
             ) : null}
             {mediaType?.schema && (
                 <div className="openapi-responsebody">
-                    <OpenAPISchemaProperties
-                        id={`response-${context.blockKey}`}
-                        properties={[
-                            {
-                                schema: mediaType.schema,
-                                propertyName: tString(context.translation, 'response'),
-                                required: null,
-                            },
-                        ]}
-                        context={context}
-                    />
+                    {headers.length > 0 ? (
+                        <OpenAPISchemaProperties
+                            id={`response-${context.blockKey}`}
+                            properties={[
+                                {
+                                    schema: mediaType.schema,
+                                    propertyName: tString(context.translation, 'response'),
+                                    required: null,
+                                },
+                            ]}
+                            context={context}
+                        />
+                    ) : (
+                        <OpenAPIRootSchema schema={mediaType.schema} context={context} />
+                    )}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## BEFORE

<img width="1100" height="364" alt="CleanShot 2026-02-18 at 01 36 16@2x" src="https://github.com/user-attachments/assets/d93c2068-1459-4b57-a4dc-b0ddeb0edba1" />

## AFTER

Without headers: 
<img width="1110" height="646" alt="CleanShot 2026-02-18 at 01 36 06@2x" src="https://github.com/user-attachments/assets/09b47806-697f-4f42-af35-2a56b5875a5d" />

With headers:
<img width="1066" height="488" alt="CleanShot 2026-02-18 at 01 37 04@2x" src="https://github.com/user-attachments/assets/0cef83f2-6a99-4c63-89b2-772fa3800346" />
