### PR TITLE
Fix search results linking to page instead of section anchor

### DIFF
--- a/.changeset/search-section-anchor.md
+++ b/.changeset/search-section-anchor.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix search results linking to the page instead of the section anchor when a section snippet is displayed.

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
@@ -158,7 +158,7 @@ function transformSitePageResult(args: {
         pageItem.sections
             ?.filter((section) => section.title || section.body)
             .map<ComputedSectionResult>((section) => {
-                let sectionHref = linker.toPathInSpace(pageItem.path);
+                let sectionHref = linker.toPathInSpace(section.path);
 
                 if (spaceURL) {
                     if (asEmbeddable) {

--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -26,12 +26,9 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
     const language = useLanguage();
 
     const bestSection = item.type === 'page' ? item.bestSection : undefined;
-    const href = (() => {
-        if (item.type !== 'page' || !item.bestSection || item.bestSection.score <= item.score) {
-            return 'href' in item ? item.href : item.pathname;
-        }
-        return item.bestSection.href;
-    })();
+    // When the section snippet is displayed, link to the section anchor so the
+    // link matches what the user sees.
+    const href = bestSection?.body ? bestSection.href : 'href' in item ? item.href : item.pathname;
 
     const emoji = 'emoji' in item ? item.emoji : undefined;
     const icon = 'icon' in item ? item.icon : undefined;


### PR DESCRIPTION
## Summary

Search results were displaying information about a section (the section title and body snippet), but their link pointed to the page without the `#anchor` targeting that section.

Two causes:

- **`SearchPageResultItem.tsx`**: the section snippet is displayed whenever `bestSection.body` exists, but the link only used `bestSection.href` when the section *strictly* outscored the page (`bestSection.score > item.score`). Since the page score aggregates its sections' matches, that condition virtually never holds, so the link always fell back to the page URL. The link now targets the section anchor whenever the section snippet is what's displayed, keeping the link consistent with what the user sees.
- **`~gitbook/search/route.ts`**: the section href fallback (used when there is no published space URL) was built from `pageItem.path` instead of `section.path`, which also dropped the anchor in that case.


Fix RND-10969

## Testing

- `bun run format` and `bun run typecheck` pass (the only typecheck errors are pre-existing in `tailwind.config.ts`, verified against a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)