### PR TITLE
Fix inflated visitor counts from unstable anonymous visitorId

### DIFF
--- a/packages/gitbook/src/components/Insights/visitorId.tsx
+++ b/packages/gitbook/src/components/Insights/visitorId.tsx
@@ -5,7 +5,12 @@ import type { MaybePromise } from 'p-map';
 import React from 'react';
 import { createStore, useStore } from 'zustand';
 
-import { getBrowserCookie, getLocalStorageItem, setLocalStorageItem } from '@/lib/browser';
+import {
+    getBrowserCookie,
+    getLocalStorageItem,
+    removeLocalStorageItem,
+    setLocalStorageItem,
+} from '@/lib/browser';
 
 import { isCookiesTrackingDisabled } from './cookies';
 import { getSession } from './sessions';
@@ -169,6 +174,8 @@ function getGlobalVisitor({
     const withoutCookies = isCookiesTrackingDisabled();
 
     if (withoutCookies || !visitorCookieTrackingEnabled) {
+        // Consent withdrawn or tracking disabled: stop using AND retaining the stored id.
+        removeLocalStorageItem(VISITOR_STORAGE_KEY);
         return { visitor: { deviceId: getProposedVisitorId() }, pendingVisitor: null };
     }
 

--- a/packages/gitbook/src/components/Insights/visitorId.tsx
+++ b/packages/gitbook/src/components/Insights/visitorId.tsx
@@ -44,10 +44,23 @@ interface StoredVisitor {
     updatedAt: number;
 }
 
+interface StoredVisitorRaw {
+    visitor?: unknown;
+    deviceId?: unknown;
+    updatedAt?: unknown;
+}
+
 function getStoredVisitor(): StoredVisitor | null {
-    const value = getLocalStorageItem<StoredVisitor | null>(VISITOR_STORAGE_KEY, null);
-    if (value && isVisitor(value.visitor) && typeof value.updatedAt === 'number') {
-        return value;
+    const value = getLocalStorageItem<StoredVisitorRaw | null>(VISITOR_STORAGE_KEY, null);
+    if (!value || typeof value.updatedAt !== 'number') {
+        return null;
+    }
+    if (isVisitor(value.visitor)) {
+        return { visitor: value.visitor, updatedAt: value.updatedAt };
+    }
+    // Migrate the legacy { deviceId, updatedAt } shape written by older clients.
+    if (typeof value.deviceId === 'string' && value.deviceId) {
+        return { visitor: { deviceId: value.deviceId }, updatedAt: value.updatedAt };
     }
     return null;
 }
@@ -201,7 +214,10 @@ function getGlobalVisitor({
     // Return immediately if we already have a visitor, revalidate in the background only when stale
     const immediate = existing ?? stored?.visitor ?? null;
     if (immediate) {
-        const isStale = !stored || stored.updatedAt < Date.now() - STALE_TIME_MS;
+        const isStale =
+            !stored ||
+            stored.visitor.deviceId !== immediate.deviceId ||
+            stored.updatedAt < Date.now() - STALE_TIME_MS;
         return {
             visitor: immediate,
             pendingVisitor: isStale ? fetchGlobalVisitor() : null,

--- a/packages/gitbook/src/components/Insights/visitorId.tsx
+++ b/packages/gitbook/src/components/Insights/visitorId.tsx
@@ -5,19 +5,14 @@ import type { MaybePromise } from 'p-map';
 import React from 'react';
 import { createStore, useStore } from 'zustand';
 
-import {
-    getBrowserCookie,
-    getLocalStorageItem,
-    removeLocalStorageItem,
-    setLocalStorageItem,
-} from '@/lib/browser';
+import { getBrowserCookie, getLocalStorageItem, setLocalStorageItem } from '@/lib/browser';
 
 import { isCookiesTrackingDisabled } from './cookies';
 import { getSession } from './sessions';
 import { generateRandomId } from './utils';
 
 const VISITORID_COOKIE = '__session';
-const VISITOR_UPDATED_AT_STORAGE_KEY = '__session_updated';
+const VISITOR_STORAGE_KEY = '__session_updated';
 
 /**
  * Visitor state when the visitor is not a signed-in GitBook user.
@@ -40,31 +35,25 @@ type VisitorUserResponse = Pick<AnyVisitorResponse, 'deviceId'> & {
 };
 
 /**
- * Time while a cookie is considered valid before revalidating it.
+ * Time while a stored visitor is considered valid before revalidating it.
  */
 const STALE_TIME_MS = 60 * 60 * 1000;
 
-function getVisitorUpdatedAt(deviceId: string): number | null {
-    const value = getLocalStorageItem<{ deviceId: string; updatedAt: number } | null>(
-        VISITOR_UPDATED_AT_STORAGE_KEY,
-        null
-    );
-    if (!value) {
-        return null;
-    }
-    if (value.deviceId !== deviceId) {
-        clearVisitorUpdatedAt();
-        return null;
-    }
-    return value.updatedAt;
+interface StoredVisitor {
+    visitor: VisitorResponse;
+    updatedAt: number;
 }
 
-function clearVisitorUpdatedAt() {
-    removeLocalStorageItem(VISITOR_UPDATED_AT_STORAGE_KEY);
+function getStoredVisitor(): StoredVisitor | null {
+    const value = getLocalStorageItem<StoredVisitor | null>(VISITOR_STORAGE_KEY, null);
+    if (value && isVisitor(value.visitor) && typeof value.updatedAt === 'number') {
+        return value;
+    }
+    return null;
 }
 
-function setVisitorUpdatedAt(deviceId: string, updatedAt: number) {
-    setLocalStorageItem(VISITOR_UPDATED_AT_STORAGE_KEY, { deviceId, updatedAt });
+function setStoredVisitor(visitor: VisitorResponse, updatedAt: number) {
+    setLocalStorageItem(VISITOR_STORAGE_KEY, { visitor, updatedAt });
 }
 
 export type VisitorResponse = AnyVisitorResponse | VisitorUserResponse;
@@ -77,10 +66,6 @@ function isVisitor(value: unknown): value is VisitorResponse {
             typeof value.deviceId === 'string' &&
             value.deviceId
     );
-}
-
-function isSignedInVisitor(value: unknown): value is VisitorUserResponse {
-    return Boolean(isVisitor(value) && value?.userId && value.organizationId);
 }
 
 const visitorStore = createStore<{
@@ -174,10 +159,16 @@ function getGlobalVisitor({
         return { visitor: { deviceId: getProposedVisitorId() }, pendingVisitor: null };
     }
 
+    const { existing, proposedId } = getVisitorFromCookies();
+    const stored = getStoredVisitor();
+
+    // Cookie wins, localStorage survives third-party cookie blocking, proposed id is the fallback
+    const stableId = existing?.deviceId ?? stored?.visitor.deviceId ?? proposedId;
+
     const fetchGlobalVisitor = async () => {
         const url = new URL(appURL);
         url.pathname = '/__session/2/';
-        url.searchParams.set('proposed', proposedId);
+        url.searchParams.set('proposed', stableId);
 
         try {
             const resp = await fetch(url, {
@@ -198,33 +189,23 @@ function getGlobalVisitor({
                 throw new Error(`Unexpected __session format: ${JSON.stringify(visitor)}`);
             }
 
-            // When cookie tracking is disabled we still allow a signed-in session to be detected,
-            // but otherwise we preserve the no-cookie behavior by returning an anonymous visitor.
-            if (!isSignedInVisitor(visitor)) {
-                clearVisitorUpdatedAt();
-                return { deviceId: proposedId };
-            }
-
-            setVisitorUpdatedAt(visitor.deviceId, Date.now());
+            setStoredVisitor(visitor, Date.now());
 
             return visitor;
         } catch (error) {
-            clearVisitorUpdatedAt();
             console.error('Failed to fetch visitor session ID', error);
-            if (existing) {
-                return existing;
-            }
-            return { deviceId: proposedId };
+            return existing ?? stored?.visitor ?? { deviceId: stableId };
         }
     };
 
-    const { existing, proposedId } = getVisitorFromCookies();
-
-    if (existing) {
-        // Revalidate in background if stale.
-        const updatedAt = getVisitorUpdatedAt(existing.deviceId);
-        const isStale = !updatedAt || updatedAt < Date.now() - STALE_TIME_MS;
-        return { visitor: existing, pendingVisitor: isStale ? fetchGlobalVisitor() : null };
+    // Return immediately if we already have a visitor, revalidate in the background only when stale
+    const immediate = existing ?? stored?.visitor ?? null;
+    if (immediate) {
+        const isStale = !stored || stored.updatedAt < Date.now() - STALE_TIME_MS;
+        return {
+            visitor: immediate,
+            pendingVisitor: isStale ? fetchGlobalVisitor() : null,
+        };
     }
 
     return { visitor: null, pendingVisitor: fetchGlobalVisitor() };


### PR DESCRIPTION
## Summary

Anonymous visitors were counted as new on every page load, inflating the **Visitors** metric (it tracked roughly *total visits*). This restores a stable `visitorId` per visitor while keeping the signed-in detection introduced in #4061.

## Background

#4061 (RND-8584) hardened visitor session detection so the GBO toolbar reliably opens for signed-in users. In doing so (commit `c5bdde44`), the client started discarding the stable `deviceId` returned by the cross-origin `GET /__session/2/` worker for anonymous visitors and used a fresh random id instead.

On custom-domain sites the `__session` cookie is third-party and often unreadable, so the client resolves through the worker on every load — anonymous visitors got a new id each page view and were counted as new every time.

## What this changes

In `getGlobalVisitor` (`packages/gitbook/src/components/Insights/visitorId.tsx`):

- **Honor the worker's `deviceId` for every visitor** — removed the anonymous-only branch that returned a per-load random id, so the server's stable id is always used.
- **Persist the resolved visitor in `localStorage`** so it survives third-party-cookie blocking, Safari ITP, and custom domains where the cookie can't be read.
- **Seed the worker's `proposed` param with a `stableId`** (first-party cookie → persisted localStorage → fresh id). When the worker can't read the cookie, it echoes this id back instead of minting a new one.
- **Resolve from the known visitor immediately, revalidate only when stale (>1h)** — no `/__session/2/` request on every page view.