### PR TITLE
Refactor test setup for improved mock restoration

### DIFF
--- a/packages/gitbook/src/lib/openapi/proxy-token.test.ts
+++ b/packages/gitbook/src/lib/openapi/proxy-token.test.ts
@@ -2,7 +2,8 @@ import { afterAll, describe, expect, it, mock } from 'bun:test';
 
 afterAll(() => mock.restore());
 
-mock.module('@/lib/env/globals', () => ({ GITBOOK_SECRET: 'test-secret-key' }));
+const realGlobals = await import('@/lib/env/globals');
+mock.module('@/lib/env/globals', () => ({ ...realGlobals, GITBOOK_SECRET: 'test-secret-key' }));
 
 const { buildSignedProxyUrl, verifyProxyRequest } = await import('./proxy-token');
 

--- a/packages/gitbook/src/lib/openapi/proxy-token.test.ts
+++ b/packages/gitbook/src/lib/openapi/proxy-token.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { afterAll, describe, expect, it, mock } from 'bun:test';
+
+afterAll(() => mock.restore());
 
 mock.module('@/lib/env/globals', () => ({ GITBOOK_SECRET: 'test-secret-key' }));
 

--- a/packages/gitbook/src/routes/openapi-proxy.test.ts
+++ b/packages/gitbook/src/routes/openapi-proxy.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+afterAll(() => mock.restore());
 
 const mockDnsLookup = mock(() => Promise.resolve([{ address: '93.184.215.14', family: 4 }]));
 mock.module('node:dns/promises', () => ({ lookup: mockDnsLookup }));

--- a/packages/gitbook/src/routes/openapi-proxy.test.ts
+++ b/packages/gitbook/src/routes/openapi-proxy.test.ts
@@ -4,7 +4,8 @@ afterAll(() => mock.restore());
 
 const mockDnsLookup = mock(() => Promise.resolve([{ address: '93.184.215.14', family: 4 }]));
 mock.module('node:dns/promises', () => ({ lookup: mockDnsLookup }));
-mock.module('@/lib/env/globals', () => ({ GITBOOK_SECRET: 'test-secret-key' }));
+const realGlobals = await import('@/lib/env/globals');
+mock.module('@/lib/env/globals', () => ({ ...realGlobals, GITBOOK_SECRET: 'test-secret-key' }));
 
 import { NextRequest } from 'next/server';
 


### PR DESCRIPTION
Update test setup to use `afterAll` for restoring mocks, ensuring a cleaner and more efficient teardown process.