### PR TITLE
Don't display agents instructions for page action

### DIFF
--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -86,7 +86,7 @@ function useCopiedStore(stateKey: string) {
 }
 
 /**
- * Cache for the markdown versbion of the page.
+ * Cache for the markdown version of the page.
  */
 const markdownCache = new QuickLRU<string, string>({ maxSize: 10 });
 
@@ -109,7 +109,8 @@ export function ActionCopyMarkdown(props: {
     const fetchMarkdown = async () => {
         setLoading(true);
 
-        const result = await fetch(markdownPageURL).then((res) => res.text());
+        const humanURL = `${markdownPageURL}?displayAgentInstructions=false`;
+        const result = await fetch(humanURL).then((res) => res.text());
         markdownCache.set(markdownPageURL, result);
 
         setLoading(false);
@@ -160,7 +161,7 @@ export function ActionViewAsMarkdown(props: { markdownPageURL: string; type: Pag
             icon="markdown"
             label={tString(language, 'view_page_markdown')}
             description={tString(language, 'view_page_plaintext')}
-            href={markdownPageURL}
+            href={`${markdownPageURL}?displayAgentInstructions=false`}
         />
     );
 }

--- a/packages/gitbook/src/lib/context.ts
+++ b/packages/gitbook/src/lib/context.ts
@@ -75,6 +75,13 @@ export type SiteURLData = Pick<
      * Whether the request included a visitor token.
      */
     isLoggedInVisitor?: boolean;
+
+    /**
+     * Whether to display agent instructions in the markdown output.
+     * When false, agent-facing footers (e.g. "Agent Instructions") are omitted.
+     * Defaults to true when undefined.
+     */
+    displayAgentInstructions?: boolean;
 };
 
 /**
@@ -172,6 +179,9 @@ export type GitBookSiteContext = GitBookSpaceContext & {
 
     /** Whether the request included a visitor token. */
     isLoggedInVisitor: boolean;
+
+    /** Whether to display agent instructions in the markdown output. Defaults to true when undefined. */
+    displayAgentInstructions?: boolean;
 };
 
 /**
@@ -253,6 +263,7 @@ export async function fetchSiteContextByURLLookup(
         isFallback: data.isFallback ?? false,
         noIndexSearch: data.noIndexSearch ?? false,
         isLoggedInVisitor: data.isLoggedInVisitor ?? false,
+        displayAgentInstructions: data.displayAgentInstructions,
     });
 }
 
@@ -274,6 +285,7 @@ export async function fetchSiteContextByIds(
         isFallback: boolean;
         noIndexSearch: boolean;
         isLoggedInVisitor: boolean;
+        displayAgentInstructions?: boolean;
     }
 ): Promise<GitBookSiteContext> {
     const { dataFetcher } = baseContext;
@@ -399,6 +411,7 @@ export async function fetchSiteContextByIds(
         isFallback: ids.isFallback,
         noIndexSearch: ids.noIndexSearch,
         isLoggedInVisitor: ids.isLoggedInVisitor,
+        displayAgentInstructions: ids.displayAgentInstructions,
     };
 }
 

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -379,6 +379,10 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
                     ? true
                     : undefined,
             isLoggedInVisitor: visitorToken ? true : undefined,
+            displayAgentInstructions:
+                requestURL.searchParams.get('displayAgentInstructions') === 'false'
+                    ? false
+                    : undefined,
         };
 
         const requestHeaders = new Headers(request.headers);
@@ -485,6 +489,9 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         rewrittenURL.search = request.nextUrl.search;
         if (rewrittenURL.searchParams.has('fallback')) {
             rewrittenURL.searchParams.delete('fallback');
+        }
+        if (rewrittenURL.searchParams.has('displayAgentInstructions')) {
+            rewrittenURL.searchParams.delete('displayAgentInstructions');
         }
 
         const response = NextResponse.rewrite(rewrittenURL, {

--- a/packages/gitbook/src/routes/markdownPage.ts
+++ b/packages/gitbook/src/routes/markdownPage.ts
@@ -27,6 +27,9 @@ export async function servePageMarkdown(baseContext: GitBookSiteContext, pagePat
         }
 
         const markdownPage = await getMarkdownForPage(context, pageLookup);
+        if (baseContext.displayAgentInstructions === false) {
+            return markdownPage;
+        }
         return `${markdownPage}${renderAskFooter(context, pageLookup)}`;
     });
 }


### PR DESCRIPTION
Page markdown actions now defaults to not displaying agents instructions.

Agent accessing the site will still have access to it