### PR TITLE
Stabilize AI Assistant visual regression tests

### DIFF
--- a/.changeset/assistant-chat-aria-busy.md
+++ b/.changeset/assistant-chat-aria-busy.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Mark the AI Assistant chat as `aria-busy` while it is generating a response (including the follow-up suggestion phase), so assistive technologies are notified of the in-progress state.

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -207,9 +207,9 @@ const searchTestCases: Test[] = [
             // asserting/screenshotting, rather than racing a fixed suggestion count.
             await waitForAIChatResponse(page);
             await expect(page.getByTestId('ai-chat-followup-suggestion').first()).toBeVisible();
-            // Normalize non-deterministic content for visual consistency in screenshots.
-            await page.evaluate(overrideAIResponse);
         },
+        // Re-applied per viewport so the replacement survives resize-driven re-renders.
+        normalizeBeforeScreenshot: (page) => page.evaluate(overrideAIResponse),
     },
     {
         name: 'Ask - AI Mode: Assistant - Keyboard shortcut',
@@ -223,9 +223,9 @@ const searchTestCases: Test[] = [
             await page.keyboard.press('ControlOrMeta+I');
             await expect(page.getByTestId('ai-chat')).toBeVisible();
             await expect(page.getByTestId('ai-chat-input')).toBeFocused();
-            // Override text content for visual consistency in screenshots
-            await page.evaluate(overrideAIInitialState);
         },
+        // Re-applied per viewport so the replacement survives resize-driven re-renders.
+        normalizeBeforeScreenshot: (page) => page.evaluate(overrideAIInitialState),
     },
     {
         name: 'Ask - AI Mode: Assistant - Button',
@@ -239,9 +239,9 @@ const searchTestCases: Test[] = [
             await page.getByTestId('ai-chat-button').click();
             await expect(page.getByTestId('ai-chat')).toBeVisible();
             await expect(page.getByTestId('ai-chat-input')).toBeFocused();
-            // Override text content for visual consistency in screenshots
-            await page.evaluate(overrideAIInitialState);
         },
+        // Re-applied per viewport so the replacement survives resize-driven re-renders.
+        normalizeBeforeScreenshot: (page) => page.evaluate(overrideAIInitialState),
     },
     {
         name: 'Ask - AI Mode: Assistant - URL query (Initial)',
@@ -256,9 +256,9 @@ const searchTestCases: Test[] = [
             await expect(page.getByTestId('search-input')).toBeEmpty();
             await expect(page.getByTestId('ai-chat')).toBeVisible();
             await expect(page.getByTestId('ai-chat-input')).toBeFocused();
-            // Override text content for visual consistency in screenshots
-            await page.evaluate(overrideAIInitialState);
         },
+        // Re-applied per viewport so the replacement survives resize-driven re-renders.
+        normalizeBeforeScreenshot: (page) => page.evaluate(overrideAIInitialState),
     },
     {
         name: 'Ask - AI Mode: Assistant - URL query (Results)',
@@ -278,9 +278,9 @@ const searchTestCases: Test[] = [
             // asserting/screenshotting, rather than racing a fixed suggestion count.
             await waitForAIChatResponse(page);
             await expect(page.getByTestId('ai-chat-followup-suggestion').first()).toBeVisible();
-            // Normalize non-deterministic content for visual consistency in screenshots.
-            await page.evaluate(overrideAIResponse);
         },
+        // Re-applied per viewport so the replacement survives resize-driven re-renders.
+        normalizeBeforeScreenshot: (page) => page.evaluate(overrideAIResponse),
     },
 ];
 
@@ -2259,9 +2259,13 @@ const testCases: TestsCase[] = [
 
                     await iframe.getByTestId('embed-tab-assistant').click(); // Switch to assistant tab
                     await expect(iframe.getByTestId('ai-chat')).toBeVisible();
-
-                    await iframe.owner().evaluate(overrideAIInitialState);
                 },
