### PR TITLE
Make Mermaid controls shown only on hover

### DIFF
--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
@@ -101,7 +101,11 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
     }
 
     return (
-        <div ref={rootRef} className={tcls('relative', style)} contentEditable={false}>
+        <div
+            ref={rootRef}
+            className={tcls('group/mermaid relative', style)}
+            contentEditable={false}
+        >
             <div
                 ref={wrapperRef}
                 className={

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
@@ -18,7 +18,7 @@ export function MermaidPanZoomControls(props: { panZoom: PanzoomObject }) {
     };
 
     return (
-        <div className="pointer-events-none absolute right-3 bottom-3 z-10 grid grid-cols-3 gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:pointer-events-auto group-hover/mermaid:opacity-100 motion-reduce:transition-none">
+        <div className="absolute right-3 bottom-3 z-10 grid grid-cols-3 gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:opacity-100 motion-reduce:transition-none">
             {/* Row 1: empty, pan up, zoom in */}
             <div />
             <Button
@@ -26,7 +26,7 @@ export function MermaidPanZoomControls(props: { panZoom: PanzoomObject }) {
                 icon="chevron-up"
                 onClick={() => panZoom.pan(0, PAN_STEP, { relative: true })}
             />
-            <Button {...btnProps} label="Zoom in" icon="plus" onClick={() => panZoom.zoomIn()} />
+            <Button {...btnProps} icon="plus" onClick={() => panZoom.zoomIn()} />
             {/* Row 2: pan left, reset, pan right */}
             <Button
                 {...btnProps}

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
@@ -11,70 +11,42 @@ const PAN_STEP = 50;
  */
 export function MermaidPanZoomControls(props: { panZoom: PanzoomObject }) {
     const { panZoom } = props;
+    const btnProps = {
+        variant: 'secondary' as const,
+        size: 'xsmall' as const,
+        iconOnly: true,
+    };
 
     return (
-        <div className="absolute right-3 bottom-3 z-10 grid grid-cols-3 gap-0.5">
+        <div className="pointer-events-none absolute right-3 bottom-3 z-10 grid grid-cols-3 gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:pointer-events-auto group-hover/mermaid:opacity-100 motion-reduce:transition-none">
             {/* Row 1: empty, pan up, zoom in */}
             <div />
             <Button
-                label="Pan up"
+                {...btnProps}
                 icon="chevron-up"
-                variant="secondary"
-                size="xsmall"
-                iconOnly
                 onClick={() => panZoom.pan(0, PAN_STEP, { relative: true })}
             />
-            <Button
-                label="Zoom in"
-                icon="plus"
-                variant="secondary"
-                size="xsmall"
-                iconOnly
-                onClick={() => panZoom.zoomIn()}
-            />
+            <Button {...btnProps} label="Zoom in" icon="plus" onClick={() => panZoom.zoomIn()} />
             {/* Row 2: pan left, reset, pan right */}
             <Button
-                label="Pan left"
+                {...btnProps}
                 icon="chevron-left"
-                variant="secondary"
-                size="xsmall"
-                iconOnly
                 onClick={() => panZoom.pan(PAN_STEP, 0, { relative: true })}
             />
+            <Button {...btnProps} icon="refresh" onClick={() => panZoom.reset()} />
             <Button
-                label="Reset view"
-                icon="refresh"
-                variant="secondary"
-                size="xsmall"
-                iconOnly
-                onClick={() => panZoom.reset()}
-            />
-            <Button
-                label="Pan right"
+                {...btnProps}
                 icon="chevron-right"
-                variant="secondary"
-                size="xsmall"
-                iconOnly
                 onClick={() => panZoom.pan(-PAN_STEP, 0, { relative: true })}
             />
             {/* Row 3: empty, pan down, zoom out */}
             <div />
             <Button
-                label="Pan down"
+                {...btnProps}
                 icon="chevron-down"
-                variant="secondary"
-                size="xsmall"
-                iconOnly
                 onClick={() => panZoom.pan(0, -PAN_STEP, { relative: true })}
             />
-            <Button
-                label="Zoom out"
-                icon="minus"
-                variant="secondary"
-                size="xsmall"
-                iconOnly
-                onClick={() => panZoom.zoomOut()}
-            />
+            <Button {...btnProps} icon="minus" onClick={() => panZoom.zoomOut()} />
         </div>
     );
 }


### PR DESCRIPTION
I removed the tooltip because we use and old tootlip library (Radix)
that hasn't a good implementation to work in this case.
