### PR TITLE
Add tests for markdown serving based on user agents

### DIFF
--- a/packages/gitbook/tests/markdown.test.ts
+++ b/packages/gitbook/tests/markdown.test.ts
@@ -29,8 +29,7 @@ describe('markdown serving based on user agent', () => {
     it('should NOT serve markdown to Slackbot (heuristic detection only)', async () => {
         const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
             headers: {
-                'User-Agent':
-                    'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
+                'User-Agent': 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
             },
         });
 

--- a/packages/gitbook/tests/markdown.test.ts
+++ b/packages/gitbook/tests/markdown.test.ts
@@ -1,6 +1,56 @@
 import { describe, expect, it } from 'bun:test';
 import { getContentTestURL } from './utils';
 
+const TEST_PAGE_URL = 'https://gitbook.gitbook.io/test-gitbook-open/text-page';
+
+describe('markdown serving based on user agent', () => {
+    it('should serve markdown to GPTBot (ua-match AI agent)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent': 'GPTBot/1.2',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/markdown');
+    });
+
+    it('should serve markdown to ClaudeBot (ua-match AI agent)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent': 'ClaudeBot/1.0',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/markdown');
+    });
+
+    it('should NOT serve markdown to Slackbot (heuristic detection only)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent':
+                    'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/html');
+    });
+
+    it('should NOT serve markdown to Googlebot (traditional bot, not an AI agent)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent':
+                    'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/html');
+    });
+});
+
 describe('markdown pages', () => {
     it('should expose a markdown page with the .md extension', async () => {
         const response = await fetch(

--- a/packages/gitbook/tests/robots.test.ts
+++ b/packages/gitbook/tests/robots.test.ts
@@ -1,6 +1,56 @@
 import { describe, expect, it } from 'bun:test';
 import { getContentTestURL } from './utils';
 
+const TEST_PAGE_URL = 'https://gitbook.gitbook.io/test-gitbook-open/text-page';
+
+describe('markdown serving based on user agent', () => {
+    it('should serve markdown to GPTBot (ua-match AI agent)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent': 'GPTBot/1.2',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/markdown');
+    });
+
+    it('should serve markdown to ClaudeBot (ua-match AI agent)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent': 'ClaudeBot/1.0',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/markdown');
+    });
+
+    it('should NOT serve markdown to Slackbot (heuristic detection only)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent':
+                    'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/html');
+    });
+
+    it('should NOT serve markdown to Googlebot (traditional bot, not an AI agent)', async () => {
+        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
+            headers: {
+                'User-Agent':
+                    'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+            },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/html');
+    });
+});
+
 describe('robots.txt', () => {
     it('declares allow content signals for public sites', async () => {
         const response = await fetch(

--- a/packages/gitbook/tests/robots.test.ts
+++ b/packages/gitbook/tests/robots.test.ts
@@ -1,56 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { getContentTestURL } from './utils';
 
-const TEST_PAGE_URL = 'https://gitbook.gitbook.io/test-gitbook-open/text-page';
-
-describe('markdown serving based on user agent', () => {
-    it('should serve markdown to GPTBot (ua-match AI agent)', async () => {
-        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
-            headers: {
-                'User-Agent': 'GPTBot/1.2',
-            },
-        });
-
-        expect(response.status).toBe(200);
-        expect(response.headers.get('content-type')).toContain('text/markdown');
-    });
-
-    it('should serve markdown to ClaudeBot (ua-match AI agent)', async () => {
-        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
-            headers: {
-                'User-Agent': 'ClaudeBot/1.0',
-            },
-        });
-
-        expect(response.status).toBe(200);
-        expect(response.headers.get('content-type')).toContain('text/markdown');
-    });
-
-    it('should NOT serve markdown to Slackbot (heuristic detection only)', async () => {
-        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
-            headers: {
-                'User-Agent':
-                    'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)',
-            },
-        });
-
-        expect(response.status).toBe(200);
-        expect(response.headers.get('content-type')).toContain('text/html');
-    });
-
-    it('should NOT serve markdown to Googlebot (traditional bot, not an AI agent)', async () => {
-        const response = await fetch(getContentTestURL(TEST_PAGE_URL), {
-            headers: {
-                'User-Agent':
-                    'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-            },
-        });
-
-        expect(response.status).toBe(200);
-        expect(response.headers.get('content-type')).toContain('text/html');
-    });
-});
-
 describe('robots.txt', () => {
     it('declares allow content signals for public sites', async () => {
         const response = await fetch(


### PR DESCRIPTION
Implement tests to verify that the application serves markdown content correctly based on different user agents, ensuring proper handling for AI agents and traditional bots.