### PR TITLE
Full screen view for Mermaid diagrams

### DIFF
--- a/.changeset/mermaid-fullscreen.md
+++ b/.changeset/mermaid-fullscreen.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Allow Mermaid diagrams to be enlarged into a fullscreen dialog from a control in the bottom-right corner. Clicking outside the dialog, pressing Escape, or using the reduce control returns to the inline view.

--- a/.changeset/tooltip-non-interactive.md
+++ b/.changeset/tooltip-non-interactive.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Make `Tooltip` content non-interactive when `disableHoverableContent` is set, so its portaled popper wrapper no longer steals pointer events (e.g. hover-revealed controls) from the trigger.

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@changesets/cli": "^2.31.0",
-        "turbo": "^2.9.12",
+        "turbo": "^2.9.14",
         "vercel": "50.37.3",
       },
     },
@@ -175,6 +175,7 @@
         "p-retry": "^8.0.0",
         "quick-lru": "^7.0.1",
         "react": "19.2.4",
+        "react-aria": "^3.44.0",
         "react-dom": "19.2.4",
         "react-hotkeys-hook": "^4.4.1",
         "rehype-raw": "^7.0.0",

--- a/packages/gitbook/package.json
+++ b/packages/gitbook/package.json
@@ -67,6 +67,7 @@
         "p-retry": "^8.0.0",
         "quick-lru": "^7.0.1",
         "react": "19.2.4",
+        "react-aria": "^3.44.0",
         "react-dom": "19.2.4",
         "react-hotkeys-hook": "^4.4.1",
         "rehype-raw": "^7.0.0",

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
@@ -1,16 +1,21 @@
 'use client';
 
 import { useTheme } from 'next-themes';
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useHasBeenInViewport } from '@/components/hooks/useHasBeenInViewport';
 import { Loading } from '@/components/primitives/Loading';
 import { tcls } from '@/lib/tailwind';
 import Panzoom from '@panzoom/panzoom';
 import type { RenderResult } from 'mermaid';
+import { FocusScope, usePreventScroll } from 'react-aria';
 import { type ClientBlockProps, ClientCodeBlock } from './ClientCodeBlock';
 import { MermaidPanZoomControls } from './MermaidPanZoomControls';
 import { getPlainCodeBlock } from './highlight';
