### PR TITLE
Update regional cache settings

### DIFF
--- a/packages/gitbook/openNext/incrementalCache/middleware.ts
+++ b/packages/gitbook/openNext/incrementalCache/middleware.ts
@@ -5,7 +5,8 @@ export default withRegionalCache(new GitbookIncrementalCache(), {
     mode: 'long-lived',
     // We can do it because we use our own logic to invalidate the cache
     bypassTagCacheOnCacheHit: true,
-    defaultLongLivedTtlSec: 60 * 60 * 24 /* 24 hours */,
+    //TODO: bump it again once I figured out the race condition
+    defaultLongLivedTtlSec: 5 * 60, // 5 minutes
     // We don't want to update the cache entry on every cache hit
     shouldLazilyUpdateOnCacheHit: false,
 });

--- a/packages/gitbook/openNext/incrementalCache/server.ts
+++ b/packages/gitbook/openNext/incrementalCache/server.ts
@@ -1,15 +1,15 @@
+import { withRegionalCache } from '@opennextjs/cloudflare/overrides/incremental-cache/regional-cache';
 import { GitbookIncrementalCache } from './incrementalCache';
 
-// export default withRegionalCache(new GitbookIncrementalCache(), {
-//     mode: 'long-lived',
-//     // Because of a race condition, the middleware may have populated the cache entry before `cache.match` had time to run on the server.
-//     // TODO: We should bypass the incremental cache entirely when the interceptor has caught the request. Should be done in OpenNext.
-//     bypassTagCacheOnCacheHit: false,
-//     //TODO: remove, reducing cache ttl of regional cache to help debugging
-//     defaultLongLivedTtlSec: 5 * 60 /* 5 minutes */,
-//     // We don't want to update the cache entry on every cache hit
-//     shouldLazilyUpdateOnCacheHit: false,
-// });
-
-//TODO: reenable regional cache once we know what's going on
-export default new GitbookIncrementalCache();
+// We cannot have regional cache only in the middleware, otherwise it will override things on cache miss
+// and cause race conditions. This will be fixed in a future release of OpenNext
+export default withRegionalCache(new GitbookIncrementalCache(), {
+    mode: 'long-lived',
+    // Because of a race condition, the middleware may have populated the cache entry before `cache.match` had time to run on the server.
+    // TODO: We should bypass the incremental cache entirely when the interceptor has caught the request. Should be done in OpenNext.
+    bypassTagCacheOnCacheHit: false,
+    //TODO: remove, reducing cache ttl of regional cache to help debugging
+    defaultLongLivedTtlSec: 5 * 60 /* 5 minutes */,
+    // We don't want to update the cache entry on every cache hit
+    shouldLazilyUpdateOnCacheHit: false,
+});


### PR DESCRIPTION
Adjust the default long-lived TTL to 5 minutes and re-enable the regional cache on the server to improve caching behavior and address race conditions.