+                // Runs inside the iframe (not the parent doc) and per viewport.
+                normalizeBeforeScreenshot: (page) =>
+                    page
+                        .frameLocator('#gitbook-widget-iframe')
+                        .locator('body')
+                        .evaluate(overrideAIInitialState),
             },
             {
                 name: 'API - navigateToPage',
@@ -2295,11 +2299,15 @@ const testCases: TestsCase[] = [
                     await expect(iframe.getByTestId('ai-chat-message-user').first()).toHaveText(
                         AI_PROMPT
                     );
-                    // Wait for the full response to settle before normalizing, otherwise
-                    // late stream re-renders clobber the replacements.
+                    // Wait for the full response to settle before normalizing.
                     await waitForAIChatResponse(iframe);
-                    await iframe.owner().evaluate(overrideAIResponse);
                 },
+                // Runs inside the iframe (not the parent doc) and per viewport.
+                normalizeBeforeScreenshot: (page) =>
+                    page
+                        .frameLocator('#gitbook-widget-iframe')
+                        .locator('body')
+                        .evaluate(overrideAIResponse),
             },
             {
                 name: 'Configuration - Suggested questions',
@@ -2325,8 +2333,13 @@ const testCases: TestsCase[] = [
                     await expect(
                         iframe.getByTestId('ai-chat-suggested-question').nth(2)
                     ).toHaveText('What can you do?');
-                    await iframe.owner().evaluate(overrideAIInitialState);
                 },
+                // Runs inside the iframe (not the parent doc) and per viewport.
+                normalizeBeforeScreenshot: (page) =>
+                    page
+                        .frameLocator('#gitbook-widget-iframe')
+                        .locator('body')
+                        .evaluate(overrideAIInitialState),
             },
             {
                 name: 'Configuration - Custom action buttons',
@@ -2410,8 +2423,13 @@ const testCases: TestsCase[] = [
                     await page.locator('#gitbook-widget-button').click();
                     // Wait for the response posted above to settle before normalizing.
                     await waitForAIChatResponse(iframe);
-                    await iframe.owner().evaluate(overrideAIResponse);
                 },
+                // Runs inside the iframe (not the parent doc) and per viewport.
+                normalizeBeforeScreenshot: (page) =>
+                    page
+                        .frameLocator('#gitbook-widget-iframe')
+                        .locator('body')
+                        .evaluate(overrideAIResponse),
             },
             {
                 name: 'Configuration - Custom tools',
@@ -2458,8 +2476,13 @@ const testCases: TestsCase[] = [
                     // The turn settles (aria-busy clears) once the stream pauses on the
                     // confirmation control; wait for that before normalizing.
                     await waitForAIChatResponse(iframe);
-                    await iframe.owner().evaluate(overrideAIResponse);
                 },
+                // Runs inside the iframe (not the parent doc) and per viewport.
+                normalizeBeforeScreenshot: (page) =>
+                    page
+                        .frameLocator('#gitbook-widget-iframe')
+                        .locator('body')
+                        .evaluate(overrideAIResponse),
             },
         ],
     },

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -31,12 +31,24 @@ import {
     headerLinks,
     runTestCases,
     setTimeToMorning,
+    waitForAIChatResponse,
     waitForCookiesDialog,
     waitForCoverImages,
     waitForNotFound,
 } from './util';
 
-const AI_PROMPT = `You're being invoked by the GitBook CI/CD pipeline. Search for "Lorem ipsum", then return the first sentence of the first page you find.`;
+// Kept as deterministic as possible to reduce visual flakiness: no preamble, a
+// single fixed search, a concise answer, and a fixed number of follow-ups. The
+// model is never perfectly deterministic, so `overrideAIResponse` still
+// normalizes the rendered content below — this prompt just narrows the variance.
+const AI_PROMPT = [
+    "You're being invoked by the GitBook CI/CD pipeline for automated visual testing.",
+    'Follow these instructions exactly and do not deviate:',
+    '1. Do not write any preamble, commentary, or reasoning before acting.',
+    '2. Perform a single search for exactly "Lorem ipsum".',
+    '3. Reply with only the first sentence of the first page you find, and nothing else.',
+    '4. Always end by proposing exactly 3 follow-up suggestions.',
+].join('\n');
 
 const overrideAIInitialState = () => {
     const greeting = document.querySelector('[data-testid="ai-chat-greeting-title"]');
@@ -44,21 +56,45 @@ const overrideAIInitialState = () => {
         greeting.textContent = 'Good morning';
     }
 };