+
+/** Duration of the fullscreen dialog enter/exit animation, must match `animate-blur-in/out`. */
+const DIALOG_ANIMATION_MS = 200;
 
 /**
  * Used to render a Mermaid diagram from a CodeBlock.
@@ -19,11 +24,18 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
     const { block, mode, style } = props;
     const source = getPlainCodeBlock(block);
     const rootRef = useRef<HTMLDivElement>(null);
+    const movableRef = useRef<HTMLDivElement>(null);
+    const panelRef = useRef<HTMLDivElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);
     const diagramRef = useRef<HTMLDivElement>(null);
     const [panZoom, setPanZoom] = useState<ReturnType<typeof Panzoom> | null>(null);
     const [error, setError] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
+    // `isFullscreen` is the open intent; `isExiting` keeps the dialog mounted while it
+    // animates closed. `isPresent` is true whenever the diagram lives in the dialog.
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const [isExiting, setIsExiting] = useState(false);
+    const isPresent = isFullscreen || isExiting;
     const { resolvedTheme } = useTheme();
     const darkMode = resolvedTheme === 'dark';
     const id = useSafeId();
@@ -96,27 +108,105 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
         };
     }, [source, id, darkMode, shouldRender]);
 
+    // Lock the page scroll while the dialog is on screen (handles scrollbar width and iOS).
+    usePreventScroll({ isDisabled: !isPresent });
+
+    const openFullscreen = useCallback(() => {
+        // Reserve the inline slot's current height before the diagram is detached, so the
+        // page layout does not jump. Measured here while still inline and un-restyled.
+        const root = rootRef.current;
+        if (root) {
+            root.style.minHeight = `${root.offsetHeight}px`;
+        }
+        setIsExiting(false);
+        setIsFullscreen(true);
+        // Re-center the diagram for the larger view.
+        panZoom?.reset();
+    }, [panZoom]);
+
+    const closeFullscreen = useCallback(() => {
+        setIsFullscreen(false);
+        setIsExiting(true);
+    }, []);
+
+    // Keep the dialog mounted until the exit animation finishes, then unmount it.
+    useEffect(() => {
+        if (!isExiting) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            setIsExiting(false);
+            panZoom?.reset();
+        }, DIALOG_ANIMATION_MS);
+        return () => window.clearTimeout(timer);
+    }, [isExiting, panZoom]);
+
+    // Allow Escape to close the dialog.
+    useEffect(() => {
+        if (!isFullscreen) {
+            return;
+        }
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                closeFullscreen();
+            }
+        };
+
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [isFullscreen, closeFullscreen]);
+
+    // Move the live diagram into the fullscreen dialog (and back) without re-rendering it,
+    // so panzoom and the rendered SVG are preserved. Done in the panel's ref callback so it
+    // happens during commit, before FocusScope reads focus. The inline slot's reserved
+    // height (set in openFullscreen) is cleared once the diagram returns to it.
+    const setPanel = useCallback((panel: HTMLDivElement | null) => {
+        panelRef.current = panel;
+        const root = rootRef.current;
+        const movable = movableRef.current;
+        if (!root || !movable) {
+            return;
+        }
+
+        if (panel) {
+            panel.appendChild(movable);
+        } else {
+            root.appendChild(movable);
+            root.style.minHeight = '';
+        }
+    }, []);
+
     if (error) {
         return <ClientCodeBlock {...props} />;
     }
 
-    return (
+    // The live diagram subtree. It is reparented between the inline slot and the
+    // fullscreen dialog, so its markup must not depend on where it currently lives.
+    const diagram = (
         <div
-            ref={rootRef}
-            className={tcls('group/mermaid relative', style)}
-            contentEditable={false}
+            ref={movableRef}
+            className={tcls(
+                'group/mermaid relative',
+                isPresent ? 'flex h-full w-full flex-col' : null
+            )}
         >
             <div
                 ref={wrapperRef}
-                className={
+                className={tcls(
                     isLoading
                         ? 'invisible absolute inset-x-0 overflow-hidden'
-                        : 'cursor-grab overflow-hidden active:cursor-grabbing'
-                }
+                        : 'cursor-grab overflow-hidden active:cursor-grabbing',
+                    isPresent && !isLoading ? 'flex-1' : null
+                )}
             >
                 <div
                     ref={diagramRef}
-                    className="overflow-auto p-2 [&_svg]:h-auto [&_svg]:max-w-full"
+                    className={tcls(
+                        'overflow-auto p-2 [&_svg]:h-auto [&_svg]:max-w-full',
+                        isPresent ? 'h-full [&_svg]:max-h-full' : null
+                    )}
                 />
             </div>
             {isLoading ? (
@@ -124,8 +214,53 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
                     <Loading className="h-8 w-8" />
                 </div>
             ) : null}
-            {!isLoading && panZoom ? <MermaidPanZoomControls panZoom={panZoom} /> : null}
+            {!isLoading && panZoom ? (
+                <MermaidPanZoomControls
+                    panZoom={panZoom}
+                    isFullscreen={isPresent}
+                    onToggleFullscreen={isFullscreen ? closeFullscreen : openFullscreen}
+                />
+            ) : null}
         </div>
+    );
+
+    return (
+        <>
+            {/* Inline slot: keeps the diagram in the document flow until it goes fullscreen. */}
+            <div ref={rootRef} className={tcls('relative', style)} contentEditable={false}>
+                {diagram}
+            </div>
+            {isPresent
+                ? createPortal(
+                      <FocusScope contain restoreFocus>
+                          {/* Backdrop: dims and blurs the page, closes on click. */}
+                          {/* biome-ignore lint/a11y/useKeyWithClickEvents: a global Escape handler closes the dialog. */}
+                          <div
+                              aria-hidden="true"
+                              className={tcls(
+                                  'fixed inset-0 z-40 bg-tint-base/3 backdrop-blur-md dark:bg-tint-base/6',
+                                  isFullscreen ? 'animate-fade-in' : 'animate-fade-out'
+                              )}
+                              onClick={closeFullscreen}
+                          />
+                          {/* Centered panel. The padding area lets clicks fall through to the backdrop. */}
+                          <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center p-3 sm:p-5 lg:p-8">
+                              <div
+                                  ref={setPanel}
+                                  role="dialog"
+                                  aria-modal="true"
+                                  aria-label="Mermaid diagram"
+                                  className={tcls(
+                                      'pointer-events-auto relative flex h-full w-full max-w-[110rem] flex-col overflow-hidden rounded-2xl border border-tint-subtle bg-tint-base shadow-2xl',
+                                      isFullscreen ? 'animate-blur-in' : 'animate-blur-out'
+                                  )}
+                              />
+                          </div>
+                      </FocusScope>,
+                      document.body
+                  )
+                : null}
+        </>
     );
 }
 

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
@@ -222,7 +222,9 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
                     ref={diagramRef}
                     className={tcls(
                         'overflow-auto p-2 [&_svg]:h-auto [&_svg]:max-w-full',
-                        isPresent ? 'h-full [&_svg]:max-h-full' : null
+                        isPresent
+                            ? 'flex h-full items-center justify-center [&_svg]:max-h-full'
+                            : null
                     )}
                 />
             </div>

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlock.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTheme } from 'next-themes';
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useHasBeenInViewport } from '@/components/hooks/useHasBeenInViewport';
@@ -24,10 +24,20 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
     const { block, mode, style } = props;
     const source = getPlainCodeBlock(block);
     const rootRef = useRef<HTMLDivElement>(null);
