### PR TITLE
Use page actions items list for ordering and default action

### DIFF
--- a/.changeset/page-actions-items.md
+++ b/.changeset/page-actions-items.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Drive page actions ordering and default action from the new `pageActions.items` list
+Drive page actions ordering and default action from the new `pageActions.items` list, including the reorderable assistant action

--- a/.changeset/page-actions-items.md
+++ b/.changeset/page-actions-items.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Drive page actions ordering and default action from the new `pageActions.items` list

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@changesets/cli": "^2.31.0",
-        "turbo": "^2.9.15",
+        "turbo": "^2.9.18",
         "vercel": "50.37.3",
       },
     },
@@ -360,7 +360,7 @@
     "react-dom": "catalog:",
   },
   "catalog": {
-    "@gitbook/api": "0.183.0",
+    "@gitbook/api": "0.183.1",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -756,7 +756,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.183.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-0+6VyRH7me5AtzU+mwZVFHDaJudtnHYEcxwQ/qO7p2swj7dOe/dOevfaphgx+pUvhXAg7VVlihETaAW/WsLTzQ=="],
+    "@gitbook/api": ["@gitbook/api@0.183.1", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-l9Bse8mLXG9rUR+jTiD/xZYMQ21t4XrxQvvaa7skaibIyBjjnIsNGo7NhVmjESUKHrA6F40ouH36Oiv2DfH+Wg=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
-            "@gitbook/api": "0.183.0",
+            "@gitbook/api": "0.183.1",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonGroup } from '@/components/primitives/Button';
 import { DropdownMenu, DropdownMenuSeparator } from '@/components/primitives/DropdownMenu';
 import { tString, useLanguage } from '@/intl/client';
 import type { GitSyncState, SiteCustomizationSettings } from '@gitbook/api';
-import React, { useRef } from 'react';
+import { type ReactNode, useRef } from 'react';
 import { type Assistant, useAI } from '../AI';
 import { ToggleChevron } from '../primitives';
 import {
@@ -84,7 +84,7 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
     );
     const items = getPageActionItems(props.actions);
 
-    let defaultAction: React.ReactNode = null;
+    let defaultAction: ReactNode = null;
     let markdownIsDefault = false;
     if (urls.rss) {
         // The RSS feed is not part of the configurable `items` list: it is only available on the
@@ -109,28 +109,43 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
         }
     }
 
-    const dropdownActions: React.ReactNode[] = [
-        ...items.map((type) =>
-            renderDropdownActionsForType(type, {
+    // Build the dropdown menu items, grouped by action type. RSS is appended as its own group
+    // since it is not part of the configurable `items` list.
+    const groups: { key: string; items: ReactNode[] }[] = items
+        .map((type) => ({
+            key: type,
+            items: renderDropdownActionsForType(type, {
                 siteTitle,
                 urls,
                 markdownIsDefault,
                 assistants,
                 page: props.page,
-            })
-        ),
-        urls.rss ? (
-            <React.Fragment key="rss">
-                <DropdownMenuSeparator className="first:hidden" />
-                <ActionViewAsRSS url={urls.rss} type="dropdown-menu-item" />
-            </React.Fragment>
-        ) : null,
-    ].filter(Boolean);
+            }),
+        }))
+        .filter((group) => group.items.length > 0);
 