+
+/**
+ * Normalize the non-deterministic content of an AI response before screenshotting,
+ * while preserving the surrounding structure (message bubbles, tool/activity
+ * summary, response container, suggestion buttons) so visual regressions in the
+ * chat chrome are still caught. The actual answer formatting is covered separately
+ * by the deterministic page tests, since the AI response renders through the same
+ * `DocumentView`.
+ *
+ * Must run only once the chat is no longer `aria-busy` (the response has fully
+ * settled), otherwise React re-renders from late stream events will clobber these
+ * mutations. See `waitForAIChatResponse`.
+ */
 const overrideAIResponse = () => {
-    const userMessage = document.querySelector('[data-testid="ai-chat-message-user"]');
-    if (userMessage) {
+    // The user's prompt varies in length; pin it to a fixed string.
+    document.querySelectorAll('[data-testid="ai-chat-message-user"]').forEach((userMessage) => {
         userMessage.textContent = '[Replaced message] Chat message sent by the user';
-    }
-    const assistantMessage = document.querySelectorAll(
-        '[data-testid="ai-chat-message-assistant"] .ai-response-document'
-    );
-    assistantMessage.forEach((message) => {
-        message.innerHTML = '[Replaced message] AI chat response';
     });
-    const suggestions = document.querySelectorAll('[data-testid="ai-chat-followup-suggestion"]');
-    suggestions.forEach((suggestion) => {
-        suggestion.textContent = 'Follow-up suggestion';
+
+    // The assistant's answer text is non-deterministic; replace the rendered
+    // document body while keeping the `.ai-response-document` container.
+    document
+        .querySelectorAll('[data-testid="ai-chat-message-assistant"] .ai-response-document')
+        .forEach((message) => {
+            message.innerHTML = '<p>[Replaced message] AI chat response</p>';
+        });
+
+    // The "Explored with N tools" activity label varies with the number of tool
+    // calls; pin it (the chevron sibling is left intact).
+    document.querySelectorAll('[data-testid="ai-chat-activity-summary"]').forEach((summary) => {
+        summary.textContent = 'Explored';
     });
+
+    // Follow-up suggestion text varies; pin each label.
+    document
+        .querySelectorAll('[data-testid="ai-chat-followup-suggestion"]')
+        .forEach((suggestion) => {
+            suggestion.textContent = 'Follow-up suggestion';
+        });
 };
 
 const searchTestCases: Test[] = [
@@ -167,10 +203,11 @@ const searchTestCases: Test[] = [
             await expect(page.getByTestId('ai-chat')).toBeVisible();
             await expect(page.getByTestId('ai-chat-message-user').first()).toHaveText(AI_PROMPT);
             await expect(page.getByTestId('ai-chat-message-assistant').first()).toBeVisible();
-            await expect(page.getByTestId('ai-chat-followup-suggestion')).toHaveCount(3, {
-                timeout: 60_000,
-            });
-            // Override text content for visual consistency in screenshots
+            // Wait for the full response (incl. follow-up suggestions) to settle before
+            // asserting/screenshotting, rather than racing a fixed suggestion count.
+            await waitForAIChatResponse(page);
+            await expect(page.getByTestId('ai-chat-followup-suggestion').first()).toBeVisible();
+            // Normalize non-deterministic content for visual consistency in screenshots.
             await page.evaluate(overrideAIResponse);
         },
     },
@@ -237,10 +274,11 @@ const searchTestCases: Test[] = [
             await expect(page.getByTestId('ai-chat')).toBeVisible();
             await expect(page.getByTestId('ai-chat-message-user').first()).toHaveText(AI_PROMPT);
             await expect(page.getByTestId('ai-chat-message-assistant').first()).toBeVisible();
-            await expect(page.getByTestId('ai-chat-followup-suggestion')).toHaveCount(3, {
-                timeout: 60_000,
-            });
-            // Override text content for visual consistency in screenshots
+            // Wait for the full response (incl. follow-up suggestions) to settle before
+            // asserting/screenshotting, rather than racing a fixed suggestion count.
+            await waitForAIChatResponse(page);
+            await expect(page.getByTestId('ai-chat-followup-suggestion').first()).toBeVisible();
+            // Normalize non-deterministic content for visual consistency in screenshots.
             await page.evaluate(overrideAIResponse);
         },
     },
@@ -2257,6 +2295,9 @@ const testCases: TestsCase[] = [
                     await expect(iframe.getByTestId('ai-chat-message-user').first()).toHaveText(
                         AI_PROMPT
                     );
+                    // Wait for the full response to settle before normalizing, otherwise
+                    // late stream re-renders clobber the replacements.
+                    await waitForAIChatResponse(iframe);
                     await iframe.owner().evaluate(overrideAIResponse);
                 },
             },
@@ -2367,6 +2408,8 @@ const testCases: TestsCase[] = [
                     await actions.nth(3).click();
                     await expect(page.locator('#gitbook-widget-window')).not.toBeVisible();
                     await page.locator('#gitbook-widget-button').click();
+                    // Wait for the response posted above to settle before normalizing.
+                    await waitForAIChatResponse(iframe);
                     await iframe.owner().evaluate(overrideAIResponse);
                 },
             },
@@ -2412,6 +2455,9 @@ const testCases: TestsCase[] = [
                     await expect(toolConfirmation).toBeVisible({
                         timeout: 30000,
                     });
+                    // The turn settles (aria-busy clears) once the stream pauses on the
+                    // confirmation control; wait for that before normalizing.
+                    await waitForAIChatResponse(iframe);
                     await iframe.owner().evaluate(overrideAIResponse);
                 },
             },