-    const movableRef = useRef<HTMLDivElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);
     const diagramRef = useRef<HTMLDivElement>(null);
+    // A stable container that holds the diagram subtree. We portal the diagram into it and
+    // only ever move this plain node between the inline slot and the dialog — never the
+    // React-managed subtree itself — so React stays in control and panzoom/SVG are preserved.
+    const diagramHostRef = useRef<HTMLDivElement | null>(null);
+    if (diagramHostRef.current === null && typeof document !== 'undefined') {
+        const host = document.createElement('div');
+        // `display: contents` so the host adds no box of its own (the diagram becomes a
+        // direct flex child of the dialog panel and can fill it).
+        host.style.display = 'contents';
+        diagramHostRef.current = host;
+    }
     const [panZoom, setPanZoom] = useState<ReturnType<typeof Panzoom> | null>(null);
     const [error, setError] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
@@ -158,22 +168,30 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
         return () => document.removeEventListener('keydown', onKeyDown);
     }, [isFullscreen, closeFullscreen]);
 
-    // Move the live diagram into the fullscreen dialog (and back) without re-rendering it,
-    // so panzoom and the rendered SVG are preserved. Done in the panel's ref callback so it
-    // happens during commit, before FocusScope reads focus. The inline slot's reserved
-    // height (set in openFullscreen) is cleared once the diagram returns to it.
+    // Keep the diagram host in the inline slot on mount (and whenever it isn't in the dialog).
+    useLayoutEffect(() => {
+        const host = diagramHostRef.current;
+        const root = rootRef.current;
+        if (host && root && !host.parentNode) {
+            root.appendChild(host);
+        }
+    }, []);
+
+    // Move the diagram host into the dialog panel (and back) as the panel mounts/unmounts.
+    // Done in the panel's ref callback so it happens during commit, before FocusScope reads
+    // focus. The inline slot's reserved height (set in openFullscreen) is cleared on return.
     const setPanel = useCallback((panel: HTMLDivElement | null) => {
         panelRef.current = panel;
+        const host = diagramHostRef.current;
         const root = rootRef.current;
-        const movable = movableRef.current;
-        if (!root || !movable) {
+        if (!host) {
             return;
         }
 
         if (panel) {
-            panel.appendChild(movable);
-        } else {
-            root.appendChild(movable);
+            panel.appendChild(host);
+        } else if (root) {
+            root.appendChild(host);
             root.style.minHeight = '';
         }
     }, []);
@@ -182,11 +200,10 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
         return <ClientCodeBlock {...props} />;
     }
 
