### PR TITLE
Fix issue where customizations stored in cookie is shared between different site previews

### DIFF
--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -28,6 +28,7 @@ import {
 import { serveResizedImage } from '@/routes/image';
 import { cookies } from 'next/headers';
 import type { SiteURLData } from './lib/context';
+import { getPreviewRequestIdentifier } from './lib/preview';
 import { serveProxyAnalyticsEvent } from './lib/tracking';
 export const config = {
     matcher: [
@@ -327,7 +328,9 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
                     httpOnly: true,
                     sameSite: 'lax',
                     maxAge: 10 * 60, // 10 minutes
-                    path: '/url/preview', // Only send the cookie to preview routes
+                    // Only send the cookie to preview routes and scope it to the specific site
+                    // to avoid conflicts between different sites previews potentially opened at the same time.
+                    path: `/url/preview/${getPreviewRequestIdentifier(siteRequestURL)}`,
                 },
             });
         }


### PR DESCRIPTION
This PR aims to fix an issue where customizations stored in cookie is shared between different site previews. This caused an issue in the app where a customization change in a site settings was applied to all sites preview in the All site screen. 