### PR TITLE
chore(a11y): increase width of the collapse/expand arrow in menu items

### DIFF
--- a/.changeset/polite-taxis-itch.md
+++ b/.changeset/polite-taxis-itch.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Improve a11y of list item collapse/extend toggle

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -172,7 +172,7 @@ function Toggler(props: {
             size="xsmall"
             iconOnly
             variant="blank"
-            className="ml-auto min-h-6 min-w-6 text-current hover:bg-tint-base -my-0.5"
+            className="-my-0.5 ml-auto min-h-6 min-w-6 text-current hover:bg-tint-base"
             tabIndex={-1} // Prevent focus on the button since it's already inside a clickable link that performs the same toggle action.
         />
     );

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -172,7 +172,7 @@ function Toggler(props: {
             size="xsmall"
             iconOnly
             variant="blank"
-            className="ml-auto text-current hover:bg-tint-base"
+            className="ml-auto min-h-6 min-w-6 text-current hover:bg-tint-base"
             tabIndex={-1} // Prevent focus on the button since it's already inside a clickable link that performs the same toggle action.
         />
     );

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -172,7 +172,7 @@ function Toggler(props: {
             size="xsmall"
             iconOnly
             variant="blank"
-            className="ml-auto min-h-6 min-w-6 text-current hover:bg-tint-base"
+            className="ml-auto min-h-6 min-w-6 text-current hover:bg-tint-base -my-0.5"
             tabIndex={-1} // Prevent focus on the button since it's already inside a clickable link that performs the same toggle action.
         />
     );


### PR DESCRIPTION
## Goal
Improve a11y of extend/collapse buttons in list items with subpages.

## Implementation details
- Increase the size of the button from 20px to 24px to meet WCAG standards.
- Keep the icon in the same position vertically
- Move the icon horizontally to keep the same position within the list item

## Demo
<img width="787" height="101" alt="image" src="https://github.com/user-attachments/assets/5edc6c2c-9c9d-424d-9436-004ca6f3ac4f" />
<img width="777" height="97" alt="image" src="https://github.com/user-attachments/assets/e29880f6-afe6-4363-89d8-d711584a087c" />
