### PR TITLE
Add page actions layout visibility

### DIFF
--- a/.changeset/page-actions-layout-visibility.md
+++ b/.changeset/page-actions-layout-visibility.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add support for hiding page actions from page layout options.

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -28,7 +28,7 @@ export async function PageHeader(props: {
     const hasAncestors = ancestors.length > 0;
 
     // @ts-expect-error available in next API update
-    const pageActionsEnabled = page.layout.pageActions !== false;
+    const pageActionsEnabled = page.layout.actions !== false;
 
     // Show page actions if *any* of the actions are enabled
     const hasPageActions =

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -27,13 +27,18 @@ export async function PageHeader(props: {
 
     const hasAncestors = ancestors.length > 0;
 
+    // @ts-expect-error available in next API update
+    const pageActionsEnabled = page.layout.pageActions !== false;
+
     // Show page actions if *any* of the actions are enabled
-    const hasPageActions = [
-        ...Object.values(context.customization.pageActions),
-        context.customization.pdf.enabled,
-        context.customization.git.showEditLink,
-        withRSSFeed,
-    ].some(Boolean);
+    const hasPageActions =
+        pageActionsEnabled &&
+        [
+            ...Object.values(context.customization.pageActions),
+            context.customization.pdf.enabled,
+            context.customization.git.showEditLink,
+            withRSSFeed,
+        ].some(Boolean);
 
     if (!page.layout.title && !page.layout.description && !hasPageActions) {
         return null;


### PR DESCRIPTION
## What changed

Added support for the new `page.layout.actions` option when deciding whether to render page actions.

When the layout option is `false`, the PageActions dropdown is hidden. Missing or undefined values preserve the existing behavior until the API types are updated.

## Validation

- `bun run format`
- `git diff --check`
- `bun run typecheck` failed on unrelated existing `DocumentBlockIntegration.meta` errors in `packages/gitbook/src/components/DocumentView/Integration/IntegrationBlock.tsx`.
