### PR TITLE
Fix issue where MCP POST requests with expired tokens returns 307 instead of 401

### DIFF
--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -250,7 +250,6 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
              */
             if (
                 siteURLData.target === 'external' &&
-                !visitorToken &&
                 isOAuthProtectedResourceRequest(siteRequestURL)
             ) {
                 return handleUnauthedOAuthProtectedResourceRequest({


### PR DESCRIPTION
Generally the MCP client should request a fresh token via `refresh_token` grant before token expiration but seen some cases where this doesn't happen.