### PR TITLE
Add updates tag filtering

### DIFF
--- a/.changeset/updates-tag-filter.md
+++ b/.changeset/updates-tag-filter.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add tag filtering controls for Updates blocks.

--- a/packages/gitbook/src/components/DocumentView/Update.tsx
+++ b/packages/gitbook/src/components/DocumentView/Update.tsx
@@ -11,6 +11,7 @@ import { assert } from 'ts-essentials';
 import { Tag } from '../Tag';
 import type { BlockProps } from './Block';
 import { Blocks } from './Blocks';
+import { FilteredUpdate } from './UpdatesFilter';
 
 export function Update(props: BlockProps<DocumentBlockUpdate>) {
     const { block, style, ancestorBlocks, ...contextProps } = props;
@@ -43,7 +44,10 @@ export function Update(props: BlockProps<DocumentBlockUpdate>) {
     const resolvedTags = resolveBlockTags(block.data.tags, revisionTags);
 
     return (
-        <div className={tcls('relative flex flex-col gap-2 md:flex-row md:gap-4 lg:gap-8', style)}>
+        <FilteredUpdate
+            tagSlugs={resolvedTags.map((tag) => tag.slug)}
+            className={tcls('relative flex flex-col gap-2 md:flex-row md:gap-4 lg:gap-8', style)}
+        >
             <div
                 className={tcls(
                     // Date is only sticky on larger screens when we use flex-row layout, with 0px fallback to prevent flicker and flaky tests before JS sets the variable
@@ -71,7 +75,7 @@ export function Update(props: BlockProps<DocumentBlockUpdate>) {
                 ancestorBlocks={[...ancestorBlocks, block]}
                 style="[&>*:first-child]:!pt-0 flex flex-1 flex-col [&>*+*]:mt-5"
             />
-        </div>
+        </FilteredUpdate>
     );
 }
 

--- a/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
+++ b/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
@@ -55,9 +55,14 @@ export function UpdatesFilterProvider(props: {
         [availableTags]
     );
 
+    const rawSelectedTags = React.useMemo(
+        () => searchParams?.getAll(UPDATES_FILTER_SEARCH_PARAM) ?? [],
+        [searchParams]
+    );
+
     const selectedTags = React.useMemo(
-        () => sanitizeTags(searchParams?.getAll(UPDATES_FILTER_SEARCH_PARAM) ?? []),
-        [sanitizeTags, searchParams]
+        () => sanitizeTags(rawSelectedTags),
+        [sanitizeTags, rawSelectedTags]
     );
 
     const replaceTags = React.useCallback(
@@ -75,6 +80,12 @@ export function UpdatesFilterProvider(props: {
         },
         [pathname, router, sanitizeTags, searchParams]
     );
+
+    React.useEffect(() => {
+        if (!areTagsEqual(rawSelectedTags, selectedTags)) {
+            replaceTags(selectedTags);
+        }
+    }, [rawSelectedTags, replaceTags, selectedTags]);
 
     const toggleTag = React.useCallback(
         (tag: string) => {
@@ -115,9 +126,10 @@ export function useUpdatesFilter(): UpdatesFilterContextValue {
 
 export function UpdatesTagFilters(props: {
     tags: RevisionTag[];
+    tagsLabel: string;
     clearLabel: string;
 }) {
-    const { tags, clearLabel } = props;
+    const { tags, tagsLabel, clearLabel } = props;
     const { selectedTagSet, selectedTags, toggleTag, clearTags } = useUpdatesFilter();
     const isFiltering = selectedTags.length > 0;
 
@@ -130,7 +142,7 @@ export function UpdatesTagFilters(props: {
             <div className="mb-3 ml-3 flex items-center justify-between gap-2">
                 <div className="flex items-center gap-1 font-semibold text-tint text-xs uppercase leading-wider">
                     <Icon icon="tags" className="size-3" />
-                    Tags
+                    {tagsLabel}
                 </div>
                 <Button
                     variant="blank"
@@ -171,6 +183,10 @@ export function UpdatesTagFilters(props: {
             </div>
         </div>
     );
+}
+
+function areTagsEqual(left: string[], right: string[]): boolean {
+    return left.length === right.length && left.every((tag, index) => tag === right[index]);
 }
 
 export function FilteredUpdate(props: {

--- a/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
+++ b/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
@@ -181,11 +181,11 @@ export function FilteredUpdate(props: {
     const { tagSlugs, className, children } = props;
     const { selectedTagSet } = useUpdatesFilter();
 
-    const visible =
+    const isVisible =
         selectedTagSet.size === 0 || tagSlugs.some((tagSlug) => selectedTagSet.has(tagSlug));
 
     return (
-        <div className={className} hidden={!visible} data-gb-update-tags={tagSlugs.join(' ')}>
+        <div className={className} hidden={!isVisible}>
             {children}
         </div>
     );

--- a/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
+++ b/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { Button } from '@/components/primitives';
+import { tcls } from '@/lib/tailwind';
+import type { RevisionTag } from '@gitbook/api';
+import { Icon } from '@gitbook/icons';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import React from 'react';
+import { TagIcon } from '../Tag';
+
+const UPDATES_FILTER_SEARCH_PARAM = 'tag';
+
+type UpdatesFilterContextValue = {
+    selectedTags: string[];
+    selectedTagSet: Set<string>;
+    toggleTag: (tag: string) => void;
+    clearTags: () => void;
+};
+
+const emptyUpdatesFilterContext: UpdatesFilterContextValue = {
+    selectedTags: [],
+    selectedTagSet: new Set(),
+    toggleTag: () => {},
+    clearTags: () => {},
+};
+
+const UpdatesFilterContext = React.createContext<UpdatesFilterContextValue | null>(null);
+
+export function UpdatesFilterProvider(props: {
+    tagSlugs: string[];
+    children: React.ReactNode;
+}) {
+    const { tagSlugs, children } = props;
+    const pathname = usePathname();
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const availableTags = React.useMemo(() => new Set(tagSlugs), [tagSlugs]);
+
+    const sanitizeTags = React.useCallback(
+        (tags: string[]) => {
+            const next: string[] = [];
+            const seen = new Set<string>();
+
+            for (const tag of tags) {
+                if (!availableTags.has(tag) || seen.has(tag)) {
+                    continue;
+                }
+
+                next.push(tag);
+                seen.add(tag);
+            }
+
+            return next;
+        },
+        [availableTags]
+    );
+
+    const selectedTags = React.useMemo(
+        () => sanitizeTags(searchParams?.getAll(UPDATES_FILTER_SEARCH_PARAM) ?? []),
+        [sanitizeTags, searchParams]
+    );
+
+    const replaceTags = React.useCallback(
+        (nextTags: string[]) => {
+            const params = new URLSearchParams(searchParams?.toString());
+            params.delete(UPDATES_FILTER_SEARCH_PARAM);
+
+            for (const tag of sanitizeTags(nextTags)) {
+                params.append(UPDATES_FILTER_SEARCH_PARAM, tag);
+            }
+
+            const query = params.toString();
+            const hash = typeof window === 'undefined' ? '' : window.location.hash;
+            router.replace(`${pathname}${query ? `?${query}` : ''}${hash}`, { scroll: false });
+        },
+        [pathname, router, sanitizeTags, searchParams]
+    );
+
+    const toggleTag = React.useCallback(
+        (tag: string) => {
+            if (!availableTags.has(tag)) {
+                return;
+            }
+
+            replaceTags(
+                selectedTags.includes(tag)
+                    ? selectedTags.filter((currentTag) => currentTag !== tag)
+                    : [...selectedTags, tag]
+            );
+        },
+        [availableTags, replaceTags, selectedTags]
+    );
+
+    const clearTags = React.useCallback(() => {
+        replaceTags([]);
+    }, [replaceTags]);
+
+    const selectedTagSet = React.useMemo(() => new Set(selectedTags), [selectedTags]);
+    const value = React.useMemo(
+        () => ({
+            selectedTags,
+            selectedTagSet,
+            toggleTag,
+            clearTags,
+        }),
+        [selectedTags, selectedTagSet, toggleTag, clearTags]
+    );
+
+    return <UpdatesFilterContext.Provider value={value}>{children}</UpdatesFilterContext.Provider>;
+}
+
+export function useUpdatesFilter(): UpdatesFilterContextValue {
+    return React.useContext(UpdatesFilterContext) ?? emptyUpdatesFilterContext;
+}
+
+export function UpdatesTagFilters(props: {
+    tags: RevisionTag[];
+    clearLabel: string;
+}) {
+    const { tags, clearLabel } = props;
+    const { selectedTagSet, selectedTags, toggleTag, clearTags } = useUpdatesFilter();
+    const isFiltering = selectedTags.length > 0;
+
+    if (tags.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="shrink-0 border-tint-subtle border-b pt-px pb-4">
+            <div className="mb-3 ml-3 flex items-center justify-between gap-2">
+                <div className="flex items-center gap-1 font-semibold text-tint text-xs uppercase leading-wider">
+                    <Icon icon="tags" className="size-3" />
+                    Tags
+                </div>
+                <Button
+                    variant="blank"
+                    size="xsmall"
+                    icon="xmark"
+                    label={clearLabel}
+                    onClick={isFiltering ? clearTags : undefined}
+                    aria-hidden={!isFiltering}
+                    tabIndex={isFiltering ? undefined : -1}
+                    className={tcls('text-xs', !isFiltering && 'pointer-events-none invisible')}
+                />
+            </div>
+            <div className="flex flex-wrap gap-1.5 px-3">
+                {tags.map((tag) => {
+                    const selected = selectedTagSet.has(tag.slug);
+
+                    return (
+                        <button
+                            key={tag.slug}
+                            type="button"
+                            aria-pressed={selected}
+                            onClick={() => toggleTag(tag.slug)}
+                            className={tcls(
+                                'inline-flex max-w-full items-center gap-1 rounded-full px-2 py-1 font-medium text-xs leading-normal transition-colors',
+                                'circular-corners:rounded-2xl straight-corners:rounded-xs',
+                                'not-focus-visible:outline-0 focus-visible:ring-2 focus-visible:ring-primary',
+                                selected
+                                    ? 'bg-primary-original text-contrast-primary-original hover:bg-primary-solid-hover'
+                                    : 'bg-tint-5 text-tint-strong hover:bg-tint-hover',
+                                isFiltering && !selected && 'opacity-8 hover:opacity-11'
+                            )}
+                        >
+                            <TagIcon tag={tag} />
+                            <span className="truncate">{tag.label}</span>
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+export function FilteredUpdate(props: {
+    tagSlugs: string[];
+    className?: string;
+    children: React.ReactNode;
+}) {
+    const { tagSlugs, className, children } = props;
+    const { selectedTagSet } = useUpdatesFilter();
+
+    const visible =
+        selectedTagSet.size === 0 || tagSlugs.some((tagSlug) => selectedTagSet.has(tagSlug));
+
+    return (
+        <div className={className} hidden={!visible} data-gb-update-tags={tagSlugs.join(' ')}>
+            {children}
+        </div>
+    );
+}

--- a/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
+++ b/packages/gitbook/src/components/DocumentView/UpdatesFilter.tsx
@@ -60,10 +60,12 @@ export function UpdatesFilterProvider(props: {
         [searchParams]
     );
 
-    const selectedTags = React.useMemo(
+    const urlSelectedTags = React.useMemo(
         () => sanitizeTags(rawSelectedTags),
         [sanitizeTags, rawSelectedTags]
     );
+    const [selectedTags, setSelectedTags] = React.useState(urlSelectedTags);
+    const selectedTagsRef = React.useRef(selectedTags);
 
     const replaceTags = React.useCallback(
         (nextTags: string[]) => {
@@ -82,10 +84,31 @@ export function UpdatesFilterProvider(props: {
     );
 
     React.useEffect(() => {
-        if (!areTagsEqual(rawSelectedTags, selectedTags)) {
-            replaceTags(selectedTags);
+        if (!areTagsEqual(rawSelectedTags, urlSelectedTags)) {
+            replaceTags(urlSelectedTags);
         }
-    }, [rawSelectedTags, replaceTags, selectedTags]);
+    }, [rawSelectedTags, replaceTags, urlSelectedTags]);
+
+    React.useEffect(() => {
+        if (areTagsEqual(selectedTagsRef.current, urlSelectedTags)) {
+            return;
+        }
+
+        selectedTagsRef.current = urlSelectedTags;
+        setSelectedTags(urlSelectedTags);
+    }, [urlSelectedTags]);
+
+    // Keep tag clicks responsive while the URL update from router.replace is still pending.
+    const updateSelectedTags = React.useCallback(
+        (getNextTags: (currentTags: string[]) => string[]) => {
+            const nextTags = sanitizeTags(getNextTags(selectedTagsRef.current));
+
+            selectedTagsRef.current = nextTags;
+            setSelectedTags(nextTags);
+            replaceTags(nextTags);
+        },
+        [replaceTags, sanitizeTags]
+    );
 
     const toggleTag = React.useCallback(
         (tag: string) => {
@@ -93,18 +116,18 @@ export function UpdatesFilterProvider(props: {
                 return;
             }
 
-            replaceTags(
-                selectedTags.includes(tag)
-                    ? selectedTags.filter((currentTag) => currentTag !== tag)
-                    : [...selectedTags, tag]
+            updateSelectedTags((currentTags) =>
+                currentTags.includes(tag)
+                    ? currentTags.filter((currentTag) => currentTag !== tag)
+                    : [...currentTags, tag]
             );
         },
-        [availableTags, replaceTags, selectedTags]
+        [availableTags, updateSelectedTags]
     );
 
     const clearTags = React.useCallback(() => {
-        replaceTags([]);
-    }, [replaceTags]);
+        updateSelectedTags(() => []);
+    }, [updateSelectedTags]);
 
     const selectedTagSet = React.useMemo(() => new Set(selectedTags), [selectedTags]);
     const value = React.useMemo(

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -1,10 +1,11 @@
-import { getSpaceLanguage, t } from '@/intl/server';
+import { getSpaceLanguage, t, tString } from '@/intl/server';
 import type { GitBookSiteContext } from '@/lib/context';
 import { getDocumentSections } from '@/lib/document-sections';
 import { tcls } from '@/lib/tailwind';
 import {
     type JSONDocument,
     type RevisionPageDocument,
+    type RevisionTag,
     SiteAdsStatus,
     SiteInsightsAdPlacement,
 } from '@gitbook/api';
@@ -12,6 +13,7 @@ import React from 'react';
 
 import { Icon } from '@gitbook/icons';
 import { Ad } from '../Ads';
+import { UpdatesTagFilters } from '../DocumentView/UpdatesFilter';
 import { PageFeedbackForm } from '../PageFeedback';
 import { ThemeToggler } from '../ThemeToggler';
 import { SideSheet } from '../primitives/SideSheet';
@@ -25,12 +27,13 @@ import { ScrollToTopButton } from './ScrollToTopButton';
 export async function PageAside(props: {
     page: RevisionPageDocument;
     document: JSONDocument | null;
+    updateTags: RevisionTag[];
     context: GitBookSiteContext;
     withHeaderOffset: { sectionsHeader: boolean; topHeader: boolean };
     withFullPageCover: boolean;
     withPageFeedback: boolean;
 }) {
-    const { page, document, withPageFeedback, context } = props;
+    const { page, document, updateTags, withPageFeedback, context } = props;
     const { customization, site } = context;
     const language = await getSpaceLanguage(context);
 
@@ -103,7 +106,18 @@ export async function PageAside(props: {
             <div className="flex h-full w-full shrink-0 flex-col overflow-hidden">
                 {page.layout.outline ? (
                     <>
-                        <div className="mb-3 ml-3 flex page-no-outline:hidden items-center justify-between max-lg:hidden">
+                        {updateTags.length > 0 ? (
+                            <UpdatesTagFilters
+                                tags={updateTags}
+                                clearLabel={tString(language, 'clear')}
+                            />
+                        ) : null}
+                        <div
+                            className={tcls(
+                                'mb-3 ml-3 flex page-no-outline:hidden items-center justify-between max-lg:hidden',
+                                updateTags.length > 0 && 'mt-4'
+                            )}
+                        >
                             <ScrollToTopButton className="flex cursor-pointer items-center gap-1 font-semibold text-tint text-xs uppercase leading-wider">
                                 <Icon icon="block-quote" className="size-3" />{' '}
                                 {t(language, 'on_this_page')}

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -109,6 +109,7 @@ export async function PageAside(props: {
                         {filterableTags.length > 0 ? (
                             <UpdatesTagFilters
                                 tags={filterableTags}
+                                tagsLabel={tString(language, 'tags')}
                                 clearLabel={tString(language, 'clear')}
                             />
                         ) : null}

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -27,13 +27,13 @@ import { ScrollToTopButton } from './ScrollToTopButton';
 export async function PageAside(props: {
     page: RevisionPageDocument;
     document: JSONDocument | null;
-    updateTags: RevisionTag[];
+    filterableTags: RevisionTag[];
     context: GitBookSiteContext;
     withHeaderOffset: { sectionsHeader: boolean; topHeader: boolean };
     withFullPageCover: boolean;
     withPageFeedback: boolean;
 }) {
-    const { page, document, updateTags, withPageFeedback, context } = props;
+    const { page, document, filterableTags, withPageFeedback, context } = props;
     const { customization, site } = context;
     const language = await getSpaceLanguage(context);
 
@@ -106,16 +106,16 @@ export async function PageAside(props: {
             <div className="flex h-full w-full shrink-0 flex-col overflow-hidden">
                 {page.layout.outline ? (
                     <>
-                        {updateTags.length > 0 ? (
+                        {filterableTags.length > 0 ? (
                             <UpdatesTagFilters
-                                tags={updateTags}
+                                tags={filterableTags}
                                 clearLabel={tString(language, 'clear')}
                             />
                         ) : null}
                         <div
                             className={tcls(
                                 'mb-3 ml-3 flex page-no-outline:hidden items-center justify-between max-lg:hidden',
-                                updateTags.length > 0 && 'mt-4'
+                                filterableTags.length > 0 && 'mt-4'
                             )}
                         >
                             <ScrollToTopButton className="flex cursor-pointer items-center gap-1 font-semibold text-tint text-xs uppercase leading-wider">

--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -27,11 +27,11 @@ export function ScrollSectionsList({ sections }: { sections: DocumentSection[] }
         }
 
         return sections.filter((section) => {
-            if (section.updateTagSlugs === undefined) {
+            if (section.tags === undefined) {
                 return true;
             }
 
-            return section.updateTagSlugs.some((tagSlug) => selectedTagSet.has(tagSlug));
+            return section.tags.some((tagSlug) => selectedTagSet.has(tagSlug));
         });
     }, [sections, selectedTagSet]);
     const ids = React.useMemo(() => visibleSections.map(({ id }) => id), [visibleSections]);

--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 
+import { useUpdatesFilter } from '@/components/DocumentView/UpdatesFilter';
 import { useScrollActiveId } from '@/components/hooks';
 import type { DocumentSection } from '@/lib/document-sections';
 import { tcls } from '@/lib/tailwind';
@@ -19,7 +20,21 @@ const SECTION_INTERSECTING_THRESHOLD = 0.9;
 const ACTIVE_ITEM_OFFSET = 100;
 
 export function ScrollSectionsList({ sections }: { sections: DocumentSection[] }) {
-    const ids = React.useMemo(() => sections.map(({ id }) => id), [sections]);
+    const { selectedTagSet } = useUpdatesFilter();
+    const visibleSections = React.useMemo(() => {
+        if (selectedTagSet.size === 0) {
+            return sections;
+        }
+
+        return sections.filter((section) => {
+            if (section.updateTagSlugs === undefined) {
+                return true;
+            }
+
+            return section.updateTagSlugs.some((tagSlug) => selectedTagSet.has(tagSlug));
+        });
+    }, [sections, selectedTagSet]);
+    const ids = React.useMemo(() => visibleSections.map(({ id }) => id), [visibleSections]);
 
     const enabled = useBodyLoaded();
 
@@ -46,7 +61,7 @@ export function ScrollSectionsList({ sections }: { sections: DocumentSection[] }
             className="relative flex flex-col border-tint-subtle sidebar-list-line:border-l pb-5"
             ref={scrollContainerRef}
         >
-            {sections.map((section) => (
+            {visibleSections.map((section) => (
                 <li
                     key={section.id}
                     className={tcls(

--- a/packages/gitbook/src/components/SitePage/SitePage.tsx
+++ b/packages/gitbook/src/components/SitePage/SitePage.tsx
@@ -16,7 +16,7 @@ import { PageAside } from '@/components/PageAside';
 import { PageBody, PageCover } from '@/components/PageBody';
 import { getPagePath } from '@/lib/pages';
 import { isPageIndexable, isSiteIndexable } from '@/lib/seo';
-import { getDocumentUpdateTags } from '@/lib/updates';
+import { getDocumentFilterableTags } from '@/lib/updates';
 
 import {
     getContentInlineIconSourceRequests,
@@ -76,7 +76,7 @@ export async function SitePage(props: SitePageProps & { staticRoute: boolean }) 
         iconSources,
     } = await getSitePageData(props);
     const headerOffset = { sectionsHeader: withSections, topHeader: withTopHeader };
-    const updateTags = document ? getDocumentUpdateTags(document, context.revision) : [];
+    const filterableTags = document ? getDocumentFilterableTags(document, context.revision) : [];
     const content = (
         <>
             {/* Using `contents` makes the children of this div according to its parent — which keeps them in a single flex row with the TOC by default.
@@ -97,7 +97,7 @@ export async function SitePage(props: SitePageProps & { staticRoute: boolean }) 
                     <PageAside
                         page={page}
                         document={document}
-                        updateTags={updateTags}
+                        filterableTags={filterableTags}
                         withHeaderOffset={headerOffset}
                         withFullPageCover={withFullPageCover}
                         withPageFeedback={withPageFeedback}
@@ -121,8 +121,8 @@ export async function SitePage(props: SitePageProps & { staticRoute: boolean }) 
     return (
         <IconsProvider iconSources={iconSources}>
             <PageContextProvider pageId={page.id} spaceId={context.space.id} title={page.title}>
-                {updateTags.length > 0 ? (
-                    <UpdatesFilterProvider tagSlugs={updateTags.map((tag) => tag.slug)}>
+                {filterableTags.length > 0 ? (
+                    <UpdatesFilterProvider tagSlugs={filterableTags.map((tag) => tag.slug)}>
                         {content}
                     </UpdatesFilterProvider>
                 ) : (

--- a/packages/gitbook/src/components/SitePage/SitePage.tsx
+++ b/packages/gitbook/src/components/SitePage/SitePage.tsx
@@ -11,10 +11,12 @@ import { IconsProvider } from '@gitbook/icons';
 import type { Metadata, Viewport } from 'next';
 import { notFound, redirect } from 'next/navigation';
 
+import { UpdatesFilterProvider } from '@/components/DocumentView/UpdatesFilter';
 import { PageAside } from '@/components/PageAside';
 import { PageBody, PageCover } from '@/components/PageBody';
 import { getPagePath } from '@/lib/pages';
 import { isPageIndexable, isSiteIndexable } from '@/lib/seo';
+import { getDocumentUpdateTags } from '@/lib/updates';
 
 import {
     getContentInlineIconSourceRequests,
@@ -74,47 +76,58 @@ export async function SitePage(props: SitePageProps & { staticRoute: boolean }) 
         iconSources,
     } = await getSitePageData(props);
     const headerOffset = { sectionsHeader: withSections, topHeader: withTopHeader };
+    const updateTags = document ? getDocumentUpdateTags(document, context.revision) : [];
+    const content = (
+        <>
+            {/* Using `contents` makes the children of this div according to its parent — which keeps them in a single flex row with the TOC by default.
+            If there's a page cover, we use `flex flex-col` to lay out the PageCover above the PageBody + PageAside instead. */}
+            <div className={withFullPageCover && page.cover ? 'flex grow flex-col' : 'contents'}>
+                {withFullPageCover && page.cover ? (
+                    <PageCover as="full" page={page} cover={page.cover} context={context} />
+                ) : null}
+
+                <div
+                    className={tcls(
+                        withFullPageCover && page.cover ? 'flex grow flex-row' : 'contents',
+                        withSections
+                            ? '[--content-scroll-margin:calc(var(--spacing)*27)]'
+                            : '[--content-scroll-margin:calc(var(--spacing)*16)]'
+                    )}
+                >
+                    <PageAside
+                        page={page}
+                        document={document}
+                        updateTags={updateTags}
+                        withHeaderOffset={headerOffset}
+                        withFullPageCover={withFullPageCover}
+                        withPageFeedback={withPageFeedback}
+                        context={context}
+                    />
+                    <PageBody
+                        context={context}
+                        page={page}
+                        ancestors={ancestors}
+                        document={document}
+                        withPageFeedback={withPageFeedback}
+                        insightsDisplayContext={SiteInsightsDisplayContext.Site}
+                        staticRoute={props.staticRoute}
+                    />
+                </div>
+                <PageClientLayout pageMetaLinks={pageMetaLinks} />
+            </div>
+        </>
+    );
 
     return (
         <IconsProvider iconSources={iconSources}>
             <PageContextProvider pageId={page.id} spaceId={context.space.id} title={page.title}>
-                {/* Using `contents` makes the children of this div according to its parent — which keeps them in a single flex row with the TOC by default.
-            If there's a page cover, we use `flex flex-col` to lay out the PageCover above the PageBody + PageAside instead. */}
-                <div
-                    className={withFullPageCover && page.cover ? 'flex grow flex-col' : 'contents'}
-                >
-                    {withFullPageCover && page.cover ? (
-                        <PageCover as="full" page={page} cover={page.cover} context={context} />
-                    ) : null}
-
-                    <div
-                        className={tcls(
-                            withFullPageCover && page.cover ? 'flex grow flex-row' : 'contents',
-                            withSections
-                                ? '[--content-scroll-margin:calc(var(--spacing)*27)]'
-                                : '[--content-scroll-margin:calc(var(--spacing)*16)]'
-                        )}
-                    >
-                        <PageAside
-                            page={page}
-                            document={document}
-                            withHeaderOffset={headerOffset}
-                            withFullPageCover={withFullPageCover}
-                            withPageFeedback={withPageFeedback}
-                            context={context}
-                        />
-                        <PageBody
-                            context={context}
-                            page={page}
-                            ancestors={ancestors}
-                            document={document}
-                            withPageFeedback={withPageFeedback}
-                            insightsDisplayContext={SiteInsightsDisplayContext.Site}
-                            staticRoute={props.staticRoute}
-                        />
-                    </div>
-                    <PageClientLayout pageMetaLinks={pageMetaLinks} />
-                </div>
+                {updateTags.length > 0 ? (
+                    <UpdatesFilterProvider tagSlugs={updateTags.map((tag) => tag.slug)}>
+                        {content}
+                    </UpdatesFilterProvider>
+                ) : (
+                    content
+                )}
             </PageContextProvider>
         </IconsProvider>
     );

--- a/packages/gitbook/src/components/Tag.tsx
+++ b/packages/gitbook/src/components/Tag.tsx
@@ -32,7 +32,7 @@ export function Tag(props: { tag: RevisionTag; className?: string }) {
 /**
  * Renders the emoji or icon for a tag, if present.
  */
-function TagIcon(props: { tag: RevisionTag }) {
+export function TagIcon(props: { tag: RevisionTag }) {
     const { tag } = props;
 
     if ('emoji' in tag) {

--- a/packages/gitbook/src/components/hooks/useScrollActiveId.ts
+++ b/packages/gitbook/src/components/hooks/useScrollActiveId.ts
@@ -14,15 +14,21 @@ export function useScrollActiveId(
         threshold?: number;
         enabled: boolean;
     } = { enabled: true }
-) {
-    const [activeId, setActiveId] = React.useState<string>(ids[0]!);
+): string | undefined {
+    const [activeId, setActiveId] = React.useState<string | undefined>(ids[0]);
     const sectionsIntersectingMap = React.useRef<Map<string, boolean>>(new Map());
 
     React.useEffect(() => {
         const defaultActiveId = ids[0];
         sectionsIntersectingMap.current.clear();
-        // @ts-expect-error
-        setActiveId((activeId) => (ids.indexOf(activeId) !== -1 ? activeId : defaultActiveId));
+        setActiveId((activeId) =>
+            activeId !== undefined && ids.includes(activeId) ? activeId : defaultActiveId
+        );
+
+        if (ids.length === 0) {
+            return;
+        }
+
         if (!enabled) {
             return;
         }

--- a/packages/gitbook/src/components/hooks/useScrollActiveId.ts
+++ b/packages/gitbook/src/components/hooks/useScrollActiveId.ts
@@ -20,6 +20,7 @@ export function useScrollActiveId(
 
     React.useEffect(() => {
         const defaultActiveId = ids[0];
+        sectionsIntersectingMap.current.clear();
         // @ts-expect-error
         setActiveId((activeId) => (ids.indexOf(activeId) !== -1 ? activeId : defaultActiveId));
         if (!enabled) {

--- a/packages/gitbook/src/intl/translations/ar.ts
+++ b/packages/gitbook/src/intl/translations/ar.ts
@@ -11,6 +11,7 @@ export const ar: TranslationLanguage = {
     switch_to_system_theme: 'التبديل إلى سمة النظام',
     search: 'بحث',
     clear: 'مسح',
+    tags: 'الوسوم',
     search_back: 'العودة إلى نتائج البحث',
     search_or_ask: 'اسأل أو ابحث',
     search_input_placeholder: 'البحث في المحتوى',

--- a/packages/gitbook/src/intl/translations/bg.ts
+++ b/packages/gitbook/src/intl/translations/bg.ts
@@ -11,6 +11,7 @@ export const bg: TranslationLanguage = {
     switch_to_system_theme: 'Превключване към системната тема',
     search: 'Търсене',
     clear: 'Изчистване',
+    tags: 'Етикети',
     search_back: 'Назад към резултатите от търсенето',
     search_or_ask: 'Попитайте или търсете',
     search_input_placeholder: 'Търсене в съдържанието',

--- a/packages/gitbook/src/intl/translations/cs.ts
+++ b/packages/gitbook/src/intl/translations/cs.ts
@@ -11,6 +11,7 @@ export const cs: TranslationLanguage = {
     switch_to_system_theme: 'Přepnout na systémový motiv',
     search: 'Hledat',
     clear: 'Vymazat',
+    tags: 'Štítky',
     search_back: 'Zpět na výsledky hledání',
     search_or_ask: 'Zeptat se nebo hledat',
     search_input_placeholder: 'Hledat v obsahu',

--- a/packages/gitbook/src/intl/translations/da.ts
+++ b/packages/gitbook/src/intl/translations/da.ts
@@ -11,6 +11,7 @@ export const da: TranslationLanguage = {
     switch_to_system_theme: 'Skift til systemtema',
     search: 'Søg',
     clear: 'Ryd',
+    tags: 'Tags',
     search_back: 'Tilbage til søgeresultater',
     search_or_ask: 'Spørg eller søg',
     search_input_placeholder: 'Søg i indhold',

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -9,6 +9,7 @@ export const de = {
     switch_to_system_theme: 'Zum Systemmodus wechseln',
     search: 'Suche',
     clear: 'Löschen',
+    tags: 'Tags',
     search_back: 'Zurück zu den Suchergebnissen',
     search_or_ask: 'Fragen oder Suchen',
     search_input_placeholder: 'Inhalt durchsuchen',

--- a/packages/gitbook/src/intl/translations/el.ts
+++ b/packages/gitbook/src/intl/translations/el.ts
@@ -11,6 +11,7 @@ export const el: TranslationLanguage = {
     switch_to_system_theme: 'Αλλαγή στο θέμα συστήματος',
     search: 'Αναζήτηση',
     clear: 'Εκκαθάριση',
+    tags: 'Ετικέτες',
     search_back: 'Επιστροφή στα αποτελέσματα αναζήτησης',
     search_or_ask: 'Ρωτήστε ή αναζητήστε',
     search_input_placeholder: 'Αναζήτηση περιεχομένου',

--- a/packages/gitbook/src/intl/translations/en.ts
+++ b/packages/gitbook/src/intl/translations/en.ts
@@ -9,6 +9,7 @@ export const en = {
     switch_to_system_theme: 'Switch to system theme',
     search: 'Search',
     clear: 'Clear',
+    tags: 'Tags',
     search_back: 'Back to search results',
     search_or_ask: 'Ask or search',
     search_input_placeholder: 'Search content',

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -11,6 +11,7 @@ export const es: TranslationLanguage = {
     switch_to_system_theme: 'Cambiar a tema del sistema',
     search: 'Buscar',
     clear: 'Limpiar',
+    tags: 'Etiquetas',
     search_back: 'Volver a los resultados de búsqueda',
     search_or_ask: 'Preguntar o Buscar',
     search_input_placeholder: 'Buscar contenido',

--- a/packages/gitbook/src/intl/translations/et.ts
+++ b/packages/gitbook/src/intl/translations/et.ts
@@ -11,6 +11,7 @@ export const et: TranslationLanguage = {
     switch_to_system_theme: 'Lülitu süsteemi teemale',
     search: 'Otsi',
     clear: 'Tühjenda',
+    tags: 'Sildid',
     search_back: 'Tagasi otsingutulemuste juurde',
     search_or_ask: 'Küsi või otsi',
     search_input_placeholder: 'Otsi sisust',

--- a/packages/gitbook/src/intl/translations/fi.ts
+++ b/packages/gitbook/src/intl/translations/fi.ts
@@ -11,6 +11,7 @@ export const fi: TranslationLanguage = {
     switch_to_system_theme: 'Vaihda järjestelmän teemaan',
     search: 'Haku',
     clear: 'Tyhjennä',
+    tags: 'Tunnisteet',
     search_back: 'Takaisin hakutuloksiin',
     search_or_ask: 'Kysy tai hae',
     search_input_placeholder: 'Hae sisällöstä',

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -9,6 +9,7 @@ export const fr = {
     switch_to_system_theme: 'Utiliser le thème du système',
     search: 'Rechercher',
     clear: 'Effacer',
+    tags: 'Étiquettes',
     search_back: 'Retour aux résultats de recherche',
     search_or_ask: 'Rechercher',
     search_input_placeholder: 'Rechercher dans le contenu',

--- a/packages/gitbook/src/intl/translations/he.ts
+++ b/packages/gitbook/src/intl/translations/he.ts
@@ -11,6 +11,7 @@ export const he: TranslationLanguage = {
     switch_to_system_theme: 'מעבר לערכת הנושא של המערכת',
     search: 'חיפוש',
     clear: 'ניקוי',
+    tags: 'תגיות',
     search_back: 'חזרה לתוצאות החיפוש',
     search_or_ask: 'שאלה או חיפוש',
     search_input_placeholder: 'חיפוש בתוכן',

--- a/packages/gitbook/src/intl/translations/hi.ts
+++ b/packages/gitbook/src/intl/translations/hi.ts
@@ -11,6 +11,7 @@ export const hi: TranslationLanguage = {
     switch_to_system_theme: 'सिस्टम थीम पर जाएं',
     search: 'खोजें',
     clear: 'साफ करें',
+    tags: 'टैग',
     search_back: 'खोज परिणामों पर वापस जाएं',
     search_or_ask: 'पूछें या खोजें',
     search_input_placeholder: 'सामग्री खोजें',

--- a/packages/gitbook/src/intl/translations/hr.ts
+++ b/packages/gitbook/src/intl/translations/hr.ts
@@ -11,6 +11,7 @@ export const hr: TranslationLanguage = {
     switch_to_system_theme: 'Prebaci na temu sustava',
     search: 'Pretraži',
     clear: 'Očisti',
+    tags: 'Oznake',
     search_back: 'Natrag na rezultate pretraživanja',
     search_or_ask: 'Pitaj ili pretraži',
     search_input_placeholder: 'Pretraži sadržaj',

--- a/packages/gitbook/src/intl/translations/hu.ts
+++ b/packages/gitbook/src/intl/translations/hu.ts
@@ -11,6 +11,7 @@ export const hu: TranslationLanguage = {
     switch_to_system_theme: 'Váltás rendszer témára',
     search: 'Keresés',
     clear: 'Törlés',
+    tags: 'Címkék',
     search_back: 'Vissza a keresési eredményekhez',
     search_or_ask: 'Kérdezés vagy keresés',
     search_input_placeholder: 'Keresés a tartalomban',

--- a/packages/gitbook/src/intl/translations/id.ts
+++ b/packages/gitbook/src/intl/translations/id.ts
@@ -11,6 +11,7 @@ export const id: TranslationLanguage = {
     switch_to_system_theme: 'Beralih ke tema sistem',
     search: 'Cari',
     clear: 'Bersihkan',
+    tags: 'Tag',
     search_back: 'Kembali ke hasil pencarian',
     search_or_ask: 'Tanya atau cari',
     search_input_placeholder: 'Cari konten',

--- a/packages/gitbook/src/intl/translations/it.ts
+++ b/packages/gitbook/src/intl/translations/it.ts
@@ -11,6 +11,7 @@ export const it: TranslationLanguage = {
     switch_to_system_theme: 'Passa al tema di sistema',
     search: 'Cerca',
     clear: 'Cancella',
+    tags: 'Tag',
     search_back: 'Torna ai risultati di ricerca',
     search_or_ask: 'Chiedi o cerca',
     search_input_placeholder: 'Cerca contenuti',

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -11,6 +11,7 @@ export const ja: TranslationLanguage = {
     switch_to_system_theme: 'システムのテーマに切り替え',
     search: '検索',
     clear: 'クリア',
+    tags: 'タグ',
     search_back: '検索結果に戻る',
     search_or_ask: '質問または検索',
     search_input_placeholder: 'コンテンツを検索',

--- a/packages/gitbook/src/intl/translations/ko.ts
+++ b/packages/gitbook/src/intl/translations/ko.ts
@@ -11,6 +11,7 @@ export const ko: TranslationLanguage = {
     switch_to_system_theme: '시스템 테마로 전환',
     search: '검색',
     clear: '지우기',
+    tags: '태그',
     search_back: '검색 결과로 돌아가기',
     search_or_ask: '질문 또는 검색',
     search_input_placeholder: '콘텐츠 검색',

--- a/packages/gitbook/src/intl/translations/lt.ts
+++ b/packages/gitbook/src/intl/translations/lt.ts
@@ -11,6 +11,7 @@ export const lt: TranslationLanguage = {
     switch_to_system_theme: 'Perjungti į sistemos temą',
     search: 'Ieškoti',
     clear: 'Išvalyti',
+    tags: 'Žymos',
     search_back: 'Grįžti į paieškos rezultatus',
     search_or_ask: 'Klausti arba ieškoti',
     search_input_placeholder: 'Ieškoti turinyje',

--- a/packages/gitbook/src/intl/translations/lv.ts
+++ b/packages/gitbook/src/intl/translations/lv.ts
@@ -11,6 +11,7 @@ export const lv: TranslationLanguage = {
     switch_to_system_theme: 'Pārslēgt uz sistēmas motīvu',
     search: 'Meklēt',
     clear: 'Notīrīt',
+    tags: 'Birkas',
     search_back: 'Atpakaļ uz meklēšanas rezultātiem',
     search_or_ask: 'Jautāt vai meklēt',
     search_input_placeholder: 'Meklēt saturā',

--- a/packages/gitbook/src/intl/translations/ms.ts
+++ b/packages/gitbook/src/intl/translations/ms.ts
@@ -11,6 +11,7 @@ export const ms: TranslationLanguage = {
     switch_to_system_theme: 'Tukar kepada tema sistem',
     search: 'Cari',
     clear: 'Kosongkan',
+    tags: 'Tag',
     search_back: 'Kembali ke hasil carian',
     search_or_ask: 'Tanya atau cari',
     search_input_placeholder: 'Cari kandungan',

--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -11,6 +11,7 @@ export const nl: TranslationLanguage = {
     switch_to_system_theme: 'Schakel over naar systeemmodus',
     search: 'Zoeken',
     clear: 'Wissen',
+    tags: 'Tags',
     search_back: 'Terug naar zoekresultaten',
     search_or_ask: 'Zoek of vraag',
     search_input_placeholder: 'Zoek inhoud',

--- a/packages/gitbook/src/intl/translations/no.ts
+++ b/packages/gitbook/src/intl/translations/no.ts
@@ -11,6 +11,7 @@ export const no: TranslationLanguage = {
     switch_to_system_theme: 'Bytt til systemtema',
     search: 'Søk',
     clear: 'Tøm',
+    tags: 'Tagger',
     search_back: 'Tilbake til søkeresultater',
     search_or_ask: 'Spør eller søk',
     search_input_placeholder: 'Søk i innhold',

--- a/packages/gitbook/src/intl/translations/pl.ts
+++ b/packages/gitbook/src/intl/translations/pl.ts
@@ -11,6 +11,7 @@ export const pl: TranslationLanguage = {
     switch_to_system_theme: 'Przełącz na motyw systemowy',
     search: 'Szukaj',
     clear: 'Wyczyść',
+    tags: 'Tagi',
     search_back: 'Wróć do wyników wyszukiwania',
     search_or_ask: 'Zapytaj lub wyszukaj',
     search_input_placeholder: 'Szukaj w treści',

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -9,6 +9,7 @@ export const pt_br = {
     switch_to_system_theme: 'Mudar para configuração do sistema',
     search: 'Buscar',
     clear: 'Limpar',
+    tags: 'Tags',
     search_back: 'Voltar aos resultados da busca',
     search_or_ask: 'Perguntar ou buscar',
     search_input_placeholder: 'Buscar conteúdo',

--- a/packages/gitbook/src/intl/translations/pt.ts
+++ b/packages/gitbook/src/intl/translations/pt.ts
@@ -11,6 +11,7 @@ export const pt: TranslationLanguage = {
     switch_to_system_theme: 'Mudar para o tema do sistema',
     search: 'Pesquisar',
     clear: 'Limpar',
+    tags: 'Etiquetas',
     search_back: 'Voltar aos resultados da pesquisa',
     search_or_ask: 'Perguntar ou pesquisar',
     search_input_placeholder: 'Pesquisar conteúdo',

--- a/packages/gitbook/src/intl/translations/ro.ts
+++ b/packages/gitbook/src/intl/translations/ro.ts
@@ -11,6 +11,7 @@ export const ro: TranslationLanguage = {
     switch_to_system_theme: 'Comută la tema sistemului',
     search: 'Caută',
     clear: 'Șterge',
+    tags: 'Etichete',
     search_back: 'Înapoi la rezultatele căutării',
     search_or_ask: 'Întreabă sau caută',
     search_input_placeholder: 'Caută în conținut',

--- a/packages/gitbook/src/intl/translations/ru.ts
+++ b/packages/gitbook/src/intl/translations/ru.ts
@@ -9,6 +9,7 @@ export const ru = {
     switch_to_system_theme: 'Переключиться на системную тему',
     search: 'Поиск',
     clear: 'Очистить',
+    tags: 'Теги',
     search_back: 'Вернуться к результатам поиска',
     search_or_ask: 'Найти или спросить',
     search_input_placeholder: 'Поиск по содержимому',

--- a/packages/gitbook/src/intl/translations/sk.ts
+++ b/packages/gitbook/src/intl/translations/sk.ts
@@ -11,6 +11,7 @@ export const sk: TranslationLanguage = {
     switch_to_system_theme: 'Prepnúť na systémový motív',
     search: 'Hľadať',
     clear: 'Vymazať',
+    tags: 'Značky',
     search_back: 'Späť na výsledky vyhľadávania',
     search_or_ask: 'Opýtať sa alebo hľadať',
     search_input_placeholder: 'Hľadať v obsahu',

--- a/packages/gitbook/src/intl/translations/sl.ts
+++ b/packages/gitbook/src/intl/translations/sl.ts
@@ -11,6 +11,7 @@ export const sl: TranslationLanguage = {
     switch_to_system_theme: 'Preklopi na sistemsko temo',
     search: 'Išči',
     clear: 'Počisti',
+    tags: 'Oznake',
     search_back: 'Nazaj na rezultate iskanja',
     search_or_ask: 'Vprašaj ali išči',
     search_input_placeholder: 'Išči po vsebini',

--- a/packages/gitbook/src/intl/translations/sv.ts
+++ b/packages/gitbook/src/intl/translations/sv.ts
@@ -11,6 +11,7 @@ export const sv: TranslationLanguage = {
     switch_to_system_theme: 'Byt till systemtema',
     search: 'Sök',
     clear: 'Rensa',
+    tags: 'Taggar',
     search_back: 'Tillbaka till sökresultat',
     search_or_ask: 'Fråga eller sök',
     search_input_placeholder: 'Sök i innehållet',

--- a/packages/gitbook/src/intl/translations/th.ts
+++ b/packages/gitbook/src/intl/translations/th.ts
@@ -11,6 +11,7 @@ export const th: TranslationLanguage = {
     switch_to_system_theme: 'เปลี่ยนเป็นธีมของระบบ',
     search: 'ค้นหา',
     clear: 'ล้าง',
+    tags: 'แท็ก',
     search_back: 'กลับไปยังผลการค้นหา',
     search_or_ask: 'ถามหรือค้นหา',
     search_input_placeholder: 'ค้นหาเนื้อหา',

--- a/packages/gitbook/src/intl/translations/tr.ts
+++ b/packages/gitbook/src/intl/translations/tr.ts
@@ -11,6 +11,7 @@ export const tr: TranslationLanguage = {
     switch_to_system_theme: 'Sistem temasına geç',
     search: 'Ara',
     clear: 'Temizle',
+    tags: 'Etiketler',
     search_back: 'Arama sonuçlarına geri dön',
     search_or_ask: 'Sor veya ara',
     search_input_placeholder: 'İçerikte ara',

--- a/packages/gitbook/src/intl/translations/uk.ts
+++ b/packages/gitbook/src/intl/translations/uk.ts
@@ -11,6 +11,7 @@ export const uk: TranslationLanguage = {
     switch_to_system_theme: 'Перемкнути на системну тему',
     search: 'Пошук',
     clear: 'Очистити',
+    tags: 'Теги',
     search_back: 'Назад до результатів пошуку',
     search_or_ask: 'Запитати або шукати',
     search_input_placeholder: 'Шукати вміст',

--- a/packages/gitbook/src/intl/translations/vi.ts
+++ b/packages/gitbook/src/intl/translations/vi.ts
@@ -11,6 +11,7 @@ export const vi: TranslationLanguage = {
     switch_to_system_theme: 'Chuyển sang giao diện hệ thống',
     search: 'Tìm kiếm',
     clear: 'Xóa',
+    tags: 'Thẻ',
     search_back: 'Quay lại kết quả tìm kiếm',
     search_or_ask: 'Hỏi hoặc tìm kiếm',
     search_input_placeholder: 'Tìm kiếm nội dung',

--- a/packages/gitbook/src/intl/translations/yue.ts
+++ b/packages/gitbook/src/intl/translations/yue.ts
@@ -11,6 +11,7 @@ export const yue: TranslationLanguage = {
     switch_to_system_theme: '切換到系統主題',
     search: '搜尋',
     clear: '清除',
+    tags: '標籤',
     search_back: '返回搜尋結果',
     search_or_ask: '發問或搜尋',
     search_input_placeholder: '搜尋內容',

--- a/packages/gitbook/src/intl/translations/zh-tw.ts
+++ b/packages/gitbook/src/intl/translations/zh-tw.ts
@@ -11,6 +11,7 @@ export const zh_tw: TranslationLanguage = {
     switch_to_system_theme: '切換至系統主題',
     search: '搜尋',
     clear: '清除',
+    tags: '標籤',
     search_back: '返回搜尋結果',
     search_or_ask: '詢問或搜尋',
     search_input_placeholder: '搜尋內容',

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -11,6 +11,7 @@ export const zh: TranslationLanguage = {
     switch_to_system_theme: '切换到系统主题',
     search: '搜索',
     clear: '清除',
+    tags: '标签',
     search_back: '返回搜索结果',
     search_or_ask: '询问或搜索',
     search_input_placeholder: '搜索内容',

--- a/packages/gitbook/src/lib/document-sections.test.ts
+++ b/packages/gitbook/src/lib/document-sections.test.ts
@@ -208,20 +208,20 @@ describe('getDocumentSections', () => {
                 id: section.id,
                 depth: section.depth,
                 title: reactNodeToText(section.title),
-                updateTagSlugs: section.updateTagSlugs,
+                tags: section.tags,
             }))
         ).toEqual([
             {
                 id: 'h1-in-update',
                 depth: 1,
                 title: 'Heading 1 in update',
-                updateTagSlugs: ['improvements'],
+                tags: ['improvements'],
             },
             {
                 id: 'h2-in-update',
                 depth: 2,
                 title: 'Heading 2 in update',
-                updateTagSlugs: ['improvements'],
+                tags: ['improvements'],
             },
         ]);
     });

--- a/packages/gitbook/src/lib/document-sections.test.ts
+++ b/packages/gitbook/src/lib/document-sections.test.ts
@@ -137,7 +137,10 @@ describe('getDocumentSections', () => {
                         {
                             object: 'block',
                             type: 'update',
-                            data: { date: '2026-04-08' },
+                            data: {
+                                date: '2026-04-08',
+                                tags: [{ kind: 'tag', tag: 'improvements' }],
+                            },
                             isVoid: false,
                             nodes: [
                                 {
@@ -183,24 +186,42 @@ describe('getDocumentSections', () => {
             ],
         };
 
-        const sections = await getDocumentSections(context, document);
+        const sections = await getDocumentSections(
+            {
+                ...context,
+                revision: {
+                    tags: [
+                        {
+                            slug: 'improvements',
+                            label: 'Improvements',
+                            color: 'default',
+                            icon: undefined,
+                        },
+                    ],
+                },
+            } as unknown as GitBookAnyContext,
+            document
+        );
 
         expect(
             sections.map((section) => ({
                 id: section.id,
                 depth: section.depth,
                 title: reactNodeToText(section.title),
+                updateTagSlugs: section.updateTagSlugs,
             }))
         ).toEqual([
             {
                 id: 'h1-in-update',
                 depth: 1,
                 title: 'Heading 1 in update',
+                updateTagSlugs: ['improvements'],
             },
             {
                 id: 'h2-in-update',
                 depth: 2,
                 title: 'Heading 2 in update',
+                updateTagSlugs: ['improvements'],
             },
         ]);
     });

--- a/packages/gitbook/src/lib/document-sections.ts
+++ b/packages/gitbook/src/lib/document-sections.ts
@@ -16,7 +16,7 @@ export interface DocumentSection {
     title: ReactNode;
     depth: number;
     deprecated?: boolean;
-    updateTagSlugs?: string[];
+    tags?: string[];
 }
 
 /**
@@ -36,7 +36,7 @@ async function getSectionsFromNodes(
     nodes: DocumentBlock[],
     context: GitBookAnyContext,
     initialDepth = 0,
-    updateTagSlugs?: string[]
+    tags?: string[]
 ): Promise<DocumentSection[]> {
     const sections: DocumentSection[] = [];
     let depth = initialDepth;
@@ -50,7 +50,7 @@ async function getSectionsFromNodes(
                 }
                 depth = 1;
                 const title = getNodeReactText(block);
-                sections.push(withUpdateTags({ id, title, depth: 1 }, updateTagSlugs));
+                sections.push(withTags({ id, title, depth: 1 }, tags));
                 continue;
             }
             case 'heading-2': {
@@ -59,16 +59,14 @@ async function getSectionsFromNodes(
                     continue;
                 }
                 const title = getNodeReactText(block);
-                sections.push(
-                    withUpdateTags({ id, title, depth: depth > 0 ? 2 : 1 }, updateTagSlugs)
-                );
+                sections.push(withTags({ id, title, depth: depth > 0 ? 2 : 1 }, tags));
                 continue;
             }
             case 'columns':
             case 'stepper': {
                 const stepNodes = await Promise.all(
                     block.nodes.map(async (step) =>
-                        getSectionsFromNodes(step.nodes, context, depth, updateTagSlugs)
+                        getSectionsFromNodes(step.nodes, context, depth, tags)
                     )
                 );
                 for (const stepSections of stepNodes) {
@@ -105,7 +103,7 @@ async function getSectionsFromNodes(
                 });
                 if (operation) {
                     sections.push(
-                        withUpdateTags(
+                        withTags(
                             {
                                 id,
                                 tag: operation.method.toUpperCase(),
@@ -113,7 +111,7 @@ async function getSectionsFromNodes(
                                 depth: 1,
                                 deprecated: operation.operation.deprecated,
                             },
-                            updateTagSlugs
+                            tags
                         )
                     );
                 }
@@ -130,14 +128,14 @@ async function getSectionsFromNodes(
                 });
                 if (webhook) {
                     sections.push(
-                        withUpdateTags(
+                        withTags(
                             {
                                 id,
                                 title: webhook.operation.summary || webhook.name,
                                 depth: 1,
                                 deprecated: webhook.operation.deprecated,
                             },
-                            updateTagSlugs
+                            tags
                         )
                     );
                 }
@@ -160,13 +158,13 @@ async function getSectionsFromNodes(
                 const schema = data?.schemas[0];
                 if (schema) {
                     sections.push(
-                        withUpdateTags(
+                        withTags(
                             {
                                 id,
                                 title: `The ${schema.name} object`,
                                 depth: 1,
                             },
-                            updateTagSlugs
+                            tags
                         )
                     );
                 }
@@ -202,7 +200,7 @@ async function getSectionsFromNodes(
                     document.nodes,
                     reusableContent.context,
                     depth,
-                    updateTagSlugs
+                    tags
                 );
                 sections.push(...reusableContentSections);
             }
@@ -212,9 +210,9 @@ async function getSectionsFromNodes(
     return sections;
 }
 
-function withUpdateTags(
-    section: Omit<DocumentSection, 'updateTagSlugs'>,
-    updateTagSlugs: string[] | undefined
+function withTags(
+    section: Omit<DocumentSection, 'tags'>,
+    tags: string[] | undefined
 ): DocumentSection {
-    return updateTagSlugs === undefined ? section : { ...section, updateTagSlugs };
+    return tags === undefined ? section : { ...section, tags };
 }

--- a/packages/gitbook/src/lib/document-sections.ts
+++ b/packages/gitbook/src/lib/document-sections.ts
@@ -8,6 +8,7 @@ import { resolveOpenAPIOperationBlock } from './openapi/resolveOpenAPIOperationB
 import { resolveOpenAPISchemasBlock } from './openapi/resolveOpenAPISchemasBlock';
 import { resolveOpenAPIWebhookBlock } from './openapi/resolveOpenAPIWebhookBlock';
 import { resolveContentRef } from './references';
+import { getRevisionTags, resolveBlockTags } from './tags';
 
 export interface DocumentSection {
     id: string;
@@ -15,6 +16,7 @@ export interface DocumentSection {
     title: ReactNode;
     depth: number;
     deprecated?: boolean;
+    updateTagSlugs?: string[];
 }
 
 /**
@@ -33,7 +35,8 @@ export async function getDocumentSections(
 async function getSectionsFromNodes(
     nodes: DocumentBlock[],
     context: GitBookAnyContext,
-    initialDepth = 0
+    initialDepth = 0,
+    updateTagSlugs?: string[]
 ): Promise<DocumentSection[]> {
     const sections: DocumentSection[] = [];
     let depth = initialDepth;
@@ -47,11 +50,7 @@ async function getSectionsFromNodes(
                 }
                 depth = 1;
                 const title = getNodeReactText(block);
-                sections.push({
-                    id,
-                    title,
-                    depth: 1,
-                });
+                sections.push(withUpdateTags({ id, title, depth: 1 }, updateTagSlugs));
                 continue;
             }
             case 'heading-2': {
@@ -60,18 +59,16 @@ async function getSectionsFromNodes(
                     continue;
                 }
                 const title = getNodeReactText(block);
-                sections.push({
-                    id,
-                    title,
-                    depth: depth > 0 ? 2 : 1,
-                });
+                sections.push(
+                    withUpdateTags({ id, title, depth: depth > 0 ? 2 : 1 }, updateTagSlugs)
+                );
                 continue;
             }
             case 'columns':
             case 'stepper': {
                 const stepNodes = await Promise.all(
                     block.nodes.map(async (step) =>
-                        getSectionsFromNodes(step.nodes, context, depth)
+                        getSectionsFromNodes(step.nodes, context, depth, updateTagSlugs)
                     )
                 );
                 for (const stepSections of stepNodes) {
@@ -80,9 +77,15 @@ async function getSectionsFromNodes(
                 continue;
             }
             case 'updates': {
+                const revisionTags = getRevisionTags(context.revision);
                 const updateNodes = await Promise.all(
                     block.nodes.map(async (update) =>
-                        getSectionsFromNodes(update.nodes as DocumentBlock[], context, depth)
+                        getSectionsFromNodes(
+                            update.nodes as DocumentBlock[],
+                            context,
+                            depth,
+                            resolveBlockTags(update.data.tags, revisionTags).map((tag) => tag.slug)
+                        )
                     )
                 );
                 for (const updateSections of updateNodes) {
@@ -101,13 +104,18 @@ async function getSectionsFromNodes(
                     context,
                 });
                 if (operation) {
-                    sections.push({
-                        id,
-                        tag: operation.method.toUpperCase(),
-                        title: operation.operation.summary || operation.path,
-                        depth: 1,
-                        deprecated: operation.operation.deprecated,
-                    });
+                    sections.push(
+                        withUpdateTags(
+                            {
+                                id,
+                                tag: operation.method.toUpperCase(),
+                                title: operation.operation.summary || operation.path,
+                                depth: 1,
+                                deprecated: operation.operation.deprecated,
+                            },
+                            updateTagSlugs
+                        )
+                    );
                 }
                 continue;
             }
@@ -121,12 +129,17 @@ async function getSectionsFromNodes(
                     context,
                 });
                 if (webhook) {
-                    sections.push({
-                        id,
-                        title: webhook.operation.summary || webhook.name,
-                        depth: 1,
-                        deprecated: webhook.operation.deprecated,
-                    });
+                    sections.push(
+                        withUpdateTags(
+                            {
+                                id,
+                                title: webhook.operation.summary || webhook.name,
+                                depth: 1,
+                                deprecated: webhook.operation.deprecated,
+                            },
+                            updateTagSlugs
+                        )
+                    );
                 }
                 continue;
             }
@@ -146,11 +159,16 @@ async function getSectionsFromNodes(
                 });
                 const schema = data?.schemas[0];
                 if (schema) {
-                    sections.push({
-                        id,
-                        title: `The ${schema.name} object`,
-                        depth: 1,
-                    });
+                    sections.push(
+                        withUpdateTags(
+                            {
+                                id,
+                                title: `The ${schema.name} object`,
+                                depth: 1,
+                            },
+                            updateTagSlugs
+                        )
+                    );
                 }
                 continue;
             }
@@ -183,7 +201,8 @@ async function getSectionsFromNodes(
                 const reusableContentSections = await getSectionsFromNodes(
                     document.nodes,
                     reusableContent.context,
-                    depth
+                    depth,
+                    updateTagSlugs
                 );
                 sections.push(...reusableContentSections);
             }
@@ -191,4 +210,11 @@ async function getSectionsFromNodes(
     }
 
     return sections;
+}
+
+function withUpdateTags(
+    section: Omit<DocumentSection, 'updateTagSlugs'>,
+    updateTagSlugs: string[] | undefined
+): DocumentSection {
+    return updateTagSlugs === undefined ? section : { ...section, updateTagSlugs };
 }

--- a/packages/gitbook/src/lib/updates.test.ts
+++ b/packages/gitbook/src/lib/updates.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test';
+import type { JSONDocument, Revision } from '@gitbook/api';
+import { getDocumentUpdateTags } from './updates';
+
+describe('getDocumentUpdateTags', () => {
+    it('returns unique update tags in document order', () => {
+        const document = createUpdatesDocument([
+            ['improvements', 'fixes'],
+            ['new-releases'],
+            ['fixes'],
+            ['unknown'],
+        ]);
+        const revision = {
+            tags: [
+                createTag('new-releases', 'New releases'),
+                createTag('fixes', 'Fixes'),
+                createTag('improvements', 'Improvements'),
+            ],
+        } as unknown as Revision;
+
+        expect(getDocumentUpdateTags(document, revision).map((tag) => tag.slug)).toEqual([
+            'improvements',
+            'fixes',
+            'new-releases',
+        ]);
+    });
+});
+
+function createUpdatesDocument(updateTags: string[][]): JSONDocument {
+    return {
+        object: 'document',
+        data: { schemaVersion: 2 },
+        nodes: [
+            {
+                object: 'block',
+                type: 'updates',
+                data: { format: 'full' },
+                isVoid: false,
+                nodes: updateTags.map((tags, index) => ({
+                    object: 'block',
+                    type: 'update',
+                    data: {
+                        date: `2026-05-${String(index + 1).padStart(2, '0')}`,
+                        tags: tags.map((tag) => ({ kind: 'tag', tag })),
+                    },
+                    isVoid: false,
+                    nodes: [],
+                })),
+            },
+        ],
+    };
+}
+
+function createTag(slug: string, label: string) {
+    return {
+        slug,
+        label,
+        color: 'default',
+        icon: undefined,
+    };
+}

--- a/packages/gitbook/src/lib/updates.test.ts
+++ b/packages/gitbook/src/lib/updates.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import type { JSONDocument, Revision } from '@gitbook/api';
-import { getDocumentUpdateTags } from './updates';
+import { getDocumentFilterableTags } from './updates';
 
-describe('getDocumentUpdateTags', () => {
+describe('getDocumentFilterableTags', () => {
     it('returns unique update tags in document order', () => {
         const document = createUpdatesDocument([
             ['improvements', 'fixes'],
@@ -18,7 +18,7 @@ describe('getDocumentUpdateTags', () => {
             ],
         } as unknown as Revision;
 
-        expect(getDocumentUpdateTags(document, revision).map((tag) => tag.slug)).toEqual([
+        expect(getDocumentFilterableTags(document, revision).map((tag) => tag.slug)).toEqual([
             'improvements',
             'fixes',
             'new-releases',
@@ -26,7 +26,7 @@ describe('getDocumentUpdateTags', () => {
     });
 });
 
-function createUpdatesDocument(updateTags: string[][]): JSONDocument {
+function createUpdatesDocument(entryTags: string[][]): JSONDocument {
     return {
         object: 'document',
         data: { schemaVersion: 2 },
@@ -36,7 +36,7 @@ function createUpdatesDocument(updateTags: string[][]): JSONDocument {
                 type: 'updates',
                 data: { format: 'full' },
                 isVoid: false,
-                nodes: updateTags.map((tags, index) => ({
+                nodes: entryTags.map((tags, index) => ({
                     object: 'block',
                     type: 'update',
                     data: {

--- a/packages/gitbook/src/lib/updates.ts
+++ b/packages/gitbook/src/lib/updates.ts
@@ -5,7 +5,7 @@ import { getRevisionTags, resolveBlockTags } from './tags';
 /**
  * Get the unique tags used by update entries in a document, preserving document order.
  */
-export function getDocumentUpdateTags(
+export function getDocumentFilterableTags(
     document: JSONDocument,
     revision: Revision | undefined
 ): RevisionTag[] {

--- a/packages/gitbook/src/lib/updates.ts
+++ b/packages/gitbook/src/lib/updates.ts
@@ -1,0 +1,30 @@
+import type { JSONDocument, Revision, RevisionTag } from '@gitbook/api';
+import { getBlocksByType } from './document';
+import { getRevisionTags, resolveBlockTags } from './tags';
+
+/**
+ * Get the unique tags used by update entries in a document, preserving document order.
+ */
+export function getDocumentUpdateTags(
+    document: JSONDocument,
+    revision: Revision | undefined
+): RevisionTag[] {
+    const revisionTags = getRevisionTags(revision);
+    const seen = new Set<string>();
+    const tags: RevisionTag[] = [];
+
+    for (const updatesBlock of getBlocksByType(document, 'updates')) {
+        for (const updateBlock of updatesBlock.nodes) {
+            for (const tag of resolveBlockTags(updateBlock.data.tags, revisionTags)) {
+                if (seen.has(tag.slug)) {
+                    continue;
+                }
+
+                tags.push(tag);
+                seen.add(tag.slug);
+            }
+        }
+    }
+
+    return tags;
+}

--- a/packages/gitbook/tests/cors.test.ts
+++ b/packages/gitbook/tests/cors.test.ts
@@ -137,7 +137,7 @@ describe('CORS', () => {
             expect(response.status).toBe(200);
             expect(response.headers.get('access-control-allow-origin')).toBe(origin);
             expect(response.headers.get('access-control-allow-credentials')).toBe('true');
-        });
+        }, 10_000);
 
         it('should allow a subdomain (same registrable domain)', async () => {
             const origin = 'https://docs.gitbook.com';
@@ -147,7 +147,7 @@ describe('CORS', () => {
 
             expect(response.status).toBe(200);
             expect(response.headers.get('access-control-allow-origin')).toBe(origin);
-        });
+        }, 10_000);
 
         it('should reject a different registrable domain', async () => {
             const response = await fetch(TEST_URL, {
@@ -156,6 +156,6 @@ describe('CORS', () => {
 
             expect(response.status).toBe(200);
             expect(response.headers.get('access-control-allow-origin')).toBeNull();
-        });
+        }, 10_000);
     });
 });


### PR DESCRIPTION
## Summary

Add a tag selector for Updates blocks in the page aside. Selecting one or more tags filters update entries with OR semantics, keeps the selected tags in the URL via repeated `tag` search params, and keeps the page outline in sync with filtered update headings.

The clear control stays mounted to avoid layout shift when the first tag is selected.

## Validation

- `bun run format` completed with existing unrelated Biome warnings.
- `bun test src/lib/updates.test.ts src/lib/document-sections.test.ts --preload ./tests/preload-bun.ts` passed.
- `bun run typecheck` still fails on existing unrelated `IntegrationBlock.tsx` `block.meta` typing errors.