### PR TITLE
Improve search breadcrumbs

### DIFF
--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -2,6 +2,7 @@ import { tString, useLanguage } from '@/intl/client';
 import { tcls } from '@/lib/tailwind';
 import { Icon, type IconName } from '@gitbook/icons';
 import React from 'react';
+import { Tooltip } from '../primitives';
 import { HighlightQuery } from './HighlightQuery';
 import { SearchResultItem } from './SearchResultItem';
 import type { ComputedPageResult } from './server-actions';
@@ -16,14 +17,6 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
 ) {
     const { query, item, active, ...rest } = props;
     const language = useLanguage();
-
-    const breadcrumbs =
-        item.breadcrumbs?.map((crumb) => (
-            <span key={crumb.label} className="flex items-center gap-1">
-                {crumb.icon ? <Icon className="size-3" icon={crumb.icon as IconName} /> : null}
-                {crumb.label}
-            </span>
-        )) ?? [];
 
     return (
         <SearchResultItem
@@ -44,49 +37,78 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
             aria-label={tString(language, 'search_page_result_title', item.title)}
             {...rest}
         >
-            {breadcrumbs.length > 0 ? (
-                <div
-                    className={tcls(
-                        'text-xs',
-                        'text-tint/7',
-                        'contrast-more:text-tint',
-                        'group-[.is-active]:text-tint',
-                        'transition-colors',
-                        'font-normal',
-                        'uppercase',
-                        'leading-snug',
-                        'mb-1',
-                        'flex',
-                        'flex-wrap',
-                        'gap-x-2',
-                        'gap-y-0',
-                        'items-center'
-                    )}
-                >
-                    {(breadcrumbs.length > 3
-                        ? [
-                              ...breadcrumbs.slice(0, 2),
-                              <Icon key="ellipsis" icon="ellipsis-h" className="size-3" />,
-                              ...breadcrumbs.slice(-1),
-                          ]
-                        : breadcrumbs
-                    ).map((crumb, index) => (
-                        <React.Fragment key={index}>
-                            {index !== 0 ? (
-                                <Icon
-                                    key={`${crumb.key}-icon`}
-                                    icon="chevron-right"
-                                    className="size-2"
-                                />
-                            ) : null}
-                            <span className="line-clamp-1">{crumb}</span>
-                        </React.Fragment>
-                    ))}
-                </div>
-            ) : null}
+            <Breadcrumbs breadcrumbs={item.breadcrumbs} />
             <p className="line-clamp-2 font-semibold text-base text-tint-strong leading-snug">
                 <HighlightQuery query={query} text={item.title} />
             </p>
         </SearchResultItem>
     );
 });
+
+const Breadcrumbs = (props: {
+    breadcrumbs: ComputedPageResult['breadcrumbs'];
+    withOverflow?: boolean;
+}) => {
+    const { breadcrumbs, withOverflow = (breadcrumbs?.length ?? 0) > 4 } = props;
+
+    if (!breadcrumbs || breadcrumbs.length === 0) return null;
+
+    const crumbs =
+        breadcrumbs?.map((crumb) => (
+            <span key={crumb.label} className="flex items-center gap-1">
+                {crumb.icon ? <Icon className="size-3" icon={crumb.icon as IconName} /> : null}
+                {crumb.label}
+            </span>
+        )) ?? [];
+
+    // Format breadcrumbs for display. Helper function to avoid code duplication across normal and in-tooltip display.
+    function formatCrumbs(crumbs: React.ReactElement[], className?: string) {
+        return (
+            <div
+                className={tcls(
+                    'transition-colors',
+                    'font-normal',
+                    'flex',
+                    'flex-wrap',
+                    'gap-x-2',
+                    'gap-y-0',
+                    'items-center',
+                    className
+                )}
+            >
+                {crumbs.map((crumb, index) => (
+                    <React.Fragment key={index}>
+                        {index !== 0 ? (
+                            <Icon
+                                key={`${crumb.key}-icon`}
+                                icon="chevron-right"
+                                className="size-2"
+                            />
+                        ) : null}
+                        <span className="line-clamp-1">{crumb}</span>
+                    </React.Fragment>
+                ))}
+            </div>
+        );
+    }
+
+    return formatCrumbs(
+        withOverflow
+            ? [
+                  ...crumbs.slice(0, 3),
+                  <Tooltip
+                      key="breadcrumbs-overflow"
+                      label={formatCrumbs(crumbs.slice(3, -1))}
+                      rootProps={{ delayDuration: 0 }}
+                      arrow
+                  >
+                      <span>
+                          <Icon key="ellipsis" icon="ellipsis-h" className="size-3" />
+                      </span>
+                  </Tooltip>,
+                  ...crumbs.slice(-1),
+              ]
+            : crumbs,
+        'text-tint/7 contrast-more:text-tint group-[.is-active]:text-tint mb-1 text-xs uppercase leading-snug'
+    );
+};


### PR DESCRIPTION
- Show 1 more breadcrumb by default
- Implement hoverable overflow ellipsis when >4 breadcrumbs are present
- Refactor breadcrumbs display into a local component

<img width="1250" height="1234" alt="CleanShot 2026-02-23 at 12 38 52@2x" src="https://github.com/user-attachments/assets/3bd45cea-1440-4283-90ed-5fddf83155e0" />
<img width="1084" height="414" alt="CleanShot 2026-02-23 at 12 25 00@2x" src="https://github.com/user-attachments/assets/487df2a1-36cb-404d-8764-94aad653f8d3" />
