### PR TITLE
fix: serve llms exports dynamically

### DIFF
--- a/.changeset/plenty-jars-collect.md
+++ b/.changeset/plenty-jars-collect.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+fix: serve llms exports dynamically

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/llms-full.txt/[page]/route.ts
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/llms-full.txt/[page]/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 import { type RouteLayoutParams, getStaticSiteContext } from '@/app/utils';
 import { serveLLMsFullTxt } from '@/routes/llms-full';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 
 export async function GET(
     _request: NextRequest,

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/llms-full.txt/route.ts
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/llms-full.txt/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 import { type RouteLayoutParams, getStaticSiteContext } from '@/app/utils';
 import { serveLLMsFullTxt } from '@/routes/llms-full';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 
 export async function GET(
     _request: NextRequest,

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/llms.txt/route.ts
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/llms.txt/route.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 import { type RouteLayoutParams, getStaticSiteContext } from '@/app/utils';
 import { serveLLMsTxt } from '@/routes/llms';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 
 export async function GET(
     _request: NextRequest,

--- a/packages/gitbook/src/routes/llms-route-config.test.ts
+++ b/packages/gitbook/src/routes/llms-route-config.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test';
+
+import * as llmsFullPageRoute from '@/app/sites/static/[mode]/[siteURL]/[siteData]/llms-full.txt/[page]/route';
+import * as llmsFullRoute from '@/app/sites/static/[mode]/[siteURL]/[siteData]/llms-full.txt/route';
+import * as llmsRoute from '@/app/sites/static/[mode]/[siteURL]/[siteData]/llms.txt/route';
+
+describe('llms route rendering strategy', () => {
+    it('renders llms.txt dynamically so new pages show up immediately', () => {
+        expect(llmsRoute.dynamic).toBe('force-dynamic');
+    });
+
+    it('renders llms-full.txt dynamically for fresh exports', () => {
+        expect(llmsFullRoute.dynamic).toBe('force-dynamic');
+        expect(llmsFullPageRoute.dynamic).toBe('force-dynamic');
+    });
+});


### PR DESCRIPTION
## Summary
- switch `llms.txt` and `llms-full.txt` routes from `force-static` to `force-dynamic`
- keep paginated `llms-full.txt/:page` exports dynamic as well
- add a regression test that locks the rendering strategy for these routes

## Why
Closes #3882. New pages were not appearing in `/llms.txt` and `/llms-full.txt` immediately because these routes were statically rendered. These exports are effectively live machine-readable indexes, so serving them dynamically keeps them aligned with the latest published content.

## Validation
- Added route config regression test for the llms export routes
- I could not run the Bun test suite in this environment because `bun` is not preinstalled here