### PR TITLE
Fix HTML lang attribute not reflecting language variants

### DIFF
--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -23,7 +23,7 @@ import * as ReactDOM from 'react-dom';
 
 import { type FontData, getFontData } from '@/fonts';
 import { fontNotoColorEmoji, fonts } from '@/fonts/default';
-import { getSpaceLanguage, getSpaceLocale } from '@/intl/server';
+import { getContentLocale, getSpaceLanguage } from '@/intl/server';
 import { getAssetURL } from '@/lib/assets';
 import { tcls } from '@/lib/tailwind';
 
@@ -69,7 +69,7 @@ export async function CustomizationRootLayout(props: {
     const customization =
         'customization' in context ? context.customization : defaultCustomization();
 
-    const locale = getSpaceLocale(context);
+    const locale = getContentLocale(context);
     const language = getSpaceLanguage(context);
     const tintColor = getTintColor(customization);
     const mixColor = getTintMixColor(customization.styling.primaryColor, tintColor);

--- a/packages/gitbook/src/intl/server.ts
+++ b/packages/gitbook/src/intl/server.ts
@@ -8,6 +8,23 @@ type TranslationLocale = keyof typeof languages;
 export const DEFAULT_LOCALE = 'en' satisfies TranslationLocale;
 
 /**
+ * Get the locale to use for the HTML lang attribute.
+ * This returns the actual content language even if we don't have UI translations for it.
+ */
+export function getContentLocale(context: GitBookAnyContext): string {
+    if (context.locale) {
+        return context.locale;
+    }
+
+    const customization = 'site' in context ? context.customization : null;
+    if (customization) {
+        return customization.internationalization.locale;
+    }
+
+    return DEFAULT_LOCALE;
+}
+
+/**
  * Get the locale to use for a space.
  */
 export function getSpaceLocale(context: GitBookAnyContext): TranslationLocale {


### PR DESCRIPTION
Use the actual content language for the HTML lang attribute instead of the UI translation locale. Previously, languages without UI translations (e.g. Polish) would always show lang="en".