### PR TITLE
Bust page document data cache

### DIFF
--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -94,15 +94,17 @@ export function createDataFetcher(
             });
         },
         getRevisionPageDocument(params) {
-            return getRevisionPageDocument(input, {
-                spaceId: params.spaceId,
-                revisionId: params.revisionId,
-                pageId: params.pageId,
-            },
-            // This API version is used only to invalidate the cache on breaking changes.
-            // It doesn't actually have to be linked to the API version
-            "0.180"
-        );
+            return getRevisionPageDocument(
+                input,
+                {
+                    spaceId: params.spaceId,
+                    revisionId: params.revisionId,
+                    pageId: params.pageId,
+                },
+                // This API version is used only to invalidate the cache on breaking changes.
+                // It doesn't actually have to be linked to the API version
+                '0.180'
+            );
         },
         getRevisionReusableContentDocument(params) {
             return getRevisionReusableContentDocument(input, {

--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -98,7 +98,11 @@ export function createDataFetcher(
                 spaceId: params.spaceId,
                 revisionId: params.revisionId,
                 pageId: params.pageId,
-            });
+            },
+            // This API version is used only to invalidate the cache on breaking changes.
+            // It doesn't actually have to be linked to the API version
+            "0.180"
+        );
         },
         getRevisionReusableContentDocument(params) {
             return getRevisionReusableContentDocument(input, {
@@ -351,7 +355,9 @@ const getRevisionPageMarkdown = cache(
 const getRevisionPageDocument = cache(
     async (
         input: DataFetcherInput,
-        params: { spaceId: string; revisionId: string; pageId: string }
+        params: { spaceId: string; revisionId: string; pageId: string },
+        // used only to bust the cache
+        _apiVersion: string
     ) => {
         'use cache: remote';
         return wrapCacheDataFetcherError(async () => {

--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -101,9 +101,10 @@ export function createDataFetcher(
                     revisionId: params.revisionId,
                     pageId: params.pageId,
                 },
-                // This API version is used only to invalidate the cache on breaking changes.
-                // It doesn't actually have to be linked to the API version
-                '0.180'
+                // We pass the name of the function to distinguish between cache entries
+                // By default Next only uses the arguments, the filename and the position of the function inside the file
+                // By adding a dummy argument with the function name, we can change the order without breaking anything
+                'getRevisionPageDocument'
             );
         },
         getRevisionReusableContentDocument(params) {
@@ -359,7 +360,7 @@ const getRevisionPageDocument = cache(
         input: DataFetcherInput,
         params: { spaceId: string; revisionId: string; pageId: string },
         // used only to bust the cache
-        _apiVersion: string
+        _functionName: string
     ) => {
         'use cache: remote';
         return wrapCacheDataFetcherError(async () => {


### PR DESCRIPTION
Bust page document data cache, some entry were mixed between markdown and normal document because of the cache key for the data cache being the same