--- a/packages/gitbook/e2e/util.ts
+++ b/packages/gitbook/e2e/util.ts
@@ -21,7 +21,14 @@ import {
     type SiteCustomizationSettings,
     SiteExternalLinksTarget,
 } from '@gitbook/api';
-import { type BrowserContext, type Page, type Response, expect, test } from '@playwright/test';
+import {
+    type BrowserContext,
+    type FrameLocator,
+    type Page,
+    type Response,
+    expect,
+    test,
+} from '@playwright/test';
 import deepMerge from 'deepmerge';
 import rison from 'rison';
 import type { DeepPartial } from 'ts-essentials';
@@ -157,6 +164,28 @@ export async function waitForCookiesDialog(page: Page) {
 export async function waitForNotFound(_page: Page, response: Response | null) {
     expect(response).not.toBeNull();
     expect(response?.status()).toBe(404);
+}
+
+/**
+ * Wait for an AI chat response to be fully settled before asserting or
+ * screenshotting it.
+ *
+ * The chat exposes `aria-busy` on its container (`[data-testid="ai-chat"]`),
+ * which stays true from the moment a message is sent until the stream — including
+ * the follow-up suggestion phase — completes. Gating on it avoids the two main
+ * sources of flakiness: capturing a "thinking" placeholder or a half-streamed
+ * answer, and running the content normalization while React is still re-rendering
+ * (which would clobber the replacements).
+ *
+ * Argos also waits for `aria-busy` to clear during its own stabilization
+ * (`waitForAriaBusy`), so this is both an explicit gate and a backstop.
+ *
+ * Accepts a `Page` or a `FrameLocator` (for the embedded assistant in an iframe).
+ */
+export async function waitForAIChatResponse(scope: Page | FrameLocator) {
+    await expect(scope.getByTestId('ai-chat')).toHaveAttribute('aria-busy', 'false', {
+        timeout: 60_000,
+    });
 }
 
 export async function setTimeToMorning(page: Page) {

--- a/packages/gitbook/e2e/util.ts
+++ b/packages/gitbook/e2e/util.ts
@@ -47,6 +47,16 @@ export interface Test {
      */
     run?: (page: Page, response: Response | null) => Promise<unknown>;
     /**
+     * Re-applied right before every viewport screenshot (after Argos
+     * stabilization), so it survives re-renders triggered by viewport resizing.
+     *
+     * Use this — rather than mutating the DOM once in `run` — to normalize
+     * non-deterministic content (e.g. AI responses). A one-time mutation in `run`
+     * is clobbered when React re-renders on resize (e.g. crossing the mobile
+     * breakpoint), so only the first viewport ends up normalized.
+     */
+    normalizeBeforeScreenshot?: (page: Page) => Promise<void> | void;
+    /**
      * Mode for the test.
      */
     mode?: 'page' | 'image';
@@ -282,6 +292,9 @@ export function runTestCases(testCases: TestsCase[]) {
                                         await waitForTOCScrolling(page);
                                     }
                                     await waitForIcons(page);
+                                    // Re-apply per viewport, last — after any resize-driven
+                                    // re-render — so normalized content survives to capture.
+                                    await testEntry.normalizeBeforeScreenshot?.(page);
                                 },
                             });
                         }

