### PR TITLE
Fix caching strategy for icon fetching

### DIFF
--- a/packages/gitbook/src/lib/icons/inline.ts
+++ b/packages/gitbook/src/lib/icons/inline.ts
@@ -234,7 +234,7 @@ async function getInlineIconSource(
                 fetch(getIconAssetURL(style, icon), {
                     // There is no benefit in caching this in Vercel, as we already cache in the Runtime Cache.
                     cache:
-                        process.env.GITBOOK_RUNTIME === 'cloudflare' ? 'force-cache' : 'no-cache',
+                        process.env.GITBOOK_RUNTIME === 'cloudflare' ? 'force-cache' : 'no-store',
                 }).then(async (response) => {
                     if (!response.ok) {
                         throw new Error('Failed to fetch icon');
@@ -248,6 +248,9 @@ async function getInlineIconSource(
         return await request;
     } catch {
         console.warn(`Failed to fetch icon ${icon} with style ${style} after multiple attempts`);
+        // We don't want to store failed attempts in the cache. Otherwise it may crash subsequent attempts to fetch the same icon and will crash the entire page
+        // It's very visible in dev, where the map will stay around
+        rawSvgPromises.delete(cacheKey);
         return null;
     }
 }


### PR DESCRIPTION
Update the caching strategy to prevent storing failed fetch attempts for icons, which could lead to issues in subsequent attempts.

Very visible in dev, where the map is kept around a lot.