-    return defaultAction || dropdownActions.length > 0 ? (
+    if (urls.rss) {
+        groups.push({
+            key: 'rss',
+            items: [<ActionViewAsRSS key="rss" url={urls.rss} type="dropdown-menu-item" />],
+        });
+    }
+
+    // Count the actual menu items (not the groups): the dropdown toggle must stay visible when a
+    // single action type still exposes more than one item beyond the default button (e.g. markdown
+    // exposes both "Copy page" and "View as Markdown").
+    const menuItemCount = groups.reduce((total, group) => total + group.items.length, 0);
+
+    // Insert a separator before each group; the leading one is hidden via `first:hidden`.
+    const dropdownActions = groups.flatMap((group) => [
+        <DropdownMenuSeparator key={`separator-${group.key}`} className="first:hidden" />,
+        ...group.items,
+    ]);
+
+    return defaultAction || menuItemCount > 0 ? (
         <ButtonGroup ref={ref} className={props.className}>
             {defaultAction}
-            {!defaultAction || dropdownActions.length > 1 ? (
+            {!defaultAction || menuItemCount > 1 ? (
                 <DropdownMenu
                     align="end"
                     className="!min-w-60 max-w-max"
@@ -213,7 +228,10 @@ function isActionTypeAvailable(
 }
 
 /**
- * Render the action(s) shown in the dropdown menu for a given action type.
+ * Render the list of menu items shown in the dropdown for a given action type.
+ *
+ * Returns a flat array of items (without separators); the caller groups them and inserts the
+ * separators between groups.
  */
 function renderDropdownActionsForType(
     type: CustomizationPageActionType,
@@ -224,104 +242,95 @@ function renderDropdownActionsForType(
         assistants: Assistant[];
         page: PageActionAssistantContext;
     }
-): React.ReactNode {
+): ReactNode[] {
     const { siteTitle, urls, markdownIsDefault, assistants, page } = params;
 
     switch (type) {
         case 'assistant':
-            if (assistants.length === 0) {
-                return null;
-            }
-            return (
-                <React.Fragment key="assistant">
-                    <DropdownMenuSeparator className="first:hidden" />
-                    {assistants.map((assistant) => (
-                        <ActionOpenAssistant
-                            key={assistant.label}
-                            assistant={assistant}
-                            type="dropdown-menu-item"
-                            page={page}
-                        />
-                    ))}
-                </React.Fragment>
-            );
+            return assistants.map((assistant) => (
+                <ActionOpenAssistant
+                    key={`assistant-${assistant.id}`}
+                    assistant={assistant}
+                    type="dropdown-menu-item"
+                    page={page}
+                />
+            ));
         case 'external-ai':
-            return (
-                <React.Fragment key="external-ai">
-                    <DropdownMenuSeparator className="first:hidden" />
-                    <ActionOpenInLLM provider="chatgpt" url={urls.html} type="dropdown-menu-item" />
-                    <ActionOpenInLLM provider="claude" url={urls.html} type="dropdown-menu-item" />
-                </React.Fragment>
-            );
+            return [
+                <ActionOpenInLLM
+                    key="chatgpt"
+                    provider="chatgpt"
+                    url={urls.html}
+                    type="dropdown-menu-item"
+                />,
+                <ActionOpenInLLM
+                    key="claude"
+                    provider="claude"
+                    url={urls.html}
+                    type="dropdown-menu-item"
+                />,
+            ];
         case 'markdown':
-            return (
-                <React.Fragment key="markdown">
-                    <DropdownMenuSeparator className="first:hidden" />
-                    <ActionCopyMarkdown
-                        isDefaultAction={markdownIsDefault}
-                        markdownPageURL={urls.markdown}
-                        type="dropdown-menu-item"
-                    />
-                    <ActionViewAsMarkdown
-                        markdownPageURL={urls.markdown}
-                        type="dropdown-menu-item"
-                    />
-                </React.Fragment>
-            );
+            return [
+                <ActionCopyMarkdown
+                    key="copy-markdown"
+                    isDefaultAction={markdownIsDefault}
+                    markdownPageURL={urls.markdown}
+                    type="dropdown-menu-item"
+                />,
+                <ActionViewAsMarkdown
+                    key="view-markdown"
+                    markdownPageURL={urls.markdown}
+                    type="dropdown-menu-item"
+                />,
+            ];
         case 'mcp':
             if (!urls.mcp) {
-                return null;
+                return [];
             }
-            return (
-                <React.Fragment key="mcp">
-                    <DropdownMenuSeparator className="first:hidden" />
-                    <ActionCopyMCPURL mcpURL={urls.mcp} type="dropdown-menu-item" />
-                    <ActionOpenMCP
-                        provider="vscode"
-                        mcpURL={urls.mcp}
-                        siteTitle={siteTitle}
-                        type="dropdown-menu-item"
-                    />
-                    <ActionCopyMCPCommand
-                        provider="claude-code"
-                        mcpURL={urls.mcp}
-                        siteTitle={siteTitle}
-                        type="dropdown-menu-item"
-                    />
-                    <ActionCopyMCPCommand
-                        provider="codex"
-                        mcpURL={urls.mcp}
-                        siteTitle={siteTitle}
-                        type="dropdown-menu-item"
-                    />
-                </React.Fragment>
-            );
+            return [
+                <ActionCopyMCPURL key="copy-mcp" mcpURL={urls.mcp} type="dropdown-menu-item" />,
+                <ActionOpenMCP
+                    key="mcp-vscode"
+                    provider="vscode"
+                    mcpURL={urls.mcp}
+                    siteTitle={siteTitle}
+                    type="dropdown-menu-item"
+                />,
+                <ActionCopyMCPCommand
+                    key="mcp-claude-code"
+                    provider="claude-code"
+                    mcpURL={urls.mcp}
+                    siteTitle={siteTitle}
+                    type="dropdown-menu-item"
+                />,
+                <ActionCopyMCPCommand
+                    key="mcp-codex"
+                    provider="codex"
+                    mcpURL={urls.mcp}
+                    siteTitle={siteTitle}
+                    type="dropdown-menu-item"
+                />,
+            ];
         case 'git':
             if (!urls.editOnGit) {
-                return null;
+                return [];
             }
-            return (
-                <React.Fragment key="git">
-                    <DropdownMenuSeparator className="first:hidden" />
-                    <ActionOpenEditOnGit
-                        type="dropdown-menu-item"
-                        provider={urls.editOnGit.provider}
-                        url={urls.editOnGit.url}
-                    />
-                </React.Fragment>
-            );
+            return [
+                <ActionOpenEditOnGit
+                    key="edit-git"
+                    type="dropdown-menu-item"
+                    provider={urls.editOnGit.provider}
+                    url={urls.editOnGit.url}
+                />,
+            ];
         case 'pdf':
             if (!urls.pdf) {
-                return null;
+                return [];
             }
-            return (
-                <React.Fragment key="pdf">
-                    <DropdownMenuSeparator className="first:hidden" />
-                    <ActionViewAsPDF url={urls.pdf} type="dropdown-menu-item" />
-                </React.Fragment>
-            );
+            return [<ActionViewAsPDF key="pdf" url={urls.pdf} type="dropdown-menu-item" />];
         default:
-            return null;
+            return [];
     }
 }
 
@@ -336,7 +345,7 @@ function renderDefaultActionForType(
         assistants: Assistant[];
         page: PageActionAssistantContext;
     }
-): React.ReactNode {
+): ReactNode {
     const { urls, assistants, page } = params;
 
     switch (type) {

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -84,25 +84,29 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
     );
     const items = getPageActionItems(props.actions);
 
-    // The quick-access button next to the dropdown is the first action of the configured list.
-    // The assistant action is part of `items` (governed by the AI mode setting), so it is no
-    // longer prepended here — otherwise it would render twice.
-    const firstAvailableItem = items.find((type) => isActionTypeAvailable(type, urls, assistants));
-
     let defaultAction: React.ReactNode = null;
     let markdownIsDefault = false;
-    if (firstAvailableItem) {
-        defaultAction = renderDefaultActionForType(firstAvailableItem, {
-            siteTitle,
-            urls,
-            assistants,
-            page: props.page,
-        });
-        markdownIsDefault = firstAvailableItem === 'markdown';
-    } else if (urls.rss) {
-        // The RSS feed is not part of the configurable `items`, so it is only used as a fallback
-        // default when no configured action is available (to keep a button visible).
+    if (urls.rss) {
+        // The RSS feed is not part of the configurable `items` list: it is only available on the
+        // relevant pages (e.g. blog/changelog index). It is promoted as the default action whenever
+        // present, as a contextual override of the configured list.
         defaultAction = <ActionViewAsRSS url={urls.rss} type="button" />;
+    } else {
+        // Otherwise, the quick-access button is the first action of the configured list. The
+        // assistant action is part of `items` (governed by the AI mode setting), so it is no
+        // longer prepended here — otherwise it would render twice.
+        const firstAvailableItem = items.find((type) =>
+            isActionTypeAvailable(type, urls, assistants)
+        );
+        if (firstAvailableItem) {
+            defaultAction = renderDefaultActionForType(firstAvailableItem, {
+                siteTitle,
+                urls,
+                assistants,
+                page: props.page,
+            });
+            markdownIsDefault = firstAvailableItem === 'markdown';
+        }
     }
 
     const dropdownActions: React.ReactNode[] = [

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -3,7 +3,11 @@
 import { Button, ButtonGroup } from '@/components/primitives/Button';
 import { DropdownMenu, DropdownMenuSeparator } from '@/components/primitives/DropdownMenu';
 import { tString, useLanguage } from '@/intl/client';
-import type { GitSyncState, SiteCustomizationSettings } from '@gitbook/api';
+import type {
+    CustomizationPageActionType,
+    GitSyncState,
+    SiteCustomizationSettings,
+} from '@gitbook/api';
 import { type ReactNode, useRef } from 'react';
 import { type Assistant, useAI } from '../AI';
 import { ToggleChevron } from '../primitives';
@@ -23,19 +27,15 @@ import {
 
 /**
  * Type of a built-in page action that can be displayed in the page actions menu.
- *
- * TODO: this type is not yet exposed by `@gitbook/api`. We mirror it here until the API
- * client is updated. Once `CustomizationPageActionType` and `pageActions.items` are part
- * of the API, import the type from `@gitbook/api` and remove the `@ts-expect-error` below.
  */
-type CustomizationPageActionType = 'assistant' | 'external-ai' | 'markdown' | 'mcp' | 'git' | 'pdf';
+type PageActionType = `${CustomizationPageActionType}`;
 
 /**
  * Order used to derive the list of actions from the deprecated boolean flags when the API does not
  * provide `items` yet. It matches the order the page actions menu used before the `items` model, so
  * existing sites keep the same dropdown ordering until they are migrated.
  */
-const LEGACY_PAGE_ACTION_ORDER: CustomizationPageActionType[] = [
+const LEGACY_PAGE_ACTION_ORDER: PageActionType[] = [
     'assistant',
     'markdown',
     'external-ai',
@@ -49,11 +49,7 @@ const LEGACY_PAGE_ACTION_ORDER: CustomizationPageActionType[] = [
  * which only ever surfaced the assistant, the Git edit link or the markdown copy as the default
  * action — never ChatGPT, MCP or PDF.
  */
-const LEGACY_DEFAULT_ACTION_PRIORITY: CustomizationPageActionType[] = [
-    'assistant',
-    'git',
-    'markdown',
-];
+const LEGACY_DEFAULT_ACTION_PRIORITY: PageActionType[] = ['assistant', 'git', 'markdown'];
 
 export type PageActionsDropdownURLs = {
     html: string;
@@ -188,10 +184,8 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
  */
 function getConfiguredPageActionItems(
     actions: SiteCustomizationSettings['pageActions']
-): CustomizationPageActionType[] | null {
-    // @ts-expect-error - `items` is not yet part of the `@gitbook/api` types. Remove this once it is.
-    const items: CustomizationPageActionType[] | undefined = actions.items;
-    return items ?? null;
+): PageActionType[] | null {
+    return actions.items ?? null;
 }
 
 /**
@@ -200,7 +194,7 @@ function getConfiguredPageActionItems(
  */
 function deriveLegacyPageActionItems(
     actions: SiteCustomizationSettings['pageActions']
-): CustomizationPageActionType[] {
+): PageActionType[] {
     return LEGACY_PAGE_ACTION_ORDER.filter((type) => {
         switch (type) {
             case 'external-ai':
@@ -225,7 +219,7 @@ function deriveLegacyPageActionItems(
  * Whether an action type can be rendered given the available URLs and assistants.
  */
 function isActionTypeAvailable(
-    type: CustomizationPageActionType,
+    type: PageActionType,
     urls: PageActionsDropdownURLs,
     assistants: Assistant[]
 ): boolean {
@@ -253,7 +247,7 @@ function isActionTypeAvailable(
  * separators between groups.
  */
 function renderDropdownActionsForType(
-    type: CustomizationPageActionType,
+    type: PageActionType,
     params: {
         siteTitle: string;
         urls: PageActionsDropdownURLs;
@@ -357,7 +351,7 @@ function renderDropdownActionsForType(
  * Render the action shown as the quick-access default button for a given action type.
  */
 function renderDefaultActionForType(
-    type: CustomizationPageActionType,
+    type: PageActionType,
     params: {
         siteTitle: string;
         urls: PageActionsDropdownURLs;

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -5,7 +5,7 @@ import { DropdownMenu, DropdownMenuSeparator } from '@/components/primitives/Dro
 import { tString, useLanguage } from '@/intl/client';
 import type { GitSyncState, SiteCustomizationSettings } from '@gitbook/api';
 import React, { useRef } from 'react';
-import { useAI } from '../AI';
+import { type Assistant, useAI } from '../AI';
 import { ToggleChevron } from '../primitives';
 import {
     ActionCopyMCPCommand,
@@ -28,13 +28,17 @@ import {
  * client is updated. Once `CustomizationPageActionType` and `pageActions.items` are part
  * of the API, import the type from `@gitbook/api` and remove the `@ts-expect-error` below.
  */
-type CustomizationPageActionType = 'external-ai' | 'markdown' | 'mcp' | 'git' | 'pdf';
+type CustomizationPageActionType = 'assistant' | 'external-ai' | 'markdown' | 'mcp' | 'git' | 'pdf';
 
 /**
  * Default display order of the built-in page actions, used to derive the ordered list
  * for sites that don't have an explicit `items` configuration (legacy boolean flags).
+ *
+ * The assistant action comes first as it is the default action surfaced as the main button
+ * on the page when the assistant is enabled.
  */
 const DEFAULT_PAGE_ACTION_ORDER: CustomizationPageActionType[] = [
+    'assistant',
     'external-ai',
     'markdown',
     'mcp',
@@ -81,34 +85,35 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
     const items = getPageActionItems(props.actions);
 
     // The quick-access button next to the dropdown is the first action of the configured list.
-    // The RSS feed and the AI assistant are not part of the configurable `items`, so they are only
-    // used as a fallback default when no configured action is available (to keep a button visible).
-    const firstAvailableItem = items.find((type) => isActionTypeAvailable(type, urls));
+    // The assistant action is part of `items` (governed by the AI mode setting), so it is no
+    // longer prepended here — otherwise it would render twice.
+    const firstAvailableItem = items.find((type) => isActionTypeAvailable(type, urls, assistants));
 
     let defaultAction: React.ReactNode = null;
     let markdownIsDefault = false;
     if (firstAvailableItem) {
-        defaultAction = renderDefaultActionForType(firstAvailableItem, { siteTitle, urls });
+        defaultAction = renderDefaultActionForType(firstAvailableItem, {
+            siteTitle,
+            urls,
+            assistants,
+            page: props.page,
+        });
         markdownIsDefault = firstAvailableItem === 'markdown';
     } else if (urls.rss) {
+        // The RSS feed is not part of the configurable `items`, so it is only used as a fallback
+        // default when no configured action is available (to keep a button visible).
         defaultAction = <ActionViewAsRSS url={urls.rss} type="button" />;
-    } else if (assistants[0]) {
-        defaultAction = (
-            <ActionOpenAssistant assistant={assistants[0]} type="button" page={props.page} />
-        );
     }
 
     const dropdownActions: React.ReactNode[] = [
-        ...assistants.map((assistant) => (
-            <ActionOpenAssistant
-                key={assistant.label}
-                assistant={assistant}
-                type="dropdown-menu-item"
-                page={props.page}
-            />
-        )),
         ...items.map((type) =>
-            renderDropdownActionsForType(type, { siteTitle, urls, markdownIsDefault })
+            renderDropdownActionsForType(type, {
+                siteTitle,
+                urls,
+                markdownIsDefault,
+                assistants,
+                page: props.page,
+            })
         ),
         urls.rss ? (
             <React.Fragment key="rss">
@@ -166,8 +171,9 @@ function getPageActionItems(
                 return actions.markdown;
             case 'mcp':
                 return actions.mcp;
-            // `git` and `pdf` are not represented by the legacy `pageActions` flags;
-            // they are gated by URL availability at render time.
+            // `assistant` is governed by the AI mode setting, and `git`/`pdf` are not represented
+            // by the legacy `pageActions` flags; all three are gated by availability at render time.
+            case 'assistant':
             case 'git':
             case 'pdf':
                 return true;
@@ -178,13 +184,16 @@ function getPageActionItems(
 }
 
 /**
- * Whether an action type can be rendered given the available URLs.
+ * Whether an action type can be rendered given the available URLs and assistants.
  */
 function isActionTypeAvailable(
     type: CustomizationPageActionType,
-    urls: PageActionsDropdownURLs
+    urls: PageActionsDropdownURLs,
+    assistants: Assistant[]
 ): boolean {
     switch (type) {
+        case 'assistant':
+            return assistants.length > 0;
         case 'external-ai':
         case 'markdown':
             return true;
@@ -204,11 +213,34 @@ function isActionTypeAvailable(
  */
 function renderDropdownActionsForType(
     type: CustomizationPageActionType,
-    params: { siteTitle: string; urls: PageActionsDropdownURLs; markdownIsDefault: boolean }
+    params: {
+        siteTitle: string;
+        urls: PageActionsDropdownURLs;
+        markdownIsDefault: boolean;
+        assistants: Assistant[];
+        page: PageActionAssistantContext;
+    }
 ): React.ReactNode {
-    const { siteTitle, urls, markdownIsDefault } = params;
+    const { siteTitle, urls, markdownIsDefault, assistants, page } = params;
 
     switch (type) {
+        case 'assistant':
+            if (assistants.length === 0) {
+                return null;
+            }
+            return (
+                <React.Fragment key="assistant">
+                    <DropdownMenuSeparator className="first:hidden" />
+                    {assistants.map((assistant) => (
+                        <ActionOpenAssistant
+                            key={assistant.label}
+                            assistant={assistant}
+                            type="dropdown-menu-item"
+                            page={page}
+                        />
+                    ))}
+                </React.Fragment>
+            );
         case 'external-ai':
             return (
                 <React.Fragment key="external-ai">
@@ -294,11 +326,20 @@ function renderDropdownActionsForType(
  */
 function renderDefaultActionForType(
     type: CustomizationPageActionType,
-    params: { siteTitle: string; urls: PageActionsDropdownURLs }
+    params: {
+        siteTitle: string;
+        urls: PageActionsDropdownURLs;
+        assistants: Assistant[];
+        page: PageActionAssistantContext;
+    }
 ): React.ReactNode {
-    const { urls } = params;
+    const { urls, assistants, page } = params;
 
     switch (type) {
+        case 'assistant':
+            return assistants[0] ? (
+                <ActionOpenAssistant assistant={assistants[0]} type="button" page={page} />
+            ) : null;
         case 'external-ai':
             return <ActionOpenInLLM provider="chatgpt" url={urls.html} type="button" />;
         case 'markdown':

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -21,6 +21,27 @@ import {
     type PageActionAssistantContext,
 } from './PageActions';
 
+/**
+ * Type of a built-in page action that can be displayed in the page actions menu.
+ *
+ * TODO: this type is not yet exposed by `@gitbook/api`. We mirror it here until the API
+ * client is updated. Once `CustomizationPageActionType` and `pageActions.items` are part
+ * of the API, import the type from `@gitbook/api` and remove the `@ts-expect-error` below.
+ */
+type CustomizationPageActionType = 'external-ai' | 'markdown' | 'mcp' | 'git' | 'pdf';
+
+/**
+ * Default display order of the built-in page actions, used to derive the ordered list
+ * for sites that don't have an explicit `items` configuration (legacy boolean flags).
+ */
+const DEFAULT_PAGE_ACTION_ORDER: CustomizationPageActionType[] = [
+    'external-ai',
+    'markdown',
+    'mcp',
+    'git',
+    'pdf',
+];
+
 export type PageActionsDropdownURLs = {
     html: string;
     markdown: string;
@@ -43,14 +64,59 @@ interface PageActionsDropdownProps {
 }
 
 /**
- * Dropdown menu for the AI Actions (Ask Docs Assistant, Copy page, View as Markdown, Open in LLM).
+ * Dropdown menu for the page actions (Ask Docs Assistant, Copy page, View as Markdown, Open in LLM…).
+ *
+ * The order and enabled state of the built-in actions are driven by `actions.items`, the ordered
+ * list of enabled page actions. The first available action in that list is shown as a quick-access
+ * button next to the dropdown.
  */
 export function PageActionsDropdown(props: PageActionsDropdownProps) {
     const ref = useRef<HTMLDivElement>(null);
     const language = useLanguage();
+    const { siteTitle, urls } = props;
 
-    const defaultAction = usePageDefaultAction(props);
-    const dropdownActions = getPageDropdownActions(props);
+    const assistants = useAI().assistants.filter(
+        (assistant) => assistant.ui === true && assistant.pageAction
+    );
+    const items = getPageActionItems(props.actions);
+
+    // The quick-access button next to the dropdown is the first action of the configured list.
+    // The RSS feed and the AI assistant are not part of the configurable `items`, so they are only
+    // used as a fallback default when no configured action is available (to keep a button visible).
+    const firstAvailableItem = items.find((type) => isActionTypeAvailable(type, urls));
+
+    let defaultAction: React.ReactNode = null;
+    let markdownIsDefault = false;
+    if (firstAvailableItem) {
+        defaultAction = renderDefaultActionForType(firstAvailableItem, { siteTitle, urls });
+        markdownIsDefault = firstAvailableItem === 'markdown';
+    } else if (urls.rss) {
+        defaultAction = <ActionViewAsRSS url={urls.rss} type="button" />;
+    } else if (assistants[0]) {
+        defaultAction = (
+            <ActionOpenAssistant assistant={assistants[0]} type="button" page={props.page} />
+        );
+    }
+
+    const dropdownActions: React.ReactNode[] = [
+        ...assistants.map((assistant) => (
+            <ActionOpenAssistant
+                key={assistant.label}
+                assistant={assistant}
+                type="dropdown-menu-item"
+                page={props.page}
+            />
+        )),
+        ...items.map((type) =>
+            renderDropdownActionsForType(type, { siteTitle, urls, markdownIsDefault })
+        ),
+        urls.rss ? (
+            <React.Fragment key="rss">
+                <DropdownMenuSeparator className="first:hidden" />
+                <ActionViewAsRSS url={urls.rss} type="dropdown-menu-item" />
+            </React.Fragment>
+        ) : null,
+    ].filter(Boolean);
 
     return defaultAction || dropdownActions.length > 0 ? (
         <ButtonGroup ref={ref} className={props.className}>
@@ -78,123 +144,180 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
 }
 
 /**
- * Return the list of actions to show in the dropdown menu.
+ * Return the ordered list of enabled page actions.
+ *
+ * `actions.items` is the source of truth. When it is not provided (older API responses), the list
+ * is derived from the deprecated boolean flags following the default page action order.
  */
-function getPageDropdownActions(props: PageActionsDropdownProps): React.ReactNode[] {
-    const { siteTitle, urls, actions, page } = props;
-    const assistants = useAI().assistants.filter(
-        (assistant) => assistant.ui === true && assistant.pageAction
-    );
+function getPageActionItems(
+    actions: SiteCustomizationSettings['pageActions']
+): CustomizationPageActionType[] {
+    // @ts-expect-error - `items` is not yet part of the `@gitbook/api` types. Remove this once it is.
+    const items: CustomizationPageActionType[] | undefined = actions.items;
+    if (items) {
+        return items;
+    }
 
-    return [
-        ...assistants.map((assistant) => (
-            <ActionOpenAssistant
-                key={assistant.label}
-                assistant={assistant}
-                type="dropdown-menu-item"
-                page={page}
-            />
-        )),
+    return DEFAULT_PAGE_ACTION_ORDER.filter((type) => {
+        switch (type) {
+            case 'external-ai':
+                return actions.externalAI;
+            case 'markdown':
+                return actions.markdown;
+            case 'mcp':
+                return actions.mcp;
+            // `git` and `pdf` are not represented by the legacy `pageActions` flags;
+            // they are gated by URL availability at render time.
+            case 'git':
+            case 'pdf':
+                return true;
+            default:
+                return false;
+        }
+    });
+}
 
-        actions.markdown ? (
-            <React.Fragment key="markdown">
-                <DropdownMenuSeparator className="first:hidden" />
-                <ActionCopyMarkdown
-                    isDefaultAction={!assistants.length}
-                    markdownPageURL={urls.markdown}
-                    type="dropdown-menu-item"
-                />
-                <ActionViewAsMarkdown markdownPageURL={urls.markdown} type="dropdown-menu-item" />
-            </React.Fragment>
-        ) : null,
+/**
+ * Whether an action type can be rendered given the available URLs.
+ */
+function isActionTypeAvailable(
+    type: CustomizationPageActionType,
+    urls: PageActionsDropdownURLs
+): boolean {
+    switch (type) {
+        case 'external-ai':
+        case 'markdown':
+            return true;
+        case 'mcp':
+            return !!urls.mcp;
+        case 'git':
+            return !!urls.editOnGit;
+        case 'pdf':
+            return !!urls.pdf;
+        default:
+            return false;
+    }
+}
 
-        actions.externalAI ? (
-            <React.Fragment key="externalAI">
-                <DropdownMenuSeparator className="first:hidden" />
-                <ActionOpenInLLM provider="chatgpt" url={urls.html} type="dropdown-menu-item" />
-                <ActionOpenInLLM provider="claude" url={urls.html} type="dropdown-menu-item" />
-            </React.Fragment>
-        ) : null,
+/**
+ * Render the action(s) shown in the dropdown menu for a given action type.
+ */
+function renderDropdownActionsForType(
+    type: CustomizationPageActionType,
+    params: { siteTitle: string; urls: PageActionsDropdownURLs; markdownIsDefault: boolean }
+): React.ReactNode {
+    const { siteTitle, urls, markdownIsDefault } = params;
 
-        actions.mcp && urls.mcp ? (
-            <React.Fragment key="mcp">
-                <DropdownMenuSeparator className="first:hidden" />
-                <ActionCopyMCPURL mcpURL={urls.mcp} type="dropdown-menu-item" />
-                <ActionOpenMCP
-                    provider="vscode"
-                    mcpURL={urls.mcp}
-                    siteTitle={siteTitle}
-                    type="dropdown-menu-item"
-                />
-                <ActionCopyMCPCommand
-                    provider="claude-code"
-                    mcpURL={urls.mcp}
-                    siteTitle={siteTitle}
-                    type="dropdown-menu-item"
-                />
-                <ActionCopyMCPCommand
-                    provider="codex"
-                    mcpURL={urls.mcp}
-                    siteTitle={siteTitle}
-                    type="dropdown-menu-item"
-                />
-            </React.Fragment>
-        ) : null,
-
-        urls.editOnGit || urls.pdf || urls.rss ? (
-            <React.Fragment key="editOnGit">
-                <DropdownMenuSeparator className="first:hidden" />
-                {urls.editOnGit ? (
+    switch (type) {
+        case 'external-ai':
+            return (
+                <React.Fragment key="external-ai">
+                    <DropdownMenuSeparator className="first:hidden" />
+                    <ActionOpenInLLM provider="chatgpt" url={urls.html} type="dropdown-menu-item" />
+                    <ActionOpenInLLM provider="claude" url={urls.html} type="dropdown-menu-item" />
+                </React.Fragment>
+            );
+        case 'markdown':
+            return (
+                <React.Fragment key="markdown">
+                    <DropdownMenuSeparator className="first:hidden" />
+                    <ActionCopyMarkdown
+                        isDefaultAction={markdownIsDefault}
+                        markdownPageURL={urls.markdown}
+                        type="dropdown-menu-item"
+                    />
+                    <ActionViewAsMarkdown
+                        markdownPageURL={urls.markdown}
+                        type="dropdown-menu-item"
+                    />
+                </React.Fragment>
+            );
+        case 'mcp':
+            if (!urls.mcp) {
+                return null;
+            }
+            return (
+                <React.Fragment key="mcp">
+                    <DropdownMenuSeparator className="first:hidden" />
+                    <ActionCopyMCPURL mcpURL={urls.mcp} type="dropdown-menu-item" />
+                    <ActionOpenMCP
+                        provider="vscode"
+                        mcpURL={urls.mcp}
+                        siteTitle={siteTitle}
+                        type="dropdown-menu-item"
+                    />
+                    <ActionCopyMCPCommand
+                        provider="claude-code"
+                        mcpURL={urls.mcp}
+                        siteTitle={siteTitle}
+                        type="dropdown-menu-item"
+                    />
+                    <ActionCopyMCPCommand
+                        provider="codex"
+                        mcpURL={urls.mcp}
+                        siteTitle={siteTitle}
+                        type="dropdown-menu-item"
+                    />
+                </React.Fragment>
+            );
+        case 'git':
+            if (!urls.editOnGit) {
+                return null;
+            }
+            return (
+                <React.Fragment key="git">
+                    <DropdownMenuSeparator className="first:hidden" />
                     <ActionOpenEditOnGit
                         type="dropdown-menu-item"
                         provider={urls.editOnGit.provider}
                         url={urls.editOnGit.url}
                     />
-                ) : null}
-                {urls.rss ? <ActionViewAsRSS url={urls.rss} type="dropdown-menu-item" /> : null}
-                {urls.pdf ? <ActionViewAsPDF url={urls.pdf} type="dropdown-menu-item" /> : null}
-            </React.Fragment>
-        ) : null,
-    ].filter(Boolean);
+                </React.Fragment>
+            );
+        case 'pdf':
+            if (!urls.pdf) {
+                return null;
+            }
+            return (
+                <React.Fragment key="pdf">
+                    <DropdownMenuSeparator className="first:hidden" />
+                    <ActionViewAsPDF url={urls.pdf} type="dropdown-menu-item" />
+                </React.Fragment>
+            );
+        default:
+            return null;
+    }
 }
 
 /**
- * A default action shown as a quick-access button beside the dropdown menu
+ * Render the action shown as the quick-access default button for a given action type.
  */
-function usePageDefaultAction(props: PageActionsDropdownProps) {
-    const { urls, actions, page } = props;
-    const assistants = useAI().assistants.filter(
-        (assistant) => assistant.ui === true && assistant.pageAction
-    );
+function renderDefaultActionForType(
+    type: CustomizationPageActionType,
+    params: { siteTitle: string; urls: PageActionsDropdownURLs }
+): React.ReactNode {
+    const { urls } = params;
 
-    if (urls.rss) {
-        return <ActionViewAsRSS url={urls.rss} type="button" />;
+    switch (type) {
+        case 'external-ai':
+            return <ActionOpenInLLM provider="chatgpt" url={urls.html} type="button" />;
+        case 'markdown':
+            return (
+                <ActionCopyMarkdown isDefaultAction markdownPageURL={urls.markdown} type="button" />
+            );
+        case 'mcp':
+            return urls.mcp ? <ActionCopyMCPURL mcpURL={urls.mcp} type="button" /> : null;
+        case 'git':
+            return urls.editOnGit ? (
+                <ActionOpenEditOnGit
+                    type="button"
+                    provider={urls.editOnGit.provider}
+                    url={urls.editOnGit.url}
+                />
+            ) : null;
+        case 'pdf':
+            return urls.pdf ? <ActionViewAsPDF url={urls.pdf} type="button" /> : null;
+        default:
+            return null;
     }
-
-    const assistant = assistants[0];
-    if (assistant) {
-        return <ActionOpenAssistant assistant={assistant} type="button" page={page} />;
-    }
-
-    if (urls.editOnGit) {
-        return (
-            <ActionOpenEditOnGit
-                type="button"
-                provider={urls.editOnGit.provider}
-                url={urls.editOnGit.url}
-            />
-        );
-    }
-
-    if (actions.markdown) {
-        return (
-            <ActionCopyMarkdown
-                isDefaultAction={!assistant}
-                markdownPageURL={urls.markdown}
-                type="button"
-            />
-        );
-    }
-
-    return null;
 }

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -31,19 +31,28 @@ import {
 type CustomizationPageActionType = 'assistant' | 'external-ai' | 'markdown' | 'mcp' | 'git' | 'pdf';
 
 /**
- * Default display order of the built-in page actions, used to derive the ordered list
- * for sites that don't have an explicit `items` configuration (legacy boolean flags).
- *
- * The assistant action comes first as it is the default action surfaced as the main button
- * on the page when the assistant is enabled.
+ * Order used to derive the list of actions from the deprecated boolean flags when the API does not
+ * provide `items` yet. It matches the order the page actions menu used before the `items` model, so
+ * existing sites keep the same dropdown ordering until they are migrated.
  */
-const DEFAULT_PAGE_ACTION_ORDER: CustomizationPageActionType[] = [
+const LEGACY_PAGE_ACTION_ORDER: CustomizationPageActionType[] = [
     'assistant',
-    'external-ai',
     'markdown',
+    'external-ai',
     'mcp',
     'git',
     'pdf',
+];
+
+/**
+ * Default-button priority used in legacy mode (no `items`). It reproduces the previous behavior,
+ * which only ever surfaced the assistant, the Git edit link or the markdown copy as the default
+ * action — never ChatGPT, MCP or PDF.
+ */
+const LEGACY_DEFAULT_ACTION_PRIORITY: CustomizationPageActionType[] = [
+    'assistant',
+    'git',
+    'markdown',
 ];
 
 export type PageActionsDropdownURLs = {
@@ -71,8 +80,9 @@ interface PageActionsDropdownProps {
  * Dropdown menu for the page actions (Ask Docs Assistant, Copy page, View as Markdown, Open in LLM…).
  *
  * The order and enabled state of the built-in actions are driven by `actions.items`, the ordered
- * list of enabled page actions. The first available action in that list is shown as a quick-access
- * button next to the dropdown.
+ * list of enabled page actions, with its first available action shown as a quick-access button.
+ * When the API does not provide `items` yet, the menu falls back to the previous ordering and
+ * default-action priority so existing sites keep their current behavior.
  */
 export function PageActionsDropdown(props: PageActionsDropdownProps) {
     const ref = useRef<HTMLDivElement>(null);
@@ -82,7 +92,11 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
     const assistants = useAI().assistants.filter(
         (assistant) => assistant.ui === true && assistant.pageAction
     );
-    const items = getPageActionItems(props.actions);
+    // `items` is the source of truth when the API provides it. Until then (legacy mode), we derive
+    // the list from the deprecated boolean flags using the previous ordering.
+    const configuredItems = getConfiguredPageActionItems(props.actions);
+    const isLegacy = configuredItems === null;
+    const items = configuredItems ?? deriveLegacyPageActionItems(props.actions);
 
     let defaultAction: ReactNode = null;
     let markdownIsDefault = false;
@@ -92,20 +106,21 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
         // present, as a contextual override of the configured list.
         defaultAction = <ActionViewAsRSS url={urls.rss} type="button" />;
     } else {
-        // Otherwise, the quick-access button is the first action of the configured list. The
-        // assistant action is part of `items` (governed by the AI mode setting), so it is no
-        // longer prepended here — otherwise it would render twice.
-        const firstAvailableItem = items.find((type) =>
-            isActionTypeAvailable(type, urls, assistants)
+        // The default button is the first available action. With `items`, that is simply the first
+        // entry of the configured list. In legacy mode we keep the previous default-action priority
+        // (assistant → Git → markdown), so existing sites don't suddenly surface ChatGPT/MCP/PDF.
+        const defaultPriority = isLegacy ? LEGACY_DEFAULT_ACTION_PRIORITY : items;
+        const defaultActionType = defaultPriority.find(
+            (type) => items.includes(type) && isActionTypeAvailable(type, urls, assistants)
         );
-        if (firstAvailableItem) {
-            defaultAction = renderDefaultActionForType(firstAvailableItem, {
+        if (defaultActionType) {
+            defaultAction = renderDefaultActionForType(defaultActionType, {
                 siteTitle,
                 urls,
                 assistants,
                 page: props.page,
             });
-            markdownIsDefault = firstAvailableItem === 'markdown';
+            markdownIsDefault = defaultActionType === 'markdown';
         }
     }
 
@@ -168,21 +183,25 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
 }
 
 /**
- * Return the ordered list of enabled page actions.
- *
- * `actions.items` is the source of truth. When it is not provided (older API responses), the list
- * is derived from the deprecated boolean flags following the default page action order.
+ * Return the configured ordered list of enabled page actions, or `null` when the API does not
+ * provide it yet (legacy mode).
  */
-function getPageActionItems(
+function getConfiguredPageActionItems(
     actions: SiteCustomizationSettings['pageActions']
-): CustomizationPageActionType[] {
+): CustomizationPageActionType[] | null {
     // @ts-expect-error - `items` is not yet part of the `@gitbook/api` types. Remove this once it is.
     const items: CustomizationPageActionType[] | undefined = actions.items;
-    if (items) {
-        return items;
-    }
+    return items ?? null;
+}
 
-    return DEFAULT_PAGE_ACTION_ORDER.filter((type) => {
+/**
+ * Derive the ordered list of enabled page actions from the deprecated boolean flags, following the
+ * ordering used before the `items` model. Used only when the API does not provide `items`.
+ */
+function deriveLegacyPageActionItems(
+    actions: SiteCustomizationSettings['pageActions']
+): CustomizationPageActionType[] {
+    return LEGACY_PAGE_ACTION_ORDER.filter((type) => {
         switch (type) {
             case 'external-ai':
                 return actions.externalAI;

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -33,7 +33,9 @@ export async function PageHeader(props: {
     const hasPageActions =
         pageActionsEnabled &&
         [
-            ...Object.values(context.customization.pageActions),
+            context.customization.pageActions.externalAI,
+            context.customization.pageActions.markdown,
+            context.customization.pageActions.mcp,
             context.customization.pdf.enabled,
             context.customization.git.showEditLink,
             withRSSFeed,

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -2,7 +2,7 @@ import type { GitBookSiteContext } from '@/lib/context';
 import type { AncestorRevisionPage } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
 import { getPageRSSURL } from '@/routes/rss';
-import { type RevisionPageDocument, SiteVisibility } from '@gitbook/api';
+import { CustomizationAIMode, type RevisionPageDocument, SiteVisibility } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
 import urlJoin from 'url-join';
 import { getPDFURLSearchParams } from '../PDF';
@@ -33,6 +33,7 @@ export async function PageHeader(props: {
     const hasPageActions =
         pageActionsEnabled &&
         [
+            context.customization.ai.mode === CustomizationAIMode.Assistant,
             context.customization.pageActions.externalAI,
             context.customization.pageActions.markdown,
             context.customization.pageActions.mcp,


### PR DESCRIPTION
## Proposed changes

Switches the published-site page actions to the new **`items`** model introduced in the customization backend ([gitbook-x#23374](https://github.com/GitbookIO/gitbook-x/pull/23374) and [gitbook-x#23407](https://github.com/GitbookIO/gitbook-x/pull/23407)).

`pageActions.items` is an ordered list of enabled action types and is now the source of truth for **which** page actions show and **in what order**. The first item is surfaced as the default quick-access button.

### Key changes

- **Drive ordering & enablement from `items`** in [`PageActionsDropdown.tsx`](packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx). The action groups (external AI, markdown, MCP, git, PDF) are rendered in the order given by the list, and the first available one becomes the default button. Falls back to deriving the list from the deprecated boolean flags when `items` is absent (older API responses).
- **Assistant is rendered from `items`, not prepended** (per the follow-up note in gitbook-x#23407). The `assistant` action is now a reorderable type governed by the AI mode setting; rendering it from the list — instead of always prepending — avoids it showing twice and lets it be reordered / used as the default.
- **RSS stays a contextual override.** It is not part of the configurable list (only available on relevant pages such as blog/changelog index), so it takes precedence as the default action whenever present, and is otherwise appended to the dropdown.
- Made `hasPageActions` in [`PageHeader.tsx`](packages/gitbook/src/components/PageBody/PageHeader.tsx) reference the boolean flags explicitly instead of `Object.values(pageActions)`, since the now-present `items` array would always be truthy.

### Note on types

`CustomizationPageActionType` and `pageActions.items` are **not yet exposed by `@gitbook/api`**. They are mirrored locally with a single `@ts-expect-error` on the `items` access — once the API client is updated, TS will flag the now-unused directive, signalling the next maintainer to import the type from `@gitbook/api` and remove the workaround.

Fixes RND-10708.

## Changelog

- [Feature] Render the page actions menu from the configurable, ordered `pageActions.items` list, including the reorderable assistant action and a user-selectable default action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)