### PR TITLE
Reference the current page when opening the Assistant

### DIFF
--- a/.changeset/page-reference-chip.md
+++ b/.changeset/page-reference-chip.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add a page reference chip when opening the Assistant from the page action, so the assistant is informed about the page the reader is currently on.

--- a/packages/gitbook/src/components/AI/references.test.ts
+++ b/packages/gitbook/src/components/AI/references.test.ts
@@ -6,21 +6,29 @@ describe('serializeReferences', () => {
         expect(serializeReferences([])).toBe('');
     });
 
-    it('serializes a single page reference', () => {
+    it('serializes a single page reference as a markdown link', () => {
         const refs: AIChatReference[] = [
-            { type: 'page', id: 'page-1', label: 'Getting started', path: 'getting-started' },
+            { type: 'page', id: 'page-1', label: 'Getting started', href: '/getting-started' },
         ];
         const result = serializeReferences(refs);
         expect(result).toContain('The user is referring to the following page they are reading');
-        expect(result).toContain('- "Getting started" (getting-started)');
+        expect(result).toContain('- [Getting started](/getting-started)');
         expect(result.endsWith('\n\n---\n\n')).toBe(true);
     });
 
-    it('omits the path when not provided', () => {
+    it('falls back to the path when no href is provided', () => {
+        const refs: AIChatReference[] = [
+            { type: 'page', id: 'page-1', label: 'Overview', path: 'getting-started' },
+        ];
+        const result = serializeReferences(refs);
+        expect(result).toContain('- [Overview](getting-started)');
+    });
+
+    it('renders a quoted label when neither href nor path is provided', () => {
         const refs: AIChatReference[] = [{ type: 'page', id: 'page-1', label: 'Overview' }];
         const result = serializeReferences(refs);
         expect(result).toContain('- "Overview"');
-        expect(result).not.toContain('(');
+        expect(result).not.toContain('](');
     });
 
     it('uses the plural form for multiple pages', () => {

--- a/packages/gitbook/src/components/AI/references.test.ts
+++ b/packages/gitbook/src/components/AI/references.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+import { type AIChatReference, serializeReferences } from './references';
+
+describe('serializeReferences', () => {
+    it('returns an empty string when there are no references', () => {
+        expect(serializeReferences([])).toBe('');
+    });
+
+    it('serializes a single page reference', () => {
+        const refs: AIChatReference[] = [
+            { type: 'page', id: 'page-1', label: 'Getting started', path: 'getting-started' },
+        ];
+        const result = serializeReferences(refs);
+        expect(result).toContain('The user is referring to the following page they are reading');
+        expect(result).toContain('- "Getting started" (getting-started)');
+        expect(result.endsWith('\n\n---\n\n')).toBe(true);
+    });
+
+    it('omits the path when not provided', () => {
+        const refs: AIChatReference[] = [{ type: 'page', id: 'page-1', label: 'Overview' }];
+        const result = serializeReferences(refs);
+        expect(result).toContain('- "Overview"');
+        expect(result).not.toContain('(');
+    });
+
+    it('uses the plural form for multiple pages', () => {
+        const refs: AIChatReference[] = [
+            { type: 'page', id: 'page-1', label: 'One' },
+            { type: 'page', id: 'page-2', label: 'Two' },
+        ];
+        const result = serializeReferences(refs);
+        expect(result).toContain('the following pages they are reading');
+        expect(result).toContain('in the context of them');
+    });
+
+    it('serializes a single code block reference', () => {
+        const refs: AIChatReference[] = [
+            {
+                type: 'code-block',
+                id: 'code-1',
+                label: 'main.ts',
+                content: 'const a = 1;',
+                syntax: 'ts',
+            },
+        ];
+        const result = serializeReferences(refs);
+        expect(result).toContain('The user is referring to the following code block');
+        expect(result).toContain('main.ts\n```ts\nconst a = 1;\n```');
+    });
+
+    it('escapes backtick fences inside the code content', () => {
+        const refs: AIChatReference[] = [
+            { type: 'code-block', id: 'code-1', content: 'a ``` b', syntax: 'md' },
+        ];
+        const result = serializeReferences(refs);
+        expect(result).toContain('````md\na ``` b\n````');
+    });
+
+    it('groups page and code references into distinct sections', () => {
+        const refs: AIChatReference[] = [
+            { type: 'page', id: 'page-1', label: 'Quickstart' },
+            { type: 'code-block', id: 'code-1', content: 'x', syntax: 'js' },
+        ];
+        const result = serializeReferences(refs);
+        const pageIndex = result.indexOf('referring to the following page');
+        const codeIndex = result.indexOf('referring to the following code block');
+        expect(pageIndex).toBeGreaterThanOrEqual(0);
+        expect(codeIndex).toBeGreaterThan(pageIndex);
+    });
+});

--- a/packages/gitbook/src/components/AI/references.ts
+++ b/packages/gitbook/src/components/AI/references.ts
@@ -52,7 +52,10 @@ export function serializeReferences(refs: AIChatReference[]): string {
 function serializePageReferences(refs: PageReference[]): string {
     const plural = refs.length > 1;
     const list = refs
-        .map((ref) => `- "${ref.label}"${ref.path ? ` (${ref.path})` : ''}`)
+        .map((ref) => {
+            const url = ref.href ?? ref.path;
+            return url ? `- [${ref.label}](${url})` : `- "${ref.label}"`;
+        })
         .join('\n');
     return `The user is referring to the following page${plural ? 's' : ''} they are reading. Answer their question in the context of ${plural ? 'them' : 'it'}:\n\n${list}`;
 }

--- a/packages/gitbook/src/components/AI/references.ts
+++ b/packages/gitbook/src/components/AI/references.ts
@@ -1,34 +1,66 @@
-import assertNever from 'assert-never';
-
 type BaseAIChatReference = {
     id: string;
     label?: string;
-    content: string;
 };
 
 export type CodeBlockReference = BaseAIChatReference & {
     type: 'code-block';
+    content: string;
     syntax?: string;
 };
 
-export type AIChatReference = CodeBlockReference;
+export type PageReference = BaseAIChatReference & {
+    type: 'page';
+    /** Title of the page being referenced. */
+    label: string;
+    /** Path of the page, used to help the assistant identify it. */
+    path?: string;
+    /** Site-relative href of the page, used to navigate back to it from the chip. */
+    href?: string;
+};
 
+export type AIChatReference = CodeBlockReference | PageReference;
+
+/**
+ * Serialize the staged references into a preamble prepended to the user's message,
+ * so the assistant is informed about the context the user is referring to.
+ */
 export function serializeReferences(refs: AIChatReference[]): string {
     if (refs.length === 0) {
         return '';
     }
-    const plural = refs.length > 1;
-    const blocks = refs.map(serializeReference).join('\n\n');
-    return `The user is referring to the following code block${plural ? 's' : ''} from the page they are reading. Answer their question about ${plural ? 'them' : 'it'}:\n\n${blocks}\n\n---\n\n`;
+
+    const sections: string[] = [];
+
+    const pageRefs = refs.filter((ref): ref is PageReference => ref.type === 'page');
+    if (pageRefs.length > 0) {
+        sections.push(serializePageReferences(pageRefs));
+    }
+
+    const codeRefs = refs.filter((ref): ref is CodeBlockReference => ref.type === 'code-block');
+    if (codeRefs.length > 0) {
+        sections.push(serializeCodeBlockReferences(codeRefs));
+    }
+
+    if (sections.length === 0) {
+        return '';
+    }
+
+    return `${sections.join('\n\n')}\n\n---\n\n`;
 }
 
-function serializeReference(ref: AIChatReference): string {
-    switch (ref.type) {
-        case 'code-block':
-            return buildCodeBlockFence(ref);
-        default:
-            assertNever(ref.type);
-    }
+function serializePageReferences(refs: PageReference[]): string {
+    const plural = refs.length > 1;
+    const list = refs
+        .map((ref) => `- "${ref.label}"${ref.path ? ` (${ref.path})` : ''}`)
+        .join('\n');
+    return `The user is referring to the following page${plural ? 's' : ''} they are reading. Answer their question in the context of ${plural ? 'them' : 'it'}:\n\n${list}`;
+}
+
+function serializeCodeBlockReferences(refs: CodeBlockReference[]): string {
+    const plural = refs.length > 1;
+    const blocks = refs.map(buildCodeBlockFence).join('\n\n');
+    return `The user is referring to the following code block${plural ? 's' : ''} from the page they are reading. Answer their question about ${plural ? 'them' : 'it'}:\n\n${blocks}`;
 }
 
 function buildCodeBlockFence(ref: CodeBlockReference): string {

--- a/packages/gitbook/src/components/AIChat/AIChatReferenceChips.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatReferenceChips.tsx
@@ -2,13 +2,13 @@
 
 import { Icon, type IconName } from '@gitbook/icons';
 import assertNever from 'assert-never';
-import { useRouter } from 'next/navigation';
-import { useContext } from 'react';
 
 import { tcls } from '@/lib/tailwind';
-import { normalizePathname, resolveNavigationTarget } from '../AI/navigation';
-import type { AIChatReference, CodeBlockReference, PageReference } from '../AI/references';
-import { NavigationStatusContext } from '../hooks';
+import type { AIChatReference } from '../AI/references';
+import { Link } from '../primitives';
+
+const triggerClassName =
+    'inline-flex min-w-0 items-center gap-1.5 circular-corners:rounded-2xl rounded-corners:rounded-sm py-0.5 pr-1 pl-1.5 text-tint no-underline transition hover:bg-tint hover:text-tint';
 
 export function AIChatReferenceChips(props: {
     references: AIChatReference[];
@@ -16,8 +16,6 @@ export function AIChatReferenceChips(props: {
     disabled?: boolean;
 }) {
     const { references, onRemove, disabled } = props;
-    const router = useRouter();
-    const { onNavigationClick } = useContext(NavigationStatusContext);
 
     if (references.length === 0) {
         return null;
@@ -25,19 +23,9 @@ export function AIChatReferenceChips(props: {
 
     return (
         <div className="flex max-w-full flex-wrap gap-1.5">
-            {references.map((ref) => (
-                <div
-                    key={ref.id}
-                    className="inline-flex max-w-52 items-center gap-1 circular-corners:rounded-2xl rounded-corners:rounded-md straight-corners:rounded-xs border border-tint-subtle bg-tint-base px-0.5 py-0.5 text-tint text-xs leading-none"
-                >
-                    <button
-                        type="button"
-                        onClick={(event) => {
-                            event.stopPropagation();
-                            activateReference(ref, { router, onNavigationClick });
-                        }}
-                        className="inline-flex min-w-0 items-center gap-1.5 circular-corners:rounded-2xl rounded-corners:rounded-sm py-0.5 pr-1 pl-1.5 transition hover:bg-tint"
-                    >
+            {references.map((ref) => {
+                const content = (
+                    <>
                         <Icon icon={getReferenceIcon(ref)} className="size-3 shrink-0 opacity-7" />
                         <span
                             className={tcls(
@@ -47,23 +35,55 @@ export function AIChatReferenceChips(props: {
                         >
                             {ref.label}
                         </span>
-                    </button>
-                    {onRemove ? (
-                        <button
-                            type="button"
-                            aria-label="Remove"
-                            onClick={(event) => {
-                                event.stopPropagation();
-                                onRemove(ref.id);
-                            }}
-                            disabled={disabled}
-                            className="inline-flex size-4 shrink-0 items-center justify-center circular-corners:rounded-full rounded-corners:rounded-sm text-tint/8 transition hover:bg-tint hover:text-tint-strong disabled:cursor-not-allowed disabled:opacity-5"
-                        >
-                            <Icon icon="xmark" className="size-2.5" />
-                        </button>
-                    ) : null}
-                </div>
-            ))}
+                    </>
+                );
+
+                return (
+                    <div
+                        key={ref.id}
+                        className="inline-flex max-w-52 items-center gap-1 circular-corners:rounded-2xl rounded-corners:rounded-md straight-corners:rounded-xs border border-tint-subtle bg-tint-base px-0.5 py-0.5 text-tint text-xs leading-none"
+                    >
+                        {ref.type === 'page' && ref.href ? (
+                            // A page reference may be clicked from anywhere: render a link so it
+                            // navigates back to the page (and supports cmd/ctrl-click to open in a
+                            // new tab).
+                            <Link
+                                href={ref.href}
+                                prefetch={false}
+                                className={triggerClassName}
+                                onClick={(event) => event.stopPropagation()}
+                            >
+                                {content}
+                            </Link>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    focusReference(ref);
+                                }}
+                                className={triggerClassName}
+                            >
+                                {content}
+                            </button>
+                        )}
+                        {onRemove ? (
+                            <button
+                                type="button"
+                                aria-label="Remove"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    onRemove(ref.id);
+                                }}
+                                disabled={disabled}
+                                className="inline-flex size-4 shrink-0 items-center justify-center circular-corners:rounded-full rounded-corners:rounded-sm text-tint/8 transition hover:bg-tint hover:text-tint-strong disabled:cursor-not-allowed disabled:opacity-5"
+                            >
+                                <Icon icon="xmark" className="size-2.5" />
+                            </button>
+                        ) : null}
+                    </div>
+                );
+            })}
         </div>
     );
 }
@@ -79,57 +99,17 @@ function getReferenceIcon(ref: AIChatReference): IconName {
     }
 }
 
-type NavigationHandle = {
-    router: ReturnType<typeof useRouter>;
-    onNavigationClick: (href: string) => void;
-};
-
 /**
- * Handle a click on a reference chip: jump to the referenced content.
+ * Jump to the content a reference points at, for chips that aren't rendered as links:
+ * - a code block: scroll it into view on the current page and focus it;
+ * - a page without a known href: scroll back to the top (the reader is most likely on it).
  */
-function activateReference(ref: AIChatReference, nav: NavigationHandle) {
+function focusReference(ref: AIChatReference) {
     if (ref.type === 'page') {
-        navigateToPageReference(ref, nav);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
         return;
     }
 
-    focusReference(ref);
-}
-
-/**
- * A page reference may be clicked from any page. Navigate to it if the reader is elsewhere,
- * otherwise scroll back to the top of the page they are already on.
- */
-function navigateToPageReference(
-    ref: PageReference,
-    { router, onNavigationClick }: NavigationHandle
-) {
-    const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
-
-    if (!ref.href) {
-        scrollToTop();
-        return;
-    }
-
-    const target = resolveNavigationTarget(ref.href, window.location);
-    if ('error' in target) {
-        scrollToTop();
-        return;
-    }
-
-    if (normalizePathname(window.location.pathname) === normalizePathname(target.pathname)) {
-        scrollToTop();
-        return;
-    }
-
-    onNavigationClick(target.href);
-    router.push(target.href);
-}
-
-/**
- * A code-block reference points at a block on the current page: scroll it into view and focus it.
- */
-function focusReference(ref: CodeBlockReference) {
     const candidates = document.querySelectorAll<HTMLElement>(`#${CSS.escape(ref.id)}`);
     const target = Array.from(candidates).find((el) => !el.closest('[data-ai-chat]'));
     if (!target) {

--- a/packages/gitbook/src/components/AIChat/AIChatReferenceChips.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatReferenceChips.tsx
@@ -1,6 +1,14 @@
-import { Icon } from '@gitbook/icons';
+'use client';
 
-import type { AIChatReference } from '../AI/references';
+import { Icon, type IconName } from '@gitbook/icons';
+import assertNever from 'assert-never';
+import { useRouter } from 'next/navigation';
+import { useContext } from 'react';
+
+import { tcls } from '@/lib/tailwind';
+import { normalizePathname, resolveNavigationTarget } from '../AI/navigation';
+import type { AIChatReference, CodeBlockReference, PageReference } from '../AI/references';
+import { NavigationStatusContext } from '../hooks';
 
 export function AIChatReferenceChips(props: {
     references: AIChatReference[];
@@ -8,6 +16,8 @@ export function AIChatReferenceChips(props: {
     disabled?: boolean;
 }) {
     const { references, onRemove, disabled } = props;
+    const router = useRouter();
+    const { onNavigationClick } = useContext(NavigationStatusContext);
 
     if (references.length === 0) {
         return null;
@@ -24,12 +34,19 @@ export function AIChatReferenceChips(props: {
                         type="button"
                         onClick={(event) => {
                             event.stopPropagation();
-                            focusReference(ref);
+                            activateReference(ref, { router, onNavigationClick });
                         }}
                         className="inline-flex min-w-0 items-center gap-1.5 circular-corners:rounded-2xl rounded-corners:rounded-sm py-0.5 pr-1 pl-1.5 transition hover:bg-tint"
                     >
-                        <Icon icon="code" className="size-3 shrink-0 opacity-7" />
-                        <span className="min-w-0 truncate font-mono">{ref.label}</span>
+                        <Icon icon={getReferenceIcon(ref)} className="size-3 shrink-0 opacity-7" />
+                        <span
+                            className={tcls(
+                                'min-w-0 truncate',
+                                ref.type === 'code-block' && 'font-mono'
+                            )}
+                        >
+                            {ref.label}
+                        </span>
                     </button>
                     {onRemove ? (
                         <button
@@ -51,7 +68,68 @@ export function AIChatReferenceChips(props: {
     );
 }
 
-function focusReference(ref: AIChatReference) {
+function getReferenceIcon(ref: AIChatReference): IconName {
+    switch (ref.type) {
+        case 'code-block':
+            return 'code';
+        case 'page':
+            return 'memo';
+        default:
+            assertNever(ref);
+    }
+}
+
+type NavigationHandle = {
+    router: ReturnType<typeof useRouter>;
+    onNavigationClick: (href: string) => void;
+};
+
+/**
+ * Handle a click on a reference chip: jump to the referenced content.
+ */
+function activateReference(ref: AIChatReference, nav: NavigationHandle) {
+    if (ref.type === 'page') {
+        navigateToPageReference(ref, nav);
+        return;
+    }
+
+    focusReference(ref);
+}
+
+/**
+ * A page reference may be clicked from any page. Navigate to it if the reader is elsewhere,
+ * otherwise scroll back to the top of the page they are already on.
+ */
+function navigateToPageReference(
+    ref: PageReference,
+    { router, onNavigationClick }: NavigationHandle
+) {
+    const scrollToTop = () => window.scrollTo({ top: 0, behavior: 'smooth' });
+
+    if (!ref.href) {
+        scrollToTop();
+        return;
+    }
+
+    const target = resolveNavigationTarget(ref.href, window.location);
+    if ('error' in target) {
+        scrollToTop();
+        return;
+    }
+
+    if (normalizePathname(window.location.pathname) === normalizePathname(target.pathname)) {
+        scrollToTop();
+        return;
+    }
+
+    onNavigationClick(target.href);
+    router.push(target.href);
+}
+
+/**
+ * A code-block reference points at a block on the current page: scroll it into view and focus it.
+ */
+function focusReference(ref: CodeBlockReference) {
     const candidates = document.querySelectorAll<HTMLElement>(`#${CSS.escape(ref.id)}`);
     const target = Array.from(candidates).find((el) => !el.closest('[data-ai-chat]'));
     if (!target) {

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useAIChatState } from '@/components/AI';
+import { useAIChatController, useAIChatState } from '@/components/AI';
 import type { Assistant } from '@/components/AI';
 import { Button } from '@/components/primitives/Button';
 import { DropdownMenuItem, useDropdownMenuClose } from '@/components/primitives/DropdownMenu';
@@ -16,11 +16,27 @@ import { createStore, useStore } from 'zustand';
 type PageActionType = 'button' | 'dropdown-menu-item';
 
 /**
+ * Context about the current page, attached to the assistant as a reference when opened.
+ */
+export type PageActionAssistantContext = {
+    id: string;
+    title: string;
+    path?: string;
+    /** Site-relative href of the page, used to navigate back to it from the chip. */
+    href?: string;
+};
+
+/**
  * Action to open the GitBook Assistant.
  */
-export function ActionOpenAssistant(props: { assistant: Assistant; type: PageActionType }) {
-    const { assistant, type } = props;
+export function ActionOpenAssistant(props: {
+    assistant: Assistant;
+    type: PageActionType;
+    page?: PageActionAssistantContext;
+}) {
+    const { assistant, type, page } = props;
     const chat = useAIChatState();
+    const chatController = useAIChatController();
     const language = useLanguage();
 
     return (
@@ -32,6 +48,18 @@ export function ActionOpenAssistant(props: { assistant: Assistant; type: PageAct
             description={tString(language, 'ai_chat_ask_about_page', assistant.label)}
             disabled={chat.loading}
             onClick={() => {
+                // Stage a reference to the current page so the assistant is informed about
+                // the context the user is asking from. Only the sidebar GitBook Assistant
+                // uses the chat reference system.
+                if (page && assistant.mode === 'sidebar') {
+                    chatController.addReference({
+                        type: 'page',
+                        id: page.id,
+                        label: page.title,
+                        path: page.path,
+                        href: page.href,
+                    });
+                }
                 assistant.open();
             }}
         />

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -18,6 +18,7 @@ import {
     ActionViewAsMarkdown,
     ActionViewAsPDF,
     ActionViewAsRSS,
+    type PageActionAssistantContext,
 } from './PageActions';
 
 export type PageActionsDropdownURLs = {
@@ -37,6 +38,8 @@ interface PageActionsDropdownProps {
     urls: PageActionsDropdownURLs;
     className?: string;
     actions: SiteCustomizationSettings['pageActions'];
+    /** The current page, referenced by the assistant when opened. */
+    page: PageActionAssistantContext;
 }
 
 /**
@@ -78,7 +81,7 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
  * Return the list of actions to show in the dropdown menu.
  */
 function getPageDropdownActions(props: PageActionsDropdownProps): React.ReactNode[] {
-    const { siteTitle, urls, actions } = props;
+    const { siteTitle, urls, actions, page } = props;
     const assistants = useAI().assistants.filter(
         (assistant) => assistant.ui === true && assistant.pageAction
     );
@@ -89,6 +92,7 @@ function getPageDropdownActions(props: PageActionsDropdownProps): React.ReactNod
                 key={assistant.label}
                 assistant={assistant}
                 type="dropdown-menu-item"
+                page={page}
             />
         )),
 
@@ -158,7 +162,7 @@ function getPageDropdownActions(props: PageActionsDropdownProps): React.ReactNod
  * A default action shown as a quick-access button beside the dropdown menu
  */
 function usePageDefaultAction(props: PageActionsDropdownProps) {
-    const { urls, actions } = props;
+    const { urls, actions, page } = props;
     const assistants = useAI().assistants.filter(
         (assistant) => assistant.ui === true && assistant.pageAction
     );
@@ -169,7 +173,7 @@ function usePageDefaultAction(props: PageActionsDropdownProps) {
 
     const assistant = assistants[0];
     if (assistant) {
-        return <ActionOpenAssistant assistant={assistant} type="button" />;
+        return <ActionOpenAssistant assistant={assistant} type="button" page={page} />;
     }
 
     if (urls.editOnGit) {

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -56,6 +56,12 @@ export async function PageHeader(props: {
                         siteTitle={context.site.title}
                         urls={getPageActionsURLs({ context, page, withRSSFeed })}
                         actions={context.customization.pageActions}
+                        page={{
+                            id: page.id,
+                            title: page.title,
+                            path: page.path,
+                            href: linker.toPathForPage({ pages: revision.pages, page }),
+                        }}
                     />
                 ) : null}
                 <PageAsideToggleButton />


### PR DESCRIPTION
## Overview

Builds on the code-block "Ask" feature so the Assistant page action carries the same kind of context chip.

- Opening the Assistant from the page action now stages a removable **"reference to the page" chip** showing the current page's title (with a page icon), mirroring the existing code-block reference chip.
- The page reference is serialized into the message, so the assistant is explicitly informed which page the reader is asking about — on top of the page location already sent in the message context.
- Clicking the chip **navigates back to the referenced page** (SPA navigation, with the app's loading indicator) when you've moved elsewhere, or scrolls to the top of the page when you're already on it.
- Scoped to the GitBook sidebar assistant (`mode === 'sidebar'`); integration assistants, which open their own UI, are untouched. The always-on `messageContext.location` is left unchanged.

## Implementation

- `AI/references.ts` — adds a `PageReference` type to the `AIChatReference` union (with optional `path` for the model and `href` for navigation) and groups serialization by reference type.
- `AIChat/AIChatReferenceChips.tsx` — renders a page-appropriate icon/label and routes chip clicks: code blocks scroll/focus the on-page block, pages navigate via the router (or scroll to top if already there), reusing `resolveNavigationTarget` / `normalizePathname`.
- `PageActions/PageActions.tsx` + `PageActionsDropdown.tsx` + `PageBody/PageHeader.tsx` — thread the current page (`id`, `title`, `path`, routable `href`) to the page action and stage the reference on click.
- Adds unit tests for `serializeReferences` (page, code, and mixed references).

## Demo / verification

Verified locally against `gitbook.com/docs`:

- Clicking **Ask** stages a chip with the current page's title; navigating between pages updates it to the page you're on.
- With a **Quickstart** chip staged, navigating to **Overview** keeps the chip; clicking it navigates back to `/getting-started/quickstart`.
- The ✕ removes the chip.
- `bun run typecheck` (27/27), `bun run format`, and the new unit tests all pass.

> Screenshots from local verification can be attached here.

*— Authored by Claude*