-    // The live diagram subtree. It is reparented between the inline slot and the
-    // fullscreen dialog, so its markup must not depend on where it currently lives.
+    // The live diagram subtree. It is portaled into a stable host that moves between the
+    // inline slot and the dialog, so its markup must not depend on where it currently lives.
     const diagram = (
         <div
-            ref={movableRef}
             className={tcls(
                 'group/mermaid relative',
                 isPresent ? 'flex h-full w-full flex-col' : null
@@ -226,10 +243,9 @@ export function MermaidCodeBlock(props: ClientBlockProps) {
 
     return (
         <>
-            {/* Inline slot: keeps the diagram in the document flow until it goes fullscreen. */}
-            <div ref={rootRef} className={tcls('relative', style)} contentEditable={false}>
-                {diagram}
-            </div>
+            {/* Inline slot: hosts the diagram in the document flow until it goes fullscreen. */}
+            <div ref={rootRef} className={tcls('relative', style)} contentEditable={false} />
+            {diagramHostRef.current ? createPortal(diagram, diagramHostRef.current) : null}
             {isPresent
                 ? createPortal(
                       <FocusScope contain restoreFocus>

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
@@ -33,7 +33,7 @@ export function MermaidPanZoomControls(props: {
     return (
         <div
             className={tcls(
-                'absolute right-2 bottom-2 z-10 flex flex-col items-center gap-0.5 rounded-lg border border-tint-subtle bg-tint-base/9 p-0.5 shadow-sm backdrop-blur-md transition-opacity duration-150 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:opacity-100 motion-reduce:transition-none',
+                'absolute right-2 bottom-2 z-10 flex flex-col items-center gap-0.5 rounded-lg bg-tint-base/5 p-0.5 backdrop-blur-xs transition-opacity duration-150 hover:bg-tint-base/8 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:opacity-100 motion-reduce:transition-none',
                 // Keep the controls always visible in fullscreen, otherwise only reveal on hover/focus.
                 isFullscreen ? 'opacity-100' : 'opacity-0'
             )}

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
@@ -3,50 +3,109 @@
 import type { PanzoomObject } from '@panzoom/panzoom';
 
 import { Button } from '@/components/primitives';
+import { tcls } from '@/lib/tailwind';
 
 const PAN_STEP = 50;
 
 /**
- * Navigation and zoom controls for mermaid diagrams, positioned as an overlay.
+ * Navigation and zoom controls for mermaid diagrams, grouped into a single floating
+ * toolbar positioned in the bottom-right corner. The toolbar reads top-to-bottom as
+ * three clusters: fullscreen, pan, then zoom.
  */
-export function MermaidPanZoomControls(props: { panZoom: PanzoomObject }) {
-    const { panZoom } = props;
+export function MermaidPanZoomControls(props: {
+    panZoom: PanzoomObject;
+    isFullscreen: boolean;
+    onToggleFullscreen: () => void;
+}) {
+    const { panZoom, isFullscreen, onToggleFullscreen } = props;
     const btnProps = {
-        variant: 'secondary' as const,
+        variant: 'blank' as const,
         size: 'xsmall' as const,
         iconOnly: true,
+        className: 'p-1 [&_svg]:size-3.5',
+        // Non-interactive tooltips: the Tooltip primitive makes their popper wrapper
+        // pointer-transparent so it can't steal the hover that reveals these controls.
+        tooltipProps: {
+            rootProps: { disableHoverableContent: true },
+        },
     };
 
     return (
-        <div className="absolute right-3 bottom-3 z-10 grid grid-cols-3 gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:opacity-100 motion-reduce:transition-none">
-            {/* Row 1: empty, pan up, zoom in */}
-            <div />
+        <div
+            className={tcls(
+                'absolute right-2 bottom-2 z-10 flex flex-col items-center gap-0.5 rounded-lg border border-tint-subtle bg-tint-base/9 p-0.5 shadow-sm backdrop-blur-md transition-opacity duration-150 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:opacity-100 motion-reduce:transition-none',
+                // Keep the controls always visible in fullscreen, otherwise only reveal on hover/focus.
+                isFullscreen ? 'opacity-100' : 'opacity-0'
+            )}
+        >
             <Button
                 {...btnProps}
-                icon="chevron-up"
-                onClick={() => panZoom.pan(0, PAN_STEP, { relative: true })}
+                icon={isFullscreen ? 'compress' : 'expand'}
+                label={isFullscreen ? 'Exit full page' : 'View in full page'}
+                onClick={onToggleFullscreen}
             />
-            <Button {...btnProps} icon="plus" onClick={() => panZoom.zoomIn()} />
-            {/* Row 2: pan left, reset, pan right */}
-            <Button
-                {...btnProps}
-                icon="chevron-left"
-                onClick={() => panZoom.pan(PAN_STEP, 0, { relative: true })}
-            />
-            <Button {...btnProps} icon="refresh" onClick={() => panZoom.reset()} />
-            <Button
-                {...btnProps}
-                icon="chevron-right"
-                onClick={() => panZoom.pan(-PAN_STEP, 0, { relative: true })}
-            />
-            {/* Row 3: empty, pan down, zoom out */}
-            <div />
-            <Button
-                {...btnProps}
-                icon="chevron-down"
-                onClick={() => panZoom.pan(0, -PAN_STEP, { relative: true })}
-            />
-            <Button {...btnProps} icon="minus" onClick={() => panZoom.zoomOut()} />
+
+            <Divider />
+
+            {/* Pan cluster: directional cross with reset in the center. */}
+            <div className="grid grid-cols-3 gap-0.5">
+                <div />
+                <Button
+                    {...btnProps}
+                    icon="chevron-up"
+                    label="Pan up"
+                    onClick={() => panZoom.pan(0, PAN_STEP, { relative: true })}
+                />
+                <div />
+                <Button
+                    {...btnProps}
+                    icon="chevron-left"
+                    label="Pan left"
+                    onClick={() => panZoom.pan(PAN_STEP, 0, { relative: true })}
+                />
+                <Button
+                    {...btnProps}
+                    icon="arrows-to-dot"
+                    label="Reset view"
+                    onClick={() => panZoom.reset()}
+                />
+                <Button
+                    {...btnProps}
+                    icon="chevron-right"
+                    label="Pan right"
+                    onClick={() => panZoom.pan(-PAN_STEP, 0, { relative: true })}
+                />
+                <div />
+                <Button
+                    {...btnProps}
+                    icon="chevron-down"
+                    label="Pan down"
+                    onClick={() => panZoom.pan(0, -PAN_STEP, { relative: true })}
+                />
+                <div />
+            </div>
+
+            <Divider />
+
+            {/* Zoom cluster. */}
+            <div className="flex gap-0.5">
+                <Button
+                    {...btnProps}
+                    icon="minus"
+                    label="Zoom out"
+                    onClick={() => panZoom.zoomOut()}
+                />
+                <Button
+                    {...btnProps}
+                    icon="plus"
+                    label="Zoom in"
+                    onClick={() => panZoom.zoomIn()}
+                />
+            </div>
         </div>
     );
+}
+
+function Divider() {
+    return <div className="h-px w-full bg-tint-subtle" />;
 }

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidPanZoomControls.tsx
@@ -5,12 +5,9 @@ import type { PanzoomObject } from '@panzoom/panzoom';
 import { Button } from '@/components/primitives';
 import { tcls } from '@/lib/tailwind';
 
-const PAN_STEP = 50;
-
 /**
- * Navigation and zoom controls for mermaid diagrams, grouped into a single floating
- * toolbar positioned in the bottom-right corner. The toolbar reads top-to-bottom as
- * three clusters: fullscreen, pan, then zoom.
+ * Zoom and fullscreen controls for mermaid diagrams, grouped into a single vertical
+ * toolbar positioned in the bottom-right corner. Panning is done by dragging the diagram.
  */
 export function MermaidPanZoomControls(props: {
     panZoom: PanzoomObject;
@@ -19,10 +16,10 @@ export function MermaidPanZoomControls(props: {
 }) {
     const { panZoom, isFullscreen, onToggleFullscreen } = props;
     const btnProps = {
-        variant: 'blank' as const,
+        variant: 'secondary' as const,
         size: 'xsmall' as const,
         iconOnly: true,
-        className: 'p-1 [&_svg]:size-3.5',
+        className: tcls('p-1 [&_svg]:size-3.5 opacity-90'),
         // Non-interactive tooltips: the Tooltip primitive makes their popper wrapper
         // pointer-transparent so it can't steal the hover that reveals these controls.
         tooltipProps: {
@@ -33,79 +30,28 @@ export function MermaidPanZoomControls(props: {
     return (
         <div
             className={tcls(
-                'absolute right-2 bottom-2 z-10 flex flex-col items-center gap-0.5 rounded-lg bg-tint-base/5 p-0.5 backdrop-blur-xs transition-opacity duration-150 hover:bg-tint-base/8 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:opacity-100 motion-reduce:transition-none',
+                'absolute right-2 bottom-2 z-10 flex flex-col items-center gap-0.5 rounded-lg transition-opacity duration-150 group-focus-within/mermaid:pointer-events-auto group-focus-within/mermaid:opacity-100 group-hover/mermaid:opacity-100 motion-reduce:transition-none',
                 // Keep the controls always visible in fullscreen, otherwise only reveal on hover/focus.
                 isFullscreen ? 'opacity-100' : 'opacity-0'
             )}
         >
+            <Button {...btnProps} icon="plus" label="Zoom in" onClick={() => panZoom.zoomIn()} />
+            <Button
+                {...btnProps}
+                icon="arrows-to-dot"
+                label="Reset view"
+                onClick={() => panZoom.reset()}
+            />
+            <Button {...btnProps} icon="minus" label="Zoom out" onClick={() => panZoom.zoomOut()} />
+
+            <div className="my-0.5 h-px w-4 bg-tint-subtle" />
+
             <Button
                 {...btnProps}
                 icon={isFullscreen ? 'compress' : 'expand'}
                 label={isFullscreen ? 'Exit full page' : 'View in full page'}
                 onClick={onToggleFullscreen}
             />
-
-            <Divider />
-
-            {/* Pan cluster: directional cross with reset in the center. */}
-            <div className="grid grid-cols-3 gap-0.5">
-                <div />
-                <Button
-                    {...btnProps}
-                    icon="chevron-up"
-                    label="Pan up"
-                    onClick={() => panZoom.pan(0, PAN_STEP, { relative: true })}
-                />
-                <div />
-                <Button
-                    {...btnProps}
-                    icon="chevron-left"
-                    label="Pan left"
-                    onClick={() => panZoom.pan(PAN_STEP, 0, { relative: true })}
-                />
-                <Button
-                    {...btnProps}
-                    icon="arrows-to-dot"
-                    label="Reset view"
-                    onClick={() => panZoom.reset()}
-                />
-                <Button
-                    {...btnProps}
-                    icon="chevron-right"
-                    label="Pan right"
-                    onClick={() => panZoom.pan(-PAN_STEP, 0, { relative: true })}
-                />
-                <div />
-                <Button
-                    {...btnProps}
-                    icon="chevron-down"
-                    label="Pan down"
-                    onClick={() => panZoom.pan(0, -PAN_STEP, { relative: true })}
-                />
-                <div />
-            </div>
-
-            <Divider />
-
-            {/* Zoom cluster. */}
-            <div className="flex gap-0.5">
-                <Button
-                    {...btnProps}
-                    icon="minus"
-                    label="Zoom out"
-                    onClick={() => panZoom.zoomOut()}
-                />
-                <Button
-                    {...btnProps}
-                    icon="plus"
-                    label="Zoom in"
-                    onClick={() => panZoom.zoomIn()}
-                />
-            </div>
         </div>
     );
-}
-
-function Divider() {
-    return <div className="h-px w-full bg-tint-subtle" />;
 }

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -47,6 +47,17 @@
     }
 }
 
+/*
+  Radix renders tooltip content inside a portaled `[data-radix-popper-content-wrapper]` attached
+  to <body>. A non-interactive tooltip (Tooltip with `disableHoverableContent`) marks its content
+  with `data-non-interactive`; without this rule the pointer-interactive wrapper could sit over
+  the trigger and steal its hover (e.g. breaking hover-revealed controls). We can't style the
+  wrapper from React, so let pointer events pass through it for these tooltips only.
+*/
+[data-radix-popper-content-wrapper]:has([data-non-interactive]) {
+    pointer-events: none;
+}
+
 @utility linear-mask-gradient {
     mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 96px, rgba(0, 0, 0, 0));
     mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 96px, rgba(0, 0, 0, 0));

--- a/packages/gitbook/src/components/primitives/Button.tsx
+++ b/packages/gitbook/src/components/primitives/Button.tsx
@@ -219,7 +219,7 @@ export const Button = React.forwardRef<
                 }}
                 label={label}
                 triggerProps={{ disabled, ...tooltipProps?.triggerProps }}
-                contentProps={{ ...tooltipProps?.contentProps }}
+                contentProps={tooltipProps?.contentProps}
             >
                 {button}
             </Tooltip>

--- a/packages/gitbook/src/components/primitives/Tooltip.tsx
+++ b/packages/gitbook/src/components/primitives/Tooltip.tsx
@@ -46,9 +46,10 @@ export function Tooltip(props: {
               ...contentProps,
               'data-non-interactive': '',
               style: {
+                  ...contentProps?.style,
+                  // Forced last so the non-interactive guarantee can't be overridden.
                   pointerEvents: 'none' as const,
                   userSelect: 'none' as const,
-                  ...contentProps?.style,
               },
           }
         : contentProps;

--- a/packages/gitbook/src/components/primitives/Tooltip.tsx
+++ b/packages/gitbook/src/components/primitives/Tooltip.tsx
@@ -36,6 +36,23 @@ export function Tooltip(props: {
     const [open, setOpen] = useState(false);
     const [clicked, setClicked] = useState(false);
 
+    // When hoverable content is disabled, the content is purely informational: make it
+    // non-interactive so its (portaled) popper wrapper can't steal hover/clicks from the
+    // trigger. The `data-non-interactive` marker lets a scoped global rule (globals.css)
+    // set `pointer-events: none` on the wrapper, which we can't reach from React.
+    const nonInteractive = rootProps?.disableHoverableContent ?? false;
+    const resolvedContentProps = nonInteractive
+        ? {
+              ...contentProps,
+              'data-non-interactive': '',
+              style: {
+                  pointerEvents: 'none' as const,
+                  userSelect: 'none' as const,
+                  ...contentProps?.style,
+              },
+          }
+        : contentProps;
+
     return (
         <RadixTooltip.Root open={open || clicked} onOpenChange={setOpen} {...rootProps}>
             <RadixTooltip.Trigger asChild onClick={() => setClicked(true)} {...triggerProps}>
@@ -50,7 +67,7 @@ export function Tooltip(props: {
                         className
                     )}
                     onPointerDownOutside={() => setClicked(false)}
-                    {...contentProps}
+                    {...resolvedContentProps}
                 >
                     {label}
                     {arrow && <RadixTooltip.Arrow {...arrowProps} />}


### PR DESCRIPTION
## Overview

Mermaid diagrams can be hard to read inline when they're large. This adds a **fullscreen view**: a control in the diagram's bottom-right toolbar opens the diagram in a centered dialog where it can be panned and zoomed comfortably.


https://github.com/user-attachments/assets/938d0792-1b12-4381-a229-370ab27ff291



## What's new

- **Fullscreen toggle** in the Mermaid controls toolbar (expand / compress).
- Opens the diagram in a **centered dialog** (not edge-to-edge), so the dimmed/blurred page stays visible around it.
- **Closes** on: clicking outside, pressing <kbd>Escape</kbd>, or the reduce control — with enter/exit animations.
- The toolbar itself was reorganized into a single harmonious cluster (fullscreen · pan · zoom) and made a bit more compact.

## How it works

- **The live diagram is reparented, not re-rendered.** When entering fullscreen, the existing diagram DOM node is moved into the dialog and moved back on close. This preserves the rendered SVG and the panzoom instance (no re-render, no flicker, no second Mermaid pass).
- **No layout jump.** While the diagram is detached, the inline slot reserves its measured height, so content below doesn't shift.
- **Dialog is portaled to `document.body`** so it escapes any transformed/clipping ancestor and reliably covers the viewport.
- **`react-aria`** provides `FocusScope` (focus containment + restore) and `usePreventScroll` (robust scroll lock, incl. scrollbar width / iOS).

## Tooltip primitive change (separate commit)

The control tooltips exposed a pre-existing issue: Radix renders tooltip content in a portaled `[data-radix-popper-content-wrapper]` outside the diagram, and—being pointer-interactive—it stole the hover that reveals the controls, causing a flicker loop.

`Tooltip` now makes its content non-interactive whenever `disableHoverableContent` is set (marks it with `data-non-interactive` + a scoped global rule sets `pointer-events: none` on that wrapper). This is a generic primitive improvement, reusable by any tooltip, not a Mermaid-specific hack.

## Testing

- [x] Open a page with a Mermaid diagram, enter/exit fullscreen via the control, <kbd>Escape</kbd>, and click-outside.
- [x] Pan/zoom works in both inline and fullscreen views.
- [x] No page jump when toggling; scroll is locked behind the dialog.
- [x] Control tooltips show correctly and no longer flicker the toolbar on hover.
- [x] Light/dark themes.
