### PR TITLE
Show variants in fully hidden sections

### DIFF
--- a/.changeset/ninety-schools-rescue.md
+++ b/.changeset/ninety-schools-rescue.md
@@ -1,0 +1,5 @@
+---
+"gitbook": minor
+---
+
+Support variant selector in hidden section

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "gitbook",

--- a/packages/gitbook/src/components/SpaceLayout/categorizeVariants.ts
+++ b/packages/gitbook/src/components/SpaceLayout/categorizeVariants.ts
@@ -6,7 +6,13 @@ import { getSiteSpaceLanguages, normalizeLanguage } from '@/lib/sites';
  * Categorize the variants of the space into generic and translation variants.
  */
 export function categorizeVariants(context: GitBookSiteContext) {
-    const { siteSpace, visibleSiteSpaces: siteSpaces } = context;
+    const { siteSpace } = context;
+
+    // By default, variants only include visible spaces.
+    // If all variants in the current section are hidden, we still show the selector in-place
+    // by falling back to all section variants.
+    const siteSpaces =
+        context.visibleSiteSpaces.length > 0 ? context.visibleSiteSpaces : context.siteSpaces;
 
     const currentLanguage = normalizeLanguage(context.locale);
 


### PR DESCRIPTION
This PR allows fully hidden sections (Section + Variants all hidden) to show the variant selector. 

The idea is that you’re able to hide a Space with variants that needs to be supported as a section, while still showing the variant selector when navigating to it.

## Before
Space with variant is hidden from section/navigation, but the variant selector is also hidden

<img width="3004" height="1652" alt="CleanShot 2026-04-20 at 15 14 08@2x" src="https://github.com/user-attachments/assets/9f0ab21c-935c-4760-8b4f-9faebea024ed" />

## After
Space with variant is hidden from section/navigation, but variant selector is showing

<img width="3008" height="1646" alt="CleanShot 2026-04-20 at 15 14 21@2x" src="https://github.com/user-attachments/assets/5f9469c0-da12-45b8-b5e9-7ec639c2be9f" />

