### PR TITLE
Fix `window.GitBook.registerAssistant` is being called twice

### DIFF
--- a/.changeset/fix-double-assistant-open.md
+++ b/.changeset/fix-double-assistant-open.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix custom assistants (e.g. Kapa, Inkeep) being opened twice when clicking "Ask with …" in the search bar.

--- a/packages/gitbook/src/components/Search/useSearchController.tsx
+++ b/packages/gitbook/src/components/Search/useSearchController.tsx
@@ -19,18 +19,23 @@ function useInitialAskBootstrap(props: {
     isLoaded: boolean;
 }) {
     const { asEmbeddable, assistants, initialAsk, isLoaded } = props;
-    const handledInitialAskRef = React.useRef<string | null | undefined>(undefined);
+    const hasBootstrappedRef = React.useRef(false);
 
     React.useEffect(() => {
         if (asEmbeddable) return;
+        if (hasBootstrappedRef.current) return;
         if (assistants.length === 0) return;
-        if (initialAsk === null) return;
-        if (handledInitialAskRef.current === initialAsk) return;
+        if (!isLoaded) return;
 
-        // For simplicity we're only triggering the first assistant.
-        if (isLoaded) {
+        // Mark bootstrap as done once assistants and the body are ready, even if
+        // there is no initial ask. Subsequent `ask` changes come from user
+        // interactions (e.g. clicking "Ask with …" in the search bar, which also
+        // calls `assistant.open` directly) and must not re-trigger this effect.
+        hasBootstrappedRef.current = true;
+
+        if (initialAsk !== null) {
+            // For simplicity we're only triggering the first assistant.
             assistants[0]?.open(initialAsk || undefined);
-            handledInitialAskRef.current = initialAsk;
         }
     }, [asEmbeddable, assistants, initialAsk, isLoaded]);
 }


### PR DESCRIPTION
**Bug:** When the user clicks "Ask with Kapa" (or any custom assistant) in the search bar, assistant.open(query) was being invoked twice, causing the integration to submit the question twice.

[**Root cause**](packages/gitbook/src/components/Search/useSearchController.tsx:15): useInitialAskBootstrap was added in commit 88c38fa50 (Apr 15) to handle the ?ask= URL parameter on page load. Its dedupe key was the ask value via handledInitialAskRef. When the user clicked "Ask with …", two things happen sequentially:
1. `assistant.open(query)` runs (call `#1`)
2. `setSearchState({ ask: query, ... })` writes the question to the URL for shareability

Step 2 changes `initialAsk` from `null` → `query`, re-running the bootstrap effect. Since the ref was still undefined (no prior bootstrap had happened), the effect fired `assistants[0]?.open(initialAsk)` — call `#2`.

**Fix:** Replace the value-based dedupe with a one-shot `hasBootstrappedRef`. Once assistants and the body are ready, mark bootstrap as done regardless of whether an initial ask existed — subsequent ask changes are user-driven and must not re-trigger the effect.