--- a/packages/gitbook/src/components/AI/useAI.tsx
+++ b/packages/gitbook/src/components/AI/useAI.tsx
@@ -95,7 +95,7 @@ export function useAI(): AIContext {
             label: config.assistantName ?? getAIChatName(language, config.trademark),
             icon: (
                 <AIChatIcon
-                    state={chat.loading ? 'thinking' : 'default'}
+                    state={chat.responding ? 'thinking' : 'default'}
                     trademark={config.trademark}
                     className="size-text-lg"
                 />

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -86,7 +86,23 @@ export type AIChatState = {
     control: AnyAIControl | null;
 
     /**
-     * If true, the session is in progress.
+     * If true, the assistant is actively producing its answer — from the moment a
+     * message is sent until the `response_finish` event. It is cleared at that point
+     * (even though follow-up suggestions may still trickle in) so the input can be
+     * re-enabled. Drives the local "are we still answering" UI: the disabled input,
+     * the loading shim, and the thinking/exploring/working status.
+     */
+    responding: boolean;
+
+    /**
+     * If true, the turn is still in progress overall: from the moment a message is
+     * sent until the stream fully completes, including the follow-up suggestion
+     * phase.
+     *
+     * Unlike `responding` — which clears on `response_finish` — this stays true
+     * until the response is truly settled. It is the global busyness indicator,
+     * surfaced as `aria-busy` on the chat so that assistive tech (and visual tests)
+     * can wait for a complete, stable response.
      */
     loading: boolean;
 
@@ -152,6 +168,7 @@ const globalState = zustand.create<AIChatState>(() => {
         query: null,
         followUpSuggestions: [],
         control: null,
+        responding: false,
         loading: false,
         error: false,
         initialQuery: null,
@@ -246,6 +263,7 @@ export function AIChatProvider(props: {
                     ...state,
                     followUpSuggestions: [],
                     control: null,
+                    responding: true,
                     loading: true,
                     error: false,
                     messages: [
@@ -333,9 +351,9 @@ export function AIChatProvider(props: {
                             globalState.setState((state) => ({
                                 ...state,
                                 responseId: event.response.id ?? null,
-                                // Mark as not loading when the response is finished
+                                // Mark as not responding when the response is finished
                                 // Even if the stream might continue as we receive 'response_followup_suggestion'
-                                loading: false,
+                                responding: false,
                                 error: false,
                             }));
                             break;
@@ -453,12 +471,17 @@ export function AIChatProvider(props: {
                     }));
                 }
 
-                // Execute the tool call if it doesn't require confirmation
+                // Execute the tool call if it doesn't require confirmation.
+                // When a tool call (or control) keeps the turn going, `loading`
+                // stays true: either the recursive `streamResponse` will clear it
+                // when its stream settles, or it is cleared below once the loop ends
+                // (e.g. while waiting on a user confirmation control).
                 if (toolToExecute) {
                     await executeToolCall(toolToExecute);
                 } else {
                     globalState.setState((state) => ({
                         ...state,
+                        responding: false,
                         loading: false,
                         error: false,
                     }));
@@ -467,6 +490,7 @@ export function AIChatProvider(props: {
                 console.error('Error streaming AI response', error);
                 globalState.setState((state) => ({
                     ...state,
+                    responding: false,
                     loading: false,
                     error: true,
                 }));
@@ -485,14 +509,14 @@ export function AIChatProvider(props: {
     // Post a message to the AI chat
     const onPostMessage = React.useCallback(
         async (input: { message: string }) => {
-            const { query, messages, control, references, loading } = globalState.getState();
+            const { query, messages, control, references, responding } = globalState.getState();
 
             if (control) {
                 throw new Error("We can't post a message when a control is active");
             }
 
             // Ignore duplicates while a previous turn is still streaming
-            if (loading) {
+            if (responding) {
                 return;
             }
 
@@ -541,7 +565,7 @@ export function AIChatProvider(props: {
                     ],
                     query: input.message,
                     followUpSuggestions: [],
-                    loading: true,
+                    responding: true,
                     error: false,
                     initialQuery: state.initialQuery ?? input.message,
                     references: [],
@@ -557,6 +581,7 @@ export function AIChatProvider(props: {
     const onClear = React.useCallback(() => {
         globalState.setState((state) => ({
             opened: state.opened,
+            responding: false,
             loading: false,
             messages: [],
             query: null,
@@ -686,7 +711,7 @@ export function getAIChatStatus(chat: AIChatState): AIChatStatus {
         return 'confirm';
     }
 
-    if (chat.loading) {
+    if (chat.responding) {
         const latestMessage = getLatestAssistantMessage(chat.messages);
         const phase = latestMessage?.activity?.currentPhase;
         switch (phase) {

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -277,6 +277,16 @@ export function AIChatProvider(props: {
                 };
             });
 
+            // A stream becomes stale once a newer turn (or a clear) has replaced its
+            // query. Because `responding` clears on `response_finish` — before follow-up
+            // suggestions finish streaming — the user can start a new turn while this one
+            // is still wrapping up. A stale stream must not mutate the shared
+            // loading/responding state, which now belongs to the active turn; otherwise
+            // it would make the UI look idle mid-response. (`userQuery` is only set for
+            // user-initiated turns, not tool-call continuations.)
+            const isSuperseded = () =>
+                !!input.userQuery && globalState.getState().query !== input.userQuery;
+
             // Execute a tool call
             const executeToolCall = async (event: AIStreamResponseToolCallPending) => {
                 const tools = getTools([navigateToPageTool]);
@@ -339,8 +349,8 @@ export function AIChatProvider(props: {
                 for await (const data of stream) {
                     if (!data) continue;
 
-                    if (input.userQuery && globalState.getState().query !== input.userQuery) {
-                        // Chat was cleared, stop processing the stream
+                    if (isSuperseded()) {
+                        // Chat was cleared or a newer turn started; stop processing.
                         break;
                     }
 
@@ -471,6 +481,14 @@ export function AIChatProvider(props: {
                     }));
                 }
 
+                // If a newer turn replaced this one while we were finishing (e.g.
+                // streaming follow-up suggestions after `response_finish`), abandon this
+                // stale stream without executing leftover tools or clearing the shared
+                // loading/responding state, which now belongs to the active turn.
+                if (isSuperseded()) {
+                    return;
+                }
+
                 // Execute the tool call if it doesn't require confirmation.
                 // When a tool call (or control) keeps the turn going, `loading`
                 // stays true: either the recursive `streamResponse` will clear it
@@ -488,12 +506,15 @@ export function AIChatProvider(props: {
                 }
             } catch (error) {
                 console.error('Error streaming AI response', error);
-                globalState.setState((state) => ({
-                    ...state,
-                    responding: false,
-                    loading: false,
-                    error: true,
-                }));
+                // Don't surface a stale stream's error onto the active turn.
+                if (!isSuperseded()) {
+                    globalState.setState((state) => ({
+                        ...state,
+                        responding: false,
+                        loading: false,
+                        error: true,
+                    }));
+                }
             }
         },
         [

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -89,7 +89,7 @@ export function AIChat() {
             )}
         >
             <EmbeddableFrame className="relative shrink-0 border-tint-subtle border-l to-tint-base">
-                <EmbeddableFrameMain data-testid="ai-chat">
+                <EmbeddableFrameMain data-testid="ai-chat" aria-busy={chat.loading}>
                     <EmbeddableFrameHeader className="not-embed:px-4">
                         <AIChatDynamicIcon trademark={config.trademark} />
                         <EmbeddableFrameHeaderMain>
@@ -281,8 +281,8 @@ export function AIChatBody(props: {
 
                 {chat.control ? <AIChatControl control={chat.control} /> : null}
                 <AIChatInput
-                    loading={chat.loading}
-                    disabled={chat.loading || chat.error}
+                    responding={chat.responding}
+                    disabled={chat.responding || chat.error}
                     onSubmit={(value) => {
                         chatController.postMessage({ message: value });
                     }}

--- a/packages/gitbook/src/components/AIChat/AIChatInput.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatInput.tsx
@@ -13,10 +13,10 @@ export function AIChatInput(props: {
     /**
      * When true, the input is disabled
      */
-    loading: boolean;
+    responding: boolean;
     onSubmit: (value: string) => void;
 }) {
-    const { onSubmit, disabled, loading } = props;
+    const { onSubmit, disabled, responding } = props;
 
     const language = useLanguage();
     const chat = useAIChatState();
@@ -25,7 +25,7 @@ export function AIChatInput(props: {
     const inputRef = useRef<HTMLTextAreaElement>(null);
 
     useEffect(() => {
-        if (chat.opened && !disabled && !loading) {
+        if (chat.opened && !disabled && !responding) {
             // Add a small delay to ensure the input is rendered before focusing
             // This fixes inconsistent focus behaviour across browsers
             const timeout = setTimeout(() => {
@@ -34,7 +34,7 @@ export function AIChatInput(props: {
 
             return () => clearTimeout(timeout);
         }
-    }, [disabled, loading, chat.opened]);
+    }, [disabled, responding, chat.opened]);
 
     // Explicit focus requests (e.g. clicking "Ask" while the chat is already open).
     useEffect(() => {
@@ -75,21 +75,21 @@ export function AIChatInput(props: {
             rows={1}
             maxLength={2048}
             keyboardShortcut={
-                !disabled && !loading
+                !disabled && !responding
                     ? {
                           keys: ['mod', 'i'],
                           className: 'bg-tint-base group-focus-within/input:hidden',
                       }
                     : undefined
             }
-            disabled={disabled || loading || chat.control !== null}
-            aria-busy={loading}
+            disabled={disabled || responding || chat.control !== null}
+            aria-busy={responding}
             ref={inputRef}
             header={
                 <AIChatReferenceChips
                     references={chat.references}
                     onRemove={chatController.removeReference}
-                    disabled={loading || disabled}
+                    disabled={responding || disabled}
                 />
             }
             trailing={

--- a/packages/gitbook/src/components/AIChat/AIChatMessages.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatMessages.tsx
@@ -22,7 +22,7 @@ export function AIChatMessages(props: {
 }) {
     const { chat, chatController } = props;
     const status = getAIChatStatus(chat);
-    const showLoadingShim = chat.loading && status !== 'working' && status !== 'done';
+    const showLoadingShim = chat.responding && status !== 'working' && status !== 'done';
 
     // Group messages: user messages start a new group, all following messages until next user message belong to that group
     type MessageGroup = { message: AIChatMessage; originalIndex: number };
@@ -116,19 +116,21 @@ export function AIChatMessages(props: {
                                             className="-mx-3 -my-1.5 group/dropdown animate-blur-in-display-slow self-start"
                                         >
                                             <div className="flex items-center gap-2">
-                                                {toolCount > 0
-                                                    ? t(
-                                                          language,
-                                                          'ai_chat_explored_with',
-                                                          tString(
+                                                <span data-testid="ai-chat-activity-summary">
+                                                    {toolCount > 0
+                                                        ? t(
                                                               language,
-                                                              toolCount === 1
-                                                                  ? 'tool_count'
-                                                                  : 'tool_count_plural',
-                                                              toolCount.toString()
+                                                              'ai_chat_explored_with',
+                                                              tString(
+                                                                  language,
+                                                                  toolCount === 1
+                                                                      ? 'tool_count'
+                                                                      : 'tool_count_plural',
+                                                                  toolCount.toString()
+                                                              )
                                                           )
-                                                      )
-                                                    : t(language, 'ai_chat_explored')}
+                                                        : t(language, 'ai_chat_explored')}
+                                                </span>
                                                 <ToggleChevron orientation="right-to-down" />
                                             </div>
                                         </Button>
@@ -153,7 +155,7 @@ export function AIChatMessages(props: {
 
                                 {isLastMessage ? (
                                     <>
-                                        {!chat.loading &&
+                                        {!chat.responding &&
                                         !chat.error &&
                                         chat.query &&
                                         chat.responseId &&

--- a/packages/gitbook/src/components/DocumentView/InlineActionButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineActionButton.tsx
@@ -51,8 +51,8 @@ export function InlineActionButton(
                     className: 'text-[1em]',
                 }}
                 maxLength={action === 'ask' ? 2048 : 512}
-                disabled={action === 'ask' && chatState.loading}
-                aria-busy={action === 'ask' && chatState.loading}
+                disabled={action === 'ask' && chatState.responding}
+                aria-busy={action === 'ask' && chatState.responding}
                 leading={icon}
                 keyboardShortcut={false}
                 onSubmit={(value) => handleSubmit(value as string)}

--- a/packages/gitbook/src/components/Embeddable/EmbeddableAIChat.tsx
+++ b/packages/gitbook/src/components/Embeddable/EmbeddableAIChat.tsx
@@ -79,7 +79,7 @@ export function EmbeddableAIChat(props: EmbeddableAIChatProps) {
                 <EmbeddableIframeButtons />
                 <EmbeddableIframeCloseButton />
             </EmbeddableFrameSidebar>
-            <EmbeddableFrameMain data-testid="ai-chat">
+            <EmbeddableFrameMain data-testid="ai-chat" aria-busy={chat.loading}>
                 <EmbeddableFrameHeader>
                     {!tabsRef.current ? (
                         <AIChatDynamicIcon className="animate-blur-in-slow" trademark={trademark} />

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -30,7 +30,7 @@ export function ActionOpenAssistant(props: { assistant: Assistant; type: PageAct
             label={assistant.label}
             shortLabel={tString(language, 'ask')}
             description={tString(language, 'ai_chat_ask_about_page', assistant.label)}
-            disabled={chat.loading}
+            disabled={chat.responding}
             onClick={() => {
                 assistant.open();
             }}


### PR DESCRIPTION
## Overview

The Assistant visual tests were flaky because screenshots were captured before the response finished streaming (catching a "thinking" placeholder or a half-generated answer), and the client-side content replacements raced React and got clobbered.

- Expose `aria-busy` on the chat container while the assistant is responding — including the follow-up suggestion phase — so Argos/Playwright wait for a complete, settled response. Also a genuine screen-reader improvement.
- Rename the chat state flags for clarity: `responding` = actively generating the answer (drives input-disable, loading shim, status); `loading` = the whole turn in flight incl. suggestions (drives `aria-busy`). Behaviour-preserving.
- Gate screenshots and content normalization on `aria-busy` settling instead of the brittle `toHaveCount(3)` follow-up assertion (now a tolerant `>= 1`).
- Make the screenshot normalizer structure-preserving — keep the message/tool/suggestion containers, replace only the non-deterministic text — and run it only after the response settles, so React no longer clobbers the replacements.
- Tighten the test prompt to reduce structural nondeterminism (no preamble, single search, exactly 3 follow-up suggestions).

*— Authored by Claude*