### PR TITLE
Improve accessibility in published docs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@changesets/cli": "^2.31.0",
-        "turbo": "^2.9.12",
+        "turbo": "^2.9.14",
         "vercel": "50.37.3",
       },
     },

--- a/packages/gitbook/src/components/AIChat/AIChatButton.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useLanguage } from '@/intl/client';
-import { t } from '@/intl/translate';
+import { t, tString } from '@/intl/translate';
 import type { Assistant } from '../AI';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { Button } from '../primitives';
@@ -38,6 +38,7 @@ export function AIChatButton(props: {
                     ) : null}
                 </div>
             }
+            aria-label={tString(language, 'ai_chat_ask', assistant.label)}
             onClick={() => assistant.open()}
         >
             {showLabel ? t(language, 'ask') : null}

--- a/packages/gitbook/src/components/Ads/Ad.tsx
+++ b/packages/gitbook/src/components/Ads/Ad.tsx
@@ -132,7 +132,7 @@ function AdSponsoredLink(props: { spaceId: string }) {
     viaUrl.searchParams.set('utm_campaign', spaceId);
 
     return (
-        <p className={tcls('mt-2', 'mr-2', 'text-xs', 'text-right', 'text-tint-subtle')}>
+        <p className={tcls('mt-2', 'mr-2', 'text-xs', 'text-right', 'text-tint')}>
             <Link
                 target="_blank"
                 href={viaUrl.toString()}

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -435,6 +435,7 @@ function PageActionWrapper(props: {
                 size="xsmall"
                 variant="secondary"
                 label={label ?? shortLabel}
+                aria-label={shortLabel}
                 className="bg-tint-base"
                 onClick={onClick}
                 href={href}

--- a/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
+++ b/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
@@ -108,7 +108,6 @@ export async function generateSiteLayoutViewport(context: GitBookSiteContext): P
                 : 'light dark', // 'system' → let browser decide based on OS preference
         width: 'device-width',
         initialScale: 1,
-        maximumScale: 1,
         viewportFit: 'cover',
     };
 }


### PR DESCRIPTION
## Improvements

- fix pinch-to-zoom on Android
- improve aria labels on "Ask assistant" buttons
- improve contrast on "Sponsored via GitBook"
- update the bun.lock

## Demo
Ask button has an aria-label
<img width="787" height="156" alt="image" src="https://github.com/user-attachments/assets/8635e803-cdd4-4101-a65f-0208da84f13f" />

Aria-label in the Ask button matches button content
<img width="727" height="92" alt="image" src="https://github.com/user-attachments/assets/61905df1-d8b8-496f-98fe-58c177501272" />

Color of "Sponsored via GitBook" changed to increase contrast ratio to more than 4.5:1
<img width="493" height="142" alt="image" src="https://github.com/user-attachments/assets/573166f2-dbc1-493c-abcb-ddb18bfccb8f" />
<img width="710" height="538" alt="image" src="https://github.com/user-attachments/assets/860bd953-3de7-46dc-9ad5-3f5962073c3e" />

Pinching to zoom is possible on Android devices (DevTools)
<img width="690" height="768" alt="image" src="https://github.com/user-attachments/assets/33e41e29-7752-4a61-8311-253fbd22a8f5" />
