### PR TITLE
Make shortcuts work on non-QWERTY keyboards

### DIFF
--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -58,7 +58,9 @@ export function AIChat() {
         () => {
             chatController.close();
         },
-        []
+        {
+            useKey: true,
+        }
     );
 
     // Track the view of the AI chat

--- a/packages/gitbook/src/components/AIChat/AIChatInput.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatInput.tsx
@@ -42,6 +42,7 @@ export function AIChatInput(props: {
         },
         {
             enableOnFormTags: true,
+            useKey: true,
         }
     );
 

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -69,6 +69,7 @@ export function SearchContainer({
         },
         {
             enableOnFormTags: true,
+            useKey: true,
         }
     );
 
@@ -84,6 +85,7 @@ export function SearchContainer({
         },
         {
             enableOnFormTags: true,
+            useKey: true,
         }
     );
 


### PR DESCRIPTION
I did not test this. You also need to update the library to 5.2.0, the version that introduced this flag.

Fixes https://github.com/GitbookIO/gitbook/issues/4008

https://github.com/JohannesKlauss/react-hotkeys-hook/issues/1323

https://github.com/JohannesKlauss/react-hotkeys-hook#options