### PR TITLE
Support marks colors for text and background

### DIFF
--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -876,6 +876,7 @@ const testCases: TestsCase[] = [
     {
         name: 'Content tests',
         contentBaseURL: 'https://gitbook.gitbook.io/test-gitbook-open/',
+        fullPage: true,
         tests: [
             {
                 name: 'Text',

--- a/packages/gitbook/e2e/util.ts
+++ b/packages/gitbook/e2e/util.ts
@@ -75,6 +75,10 @@ export type TestsCase = {
     skip?: boolean;
     tests: Array<Test>;
     contentBaseURL?: string;
+    /**
+     * Whether screenshots in this test case should capture the full scrollable page by default.
+     */
+    fullPage?: boolean;
 };
 
 export const allLocales: CustomizationLocale[] = [
@@ -240,9 +244,9 @@ export function runTestCases(testCases: TestsCase[]) {
                             .intercom-lightweight-app {
                                 display: none !important;
                             }
-                            `,
+                                `,
                                 threshold: screenshotOptions?.threshold ?? undefined,
-                                fullPage: testEntry.fullPage ?? false,
+                                fullPage: testEntry.fullPage ?? testCase.fullPage ?? false,
                                 beforeScreenshot: async ({ runStabilization }) => {
                                     await runStabilization();
                                     if (screenshotOptions?.waitForTOCScrolling !== false) {

--- a/packages/gitbook/src/lib/colors.ts
+++ b/packages/gitbook/src/lib/colors.ts
@@ -1,34 +1,42 @@
 import type { ClassValue } from '@/lib/tailwind';
 import type { DocumentMarkColor } from '@gitbook/api';
 
-export const textColorToStyle: { [color in DocumentMarkColor['data']['text']]: ClassValue } = {
+type DocumentTextColor = DocumentMarkColor['data']['text'] | 'pink' | 'violet' | 'cyan' | '$tint';
+
+export const textColorToStyle = {
     default: [],
-    blue: ['text-blue-500 contrast-more:text-blue-800'],
-    red: ['text-red-500 contrast-more:text-red-800'],
-    green: ['text-green-500 contrast-more:text-green-800'],
-    yellow: ['text-yellow-600 contrast-more:text-yellow-800'],
-    purple: ['text-purple-500 contrast-more:text-purple-800'],
-    orange: ['text-orange-500 contrast-more:text-orange-800'],
+    blue: ['text-[#0067d1] dark:text-[#7dbcff]'],
+    red: ['text-[#c01d27] dark:text-[#fb9890]'],
+    green: ['text-[#097f23] dark:text-[#8fc990]'],
+    yellow: ['text-[#7d6700] dark:text-[#c7b77c]'],
+    purple: ['text-[#4a5cc6] dark:text-[#9fb3fe]'],
+    pink: ['text-[#ab278b] dark:text-[#ee95d1]'],
+    violet: ['text-[#873fbb] dark:text-[#cda2f3]'],
+    cyan: ['text-[#007c7c] dark:text-[#6bcac9]'],
+    orange: ['text-[#ae4300] dark:text-[#eea471]'],
     $primary: ['text-primary-subtle contrast-more:text-primary'],
     $info: ['text-info-subtle contrast-more:text-info'],
     $success: ['text-success-subtle contrast-more:text-success'],
     $warning: ['text-warning-subtle contrast-more:text-warning'],
     $danger: ['text-danger-subtle contrast-more:text-danger'],
-};
+    $tint: ['text-tint-subtle contrast-more:text-tint'],
+} satisfies Record<DocumentTextColor, ClassValue>;
 
-export const backgroundColorToStyle: {
-    [color in DocumentMarkColor['data']['background']]: ClassValue;
-} = {
+export const backgroundColorToStyle = {
     default: [],
-    blue: ['bg-mark-blue'],
-    red: ['bg-mark-red'],
-    green: ['bg-mark-green'],
-    yellow: ['bg-mark-yellow'],
-    purple: ['bg-mark-purple'],
-    orange: ['bg-mark-orange'],
+    blue: ['bg-[#dff4ff] dark:bg-[#183453]'],
+    red: ['bg-[#ffe9e5] dark:bg-[#4f2422]'],
+    green: ['bg-[#e4f9e4] dark:bg-[#203a21]'],
+    yellow: ['bg-[#f8f2dc] dark:bg-[#3a3316]'],
+    purple: ['bg-[#e9f1ff] dark:bg-[#283051]'],
+    pink: ['bg-[#ffe8fa] dark:bg-[#4a233e]'],
+    violet: ['bg-[#f9ebff] dark:bg-[#3c294c]'],
+    cyan: ['bg-[#ddf8f8] dark:bg-[#093b3b]'],
+    orange: ['bg-[#ffecdc] dark:bg-[#492a13]'],
     $primary: ['bg-primary'],
     $info: ['bg-info'],
     $success: ['bg-success'],
     $warning: ['bg-warning'],
     $danger: ['bg-danger'],
-};
+    $tint: ['bg-tint'],
+} satisfies Record<DocumentTextColor, ClassValue>;

--- a/packages/gitbook/tailwind.config.ts
+++ b/packages/gitbook/tailwind.config.ts
@@ -121,12 +121,6 @@ const config: Config = {
                 periwinkle: generateShades('#acc6ee'),
             },
             backgroundColor: {
-                'mark-blue': '#89C6DA4D',
-                'mark-purple': '#DAD4FF4D',
-                'mark-orange': '#FFDCBC4D',
-                'mark-red': '#FFCCCB4D',
-                'mark-yellow': '#FFF0854D',
-                'mark-green': '#91EABF4D',
                 primary: generateVarShades('primary', [
                     ColorCategory.backgrounds,
                     ColorCategory.components,


### PR DESCRIPTION
New and updated colors introduced in the editor here: https://github.com/GitbookIO/gitbook-x/pull/22666 are in this PR also resolved in published content.