### PR TITLE
Implement getVariables method for expression evaluation

### DIFF
--- a/.changeset/chubby-walls-sniff.md
+++ b/.changeset/chubby-walls-sniff.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/expr": minor
+---
+
+Implement a getVariables function for ExpressionRuntime

--- a/packages/expr/src/__tests__/runtime.test.ts
+++ b/packages/expr/src/__tests__/runtime.test.ts
@@ -233,12 +233,9 @@ describe('ExpressionRuntime', () => {
                 scenario: 'non conditional expression',
                 condition: 'const a = 1;',
             },
-        ])(
-            'should return an empty array for invalid expressions: $scenario',
-            ({ condition }) => {
-                expect(runtime.getVariables(condition)).toEqual([]);
-            }
-        );
+        ])('should return an empty array for invalid expressions: $scenario', ({ condition }) => {
+            expect(runtime.getVariables(condition)).toEqual([]);
+        });
     });
 
     describe.skip('generate', () => {

--- a/packages/expr/src/__tests__/runtime.test.ts
+++ b/packages/expr/src/__tests__/runtime.test.ts
@@ -195,6 +195,52 @@ describe('ExpressionRuntime', () => {
         );
     });
 
+    describe('getVariables', () => {
+        it.each([
+            {
+                scenario: 'single variable',
+                condition: 'isBetaUser === true',
+                expectedVariables: ['isBetaUser'],
+            },
+            {
+                scenario: 'multiple variables',
+                condition: 'useProductA && !isBetaUser',
+                expectedVariables: ['useProductA', 'isBetaUser'],
+            },
+            {
+                scenario: 'member expression',
+                condition: 'user.role === "admin"',
+                expectedVariables: ['user.role'],
+            },
+            {
+                scenario: 'nested member expression with method call',
+                condition: 'products.includes("productA") && userSegments.alpha',
+                expectedVariables: ['products.includes', 'userSegments.alpha'],
+            },
+        ])(
+            'should return variables used in expression: $scenario',
+            ({ condition, expectedVariables }) => {
+                expect(runtime.getVariables(condition)).toEqual(expectedVariables);
+            }
+        );
+
+        it.each([
+            {
+                scenario: 'invalid syntax',
+                condition: 't}=d',
+            },
+            {
+                scenario: 'non conditional expression',
+                condition: 'const a = 1;',
+            },
+        ])(
+            'should return an empty array for invalid expressions: $scenario',
+            ({ condition }) => {
+                expect(runtime.getVariables(condition)).toEqual([]);
+            }
+        );
+    });
+
     describe.skip('generate', () => {
         it.each([
             {

--- a/packages/expr/src/runtime.ts
+++ b/packages/expr/src/runtime.ts
@@ -178,8 +178,7 @@ export class ExpressionRuntime {
                 withMembers: true,
                 generate: escodegen.generate,
             });
-            
-        }catch (error) {
+        } catch (error) {
             this.#logger.error(`Error while parsing expression ${expr} to get variables`, error);
             return [];
         }

--- a/packages/expr/src/runtime.ts
+++ b/packages/expr/src/runtime.ts
@@ -11,7 +11,7 @@ import {
 import { parse as parseLoose } from 'acorn-loose';
 import escodegen from 'escodegen';
 import evalESTreeExpr from 'eval-estree-expression';
-const { evaluate } = evalESTreeExpr;
+const { evaluate, variables } = evalESTreeExpr;
 
 import { AutoComplete } from './autocomplete';
 import { ExpressionError } from './errors';
@@ -160,6 +160,29 @@ export class ExpressionRuntime {
                 return formatExpressionResult(result, '');
             })
             .join('');
+    }
+
+    /**
+     * Given an expression, returns a list of variables used in the expression.
+     */
+    public getVariables(expr: string): string[] {
+        try {
+            const parsed = this.parse(expr);
+
+            if (parsed.invalidNodes.length > 0) {
+                throw new ExpressionError('Invalid nodes found when parsing');
+            }
+
+            return variables(parsed.result, {
+                functions: true,
+                withMembers: true,
+                generate: escodegen.generate,
+            });
+            
+        }catch (error) {
+            this.#logger.error(`Error while parsing expression ${expr} to get variables`, error);
+            return [];
+        }
     }
 
     /**

--- a/packages/expr/types/eval-estree-expression.d.ts
+++ b/packages/expr/types/eval-estree-expression.d.ts
@@ -42,6 +42,13 @@ declare module 'eval-estree-expression' {
     ): Promise<any>;
 
     /**
+     * Given an ESTree-compliant AST node, returns a list of variables used in the expression.
+     * @param ast An object representing an ESTree-compliant AST node.
+     * @param options Options for evaluation and compilation.
+     */
+    export function variables<ASTNode>(ast: ASTNode, options?: EvalESTreeExpressionOptions): string[];
+
+    /**
      * Evaluates an ESTree expression synchronously against a given context.
      * @param expression - An object representing an ESTree-compliant AST node.
      * @param context - An object containing variables and values to be used during evaluation.

--- a/packages/expr/types/eval-estree-expression.d.ts
+++ b/packages/expr/types/eval-estree-expression.d.ts
@@ -46,7 +46,10 @@ declare module 'eval-estree-expression' {
      * @param ast An object representing an ESTree-compliant AST node.
      * @param options Options for evaluation and compilation.
      */
-    export function variables<ASTNode>(ast: ASTNode, options?: EvalESTreeExpressionOptions): string[];
+    export function variables<ASTNode>(
+        ast: ASTNode,
+        options?: EvalESTreeExpressionOptions
+    ): string[];
 
     /**
      * Evaluates an ESTree expression synchronously against a given context.


### PR DESCRIPTION
Introduce a `getVariables` method in `ExpressionRuntime` to extract variables from expressions, enhancing the expression evaluation capabilities. This addition includes tests for various scenarios, ensuring accurate variable extraction and handling of invalid expressions.