### PR TITLE
Adjust caching strategy for icon fetching based on runtime environment

### DIFF
--- a/packages/gitbook/src/lib/icons/inline.ts
+++ b/packages/gitbook/src/lib/icons/inline.ts
@@ -233,7 +233,8 @@ async function getInlineIconSource(
             () =>
                 fetch(getIconAssetURL(style, icon), {
                     // There is no benefit in caching this in vercel. It just cost tons of money
-                    cache: process.env.GITBOOK_RUNTIME === "cloudflare" ? 'force-cache' : 'no-cache',
+                    cache:
+                        process.env.GITBOOK_RUNTIME === 'cloudflare' ? 'force-cache' : 'no-cache',
                 }).then(async (response) => {
                     if (!response.ok) {
                         throw new Error('Failed to fetch icon');

--- a/packages/gitbook/src/lib/icons/inline.ts
+++ b/packages/gitbook/src/lib/icons/inline.ts
@@ -232,7 +232,8 @@ async function getInlineIconSource(
         const request = pRetry(
             () =>
                 fetch(getIconAssetURL(style, icon), {
-                    cache: 'force-cache',
+                    // There is no benefit in caching this in vercel. It just cost tons of money
+                    cache: process.env.GITBOOK_RUNTIME === "cloudflare" ? 'force-cache' : 'no-cache',
                 }).then(async (response) => {
                     if (!response.ok) {
                         throw new Error('Failed to fetch icon');

--- a/packages/gitbook/src/lib/icons/inline.ts
+++ b/packages/gitbook/src/lib/icons/inline.ts
@@ -232,7 +232,7 @@ async function getInlineIconSource(
         const request = pRetry(
             () =>
                 fetch(getIconAssetURL(style, icon), {
-                    // There is no benefit in caching this in vercel. It just cost tons of money
+                    // There is no benefit in caching this in Vercel, as we already cache in the Runtime Cache.
                     cache:
                         process.env.GITBOOK_RUNTIME === 'cloudflare' ? 'force-cache' : 'no-cache',
                 }).then(async (response) => {


### PR DESCRIPTION
Modify the caching strategy for fetching icons to optimize costs in different runtime environments. Use 'force-cache' for Cloudflare and 'no-cache' for other environments.