### PR TITLE
Fix AI assistant forms overflowing the chat panel

### DIFF
--- a/.changeset/assistant-form-overflow.md
+++ b/.changeset/assistant-form-overflow.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the AI assistant panel overflowing its frame when rendering single/multi-choice question forms with long option text.

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -88,7 +88,7 @@ export function AIChat() {
                 'ai-chat mx-auto ml-8 not-hydrated:hidden w-96 transition-[width] duration-300 ease-quint lg:max-xl:w-80'
             )}
         >
-            <EmbeddableFrame className="relative shrink-0 border-tint-subtle border-l to-tint-base">
+            <EmbeddableFrame className="relative w-full shrink-0 border-tint-subtle border-l to-tint-base">
                 <EmbeddableFrameMain data-testid="ai-chat">
                     <EmbeddableFrameHeader className="not-embed:px-4">
                         <AIChatDynamicIcon trademark={config.trademark} />


### PR DESCRIPTION
## Overview

- The assistant chat panel overflowed its frame when rendering single/multi-choice question forms, clipping option labels and descriptions — most visible with long option text.
- Root cause: after the `SideSheet` refactor, the chat's `EmbeddableFrame` kept `shrink-0` but lost its explicit width. With `flex-basis: auto` and no width, the frame sized to its content's max-content width and refused to shrink back to the fixed-width panel (~626px inside a 320px panel).
- Fix: add `w-full` to the `EmbeddableFrame` so it fills the panel. This is a frame-level fix, so it covers all wide chat content (both choice controls and long messages), not just one component.
- Verified with the live assistant on desktop (320px panel) and mobile (327px): frame now matches the panel width, zero elements overflow, and all form text wraps cleanly.

## Demo

_Before — multi-choice form clipped at the panel's right edge:_

<img width="716" height="1650" alt="image" src="https://github.com/user-attachments/assets/d9661a72-a22c-40b0-8a0b-ee7a951937f0" />

_After — prompt, labels, and descriptions wrap within the panel (desktop):_

<img width="800" height="486" alt="image" src="https://github.com/user-attachments/assets/4935f7dc-2042-46cd-a7c0-88c3c64cd51e" />

_After — same on mobile:_

<img width="664" height="1436" alt="image" src="https://github.com/user-attachments/assets/6d5e8320-e53f-4d4a-aa3a-1112dfafa8f4" />

*— Authored by Claude*