### PR TITLE
Fix announcement page-picker links resolving relative to current page

### DIFF
--- a/.changeset/tender-lizards-smile.md
+++ b/.changeset/tender-lizards-smile.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix announcement page-picker links by normalizing resolved hrefs to absolute URLs before rendering the banner link in published contexts.

--- a/packages/gitbook/src/components/Announcement/Announcement.test.ts
+++ b/packages/gitbook/src/components/Announcement/Announcement.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { toAbsoluteContentRefHref } from './utils';
+
+describe('toAbsoluteContentRefHref', () => {
+    it('normalizes relative hrefs to absolute URLs', () => {
+        expect(
+            toAbsoluteContentRefHref(
+                {
+                    href: 'marketplace-integration/supported-platforms/litcommerce-native/litcommerce-as-the-main-store',
+                    text: 'LitCommerce as the Main Store',
+                    active: false,
+                },
+                (href) => new URL(href, 'https://litcommerce.gitbook.io').toString()
+            )
+        ).toMatchObject({
+            href: 'https://litcommerce.gitbook.io/marketplace-integration/supported-platforms/litcommerce-native/litcommerce-as-the-main-store',
+        });
+    });
+
+    it('keeps already absolute hrefs unchanged', () => {
+        expect(
+            toAbsoluteContentRefHref(
+                {
+                    href: 'https://litcommerce.gitbook.io/litcommerce-helpdesk/marketplace-integration/supported-platforms/litcommerce-native/litcommerce-as-the-main-store',
+                    text: 'LitCommerce as the Main Store',
+                    active: false,
+                },
+                (href) => new URL(href, 'https://litcommerce.gitbook.io').toString()
+            )
+        ).toMatchObject({
+            href: 'https://litcommerce.gitbook.io/litcommerce-helpdesk/marketplace-integration/supported-platforms/litcommerce-native/litcommerce-as-the-main-store',
+        });
+    });
+});

--- a/packages/gitbook/src/components/Announcement/Announcement.tsx
+++ b/packages/gitbook/src/components/Announcement/Announcement.tsx
@@ -1,6 +1,7 @@
 import type { GitBookSiteContext } from '@/lib/context';
 import { resolveContentRef } from '@/lib/references';
 import { AnnouncementBanner } from './AnnouncementBanner';
+import { toAbsoluteContentRefHref } from './utils';
 
 /**
  * Server-side component to resolve content refs and pass down to client-side component
@@ -20,7 +21,10 @@ export async function Announcement(props: {
     }
 
     const resolvedContentRef = customization.announcement?.link
-        ? await resolveContentRef(customization.announcement?.link?.to, context)
+        ? toAbsoluteContentRefHref(
+              await resolveContentRef(customization.announcement?.link?.to, context),
+              context.linker.toAbsoluteURL
+          )
         : null;
 
     return (

--- a/packages/gitbook/src/components/Announcement/utils.ts
+++ b/packages/gitbook/src/components/Announcement/utils.ts
@@ -1,0 +1,15 @@
+import type { ResolvedContentRef } from '@/lib/references';
+
+export function toAbsoluteContentRefHref(
+    resolvedContentRef: ResolvedContentRef | null,
+    toAbsoluteURL: (href: string) => string
+): ResolvedContentRef | null {
+    if (!resolvedContentRef?.href) {
+        return resolvedContentRef;
+    }
+
+    return {
+        ...resolvedContentRef,
+        href: toAbsoluteURL(resolvedContentRef.href),
+    };
+}


### PR DESCRIPTION
### Motivation
- Announcement links resolved via `resolveContentRef(...).href` could be relative (e.g. `marketplace-integration/...`) causing the browser to resolve them against the current pathname and produce duplicated segments in published sites.
- In preview the linker/preview rewrite masked the issue, but published GBO pages exposed the bug resulting in 404s.
- The change ensures announcement links are safe to render in published contexts by normalizing to absolute URLs at render time.

### Description
- Convert the resolved announcement `href` to an absolute URL before rendering by calling a new helper: `toAbsoluteContentRefHref(...)` with `context.linker.toAbsoluteURL` in `Announcement` (`packages/gitbook/src/components/Announcement/Announcement.tsx`).
- Add the normalization helper `toAbsoluteContentRefHref` in `packages/gitbook/src/components/Announcement/utils.ts` that applies the provided `toAbsoluteURL` function to `href` when present.
- Add a focused unit test `packages/gitbook/src/components/Announcement/Announcement.test.ts` that verifies relative hrefs are converted to absolute URLs and absolute hrefs are left unchanged.
- Add a changeset `.changeset/tender-lizards-smile.md` for the `gitbook` package describing the patch.

### Testing
- Ran the new unit tests with `cd packages/gitbook && bun test src/components/Announcement/Announcement.test.ts`, and both tests passed.
- Ran formatting with `bun run format`; Biome completed but the repo reports pre-existing lint warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f05ae56d108324a85cce58307dfaa2)