### PR TITLE
Fix publish workflow npm upgrade in Bun repo

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,10 +26,11 @@ jobs:
               with:
                   node-version: 22
                   registry-url: 'https://registry.npmjs.org'
+            # Keep npm native here. Enabling the npm Corepack shim inside this
+            # Bun-managed repo makes npm resolution go through Corepack, which
+            # rejects packageManager: bun@... during publish.
             - name: Update npm
-              run: |
-                  corepack enable npm
-                  corepack install -g npm@latest
+              run: npm install -g npm@latest
             - name: Setup Bun
               uses: ./.github/composite/setup-bun
             - name: Install dependencies


### PR DESCRIPTION
## Summary

Revert the publish workflow's npm upgrade step back to native npm instead of using Corepack.

## Why

This repository declares `packageManager: bun@1.3.7`. When the publish workflow enables the npm Corepack shim, npm resolution goes through Corepack inside the repo and fails with:

```text
Unsupported package manager specification (bun@1.3.7)
```
That prevents the Changesets publish job from running, so merged release PRs do not actually publish packages such as @gitbook/embed.

## Change
In `.github/workflows/publish.yaml`:
replace:
```
corepack enable npm
corepack install -g npm@latest
```
with:
```
npm install -g npm@latest
```
Bun setup remains unchanged, so the repo still uses Bun for install/build/publish orchestration. This only avoids routing npm through Corepack in a Bun-managed repo.

## Validation
reproduced the Corepack failure locally with `corepack npm --version`
ran `bun run format`