### PR TITLE
fix: keep the last right-nav section highlighted

### DIFF
--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -9,9 +9,11 @@ import { useBodyLoaded } from '@/components/primitives';
 import { HEADER_HEIGHT_DESKTOP } from '../layout';
 
 /**
- * The threshold at which we consider a section as intersecting the viewport.
+ * Consider sections active as soon as they enter the reading viewport.
+ * The hook then picks the heading closest to the top, which fixes short final sections
+ * that cannot scroll high enough to reach a larger intersection ratio.
  */
-const SECTION_INTERSECTING_THRESHOLD = 0.9;
+const SECTION_INTERSECTING_THRESHOLD = 0;
 
 /**
  * The offset from the top of the page when scrolling to the active item.

--- a/packages/gitbook/src/components/hooks/useScrollActiveId.test.ts
+++ b/packages/gitbook/src/components/hooks/useScrollActiveId.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getActiveSectionId } from './useScrollActiveId';
+
+describe('getActiveSectionId', () => {
+    test('prefers the first visible section below the top of the viewport', () => {
+        const ids = ['intro', 'setup', 'features'];
+        const states = new Map([
+            ['intro', { isIntersecting: true, top: -120 }],
+            ['setup', { isIntersecting: true, top: 24 }],
+            ['features', { isIntersecting: true, top: 380 }],
+        ]);
+
+        expect(getActiveSectionId(ids, states)).toBe('setup');
+    });
+
+    test('falls back to the last visible section when all visible headings are above the top', () => {
+        const ids = ['intro', 'setup', 'features'];
+        const states = new Map([
+            ['intro', { isIntersecting: true, top: -320 }],
+            ['setup', { isIntersecting: true, top: -40 }],
+            ['features', { isIntersecting: false, top: 220 }],
+        ]);
+
+        expect(getActiveSectionId(ids, states)).toBe('setup');
+    });
+
+    test('keeps the last short section active when it is visible near the bottom', () => {
+        const ids = ['intro', 'details', 'key-features'];
+        const states = new Map([
+            ['intro', { isIntersecting: false, top: -640 }],
+            ['details', { isIntersecting: true, top: -180 }],
+            ['key-features', { isIntersecting: true, top: 410 }],
+        ]);
+
+        expect(getActiveSectionId(ids, states)).toBe('key-features');
+    });
+});

--- a/packages/gitbook/src/components/hooks/useScrollActiveId.ts
+++ b/packages/gitbook/src/components/hooks/useScrollActiveId.ts
@@ -1,5 +1,32 @@
 import React from 'react';
 
+type SectionIntersectionState = {
+    isIntersecting: boolean;
+    top: number;
+};
+
+export function getActiveSectionId(
+    ids: string[],
+    sectionStates: Map<string, SectionIntersectionState>
+) {
+    const visibleSections = ids
+        .map((id) => [id, sectionStates.get(id)] as const)
+        .filter((entry): entry is readonly [string, SectionIntersectionState] => {
+            return Boolean(entry[1]?.isIntersecting);
+        });
+
+    if (visibleSections.length === 0) {
+        return undefined;
+    }
+
+    const firstVisibleBelowTop = visibleSections.find(([, state]) => state.top >= 0);
+    if (firstVisibleBelowTop) {
+        return firstVisibleBelowTop[0];
+    }
+
+    return visibleSections[visibleSections.length - 1]?.[0];
+}
+
 /**
  * Get the current ID being scrolled in the page.
  */
@@ -16,7 +43,7 @@ export function useScrollActiveId(
     } = { enabled: true }
 ) {
     const [activeId, setActiveId] = React.useState<string>(ids[0]!);
-    const sectionsIntersectingMap = React.useRef<Map<string, boolean>>(new Map());
+    const sectionStatesRef = React.useRef<Map<string, SectionIntersectionState>>(new Map());
 
     React.useEffect(() => {
         const defaultActiveId = ids[0];
@@ -31,30 +58,20 @@ export function useScrollActiveId(
         }
 
         const onObserve: IntersectionObserverCallback = (entries) => {
-            /**
-             * We need to keep track of all the sections that are intersecting
-             * the viewport. This is because we want to find the first section
-             * that is visible on the viewport.
-             */
             entries.forEach((entry) => {
                 const sectionId = entry.target.id;
                 if (sectionId) {
-                    sectionsIntersectingMap.current.set(
-                        sectionId,
-                        entry.isIntersecting && entry.intersectionRatio >= threshold
-                    );
+                    sectionStatesRef.current.set(sectionId, {
+                        isIntersecting:
+                            entry.isIntersecting && entry.intersectionRatio >= threshold,
+                        top: entry.boundingClientRect.top,
+                    });
                 }
             });
 
-            /**
-             * Find the first section that is intersecting the viewport (is visible)
-             */
-            const firstActiveSection = Array.from(sectionsIntersectingMap.current.entries()).find(
-                ([, isIntersecting]) => isIntersecting
-            );
-
-            if (firstActiveSection) {
-                setActiveId(firstActiveSection[0]);
+            const nextActiveSection = getActiveSectionId(ids, sectionStatesRef.current);
+            if (nextActiveSection) {
+                setActiveId(nextActiveSection);
             }
         };
 


### PR DESCRIPTION
## Summary
- treat TOC sections as active as soon as they enter the reading viewport instead of waiting for a very high intersection ratio
- prefer the first visible heading below the top edge, with a fallback that keeps the last visible heading active when all visible headings are already above the top
- add regression coverage for the short-final-section case reported in #3895

## Testing
- Added `packages/gitbook/src/components/hooks/useScrollActiveId.test.ts`
- `bun test packages/gitbook/src/components/hooks/useScrollActiveId.test.ts --preload ./packages/gitbook/tests/preload-bun.ts` *(could not run here because `bun` is not installed in this environment)*
- Node smoke check for the new selection logic
