### PR TITLE
Fix ⌘-C opening the Assistant on Dvorak keyboard layouts

### DIFF
--- a/.changeset/dvorak-shortcut-logical-key.md
+++ b/.changeset/dvorak-shortcut-logical-key.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Match keyboard shortcuts by the logical character typed instead of the physical key position, so that ⌘-C no longer opens the Assistant on the Dvorak layout (and other non-QWERTY layouts).

--- a/packages/gitbook/src/components/AIChat/AIChatInput.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatInput.tsx
@@ -51,6 +51,9 @@ export function AIChatInput(props: {
         },
         {
             enableOnFormTags: true,
+            // Match the logical character so Dvorak ⌘-C (physical "I" key) copies
+            // instead of focusing the Assistant input. RND-11340.
+            ignoreEventWhen: (e) => e.key.toLowerCase() !== 'i',
         }
     );
 

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -69,6 +69,10 @@ export function SearchContainer({
         },
         {
             enableOnFormTags: true,
+            // Match the logical character typed, not the physical key position, so
+            // non-QWERTY layouts don't trigger the shortcut by position (e.g. on
+            // Dvorak the physical "K"/"I" keys produce other characters). RND-11340.
+            ignoreEventWhen: (e) => e.key.toLowerCase() !== 'k',
         }
     );
 
@@ -84,6 +88,9 @@ export function SearchContainer({
         },
         {
             enableOnFormTags: true,
+            // Match the logical character so Dvorak ⌘-C (physical "I" key) copies
+            // instead of opening the Assistant. RND-11340.
+            ignoreEventWhen: (e) => e.key.toLowerCase() !== 'i',
         }
     );
 


### PR DESCRIPTION
## Overview

- On the Dvorak layout (and other non-QWERTY layouts), pressing ⌘-C to copy selected text opened the GitBook Assistant instead of copying.
- The Assistant (`mod+i`) and search (`mod+k`) shortcuts now match the **logical character** the user typed (`event.key`) rather than the **physical key position** (`event.code`), so they follow the active keyboard layout.

## Why this happened

`react-hotkeys-hook` fires a shortcut when *either* the logical character (`event.key`) *or* the physical key code (`event.code`) matches. On Dvorak, ⌘-C is produced by the physical "I" key, which the library maps to `i` and matched the `mod+i` Assistant shortcut — opening the panel and swallowing the copy.

The fix uses the library's own `ignoreEventWhen` option to reject events whose logical character doesn't match the shortcut. It runs *before* the handler fires or calls `preventDefault`, so the native ⌘-C copy proceeds untouched. `esc` is a named key (identical on every layout) and needs no guard.

## Verification

Tested live against the page from the report (`docs.maestro.dev`) through the dev proxy, dispatching synthetic key events:

| Input | Result |
|---|---|
| Dvorak ⌘-C (`key:'c', code:'KeyI'`) | Assistant stays closed, `defaultPrevented=false` → copy works ✓ |
| ⌘-I (`key:'i', code:'KeyI'`) | Assistant opens, `defaultPrevented=true` ✓ |
| Dvorak ⌘-I (`key:'i'`, remapped position) | Assistant opens ✓ |

Audited every `useHotkeys` call site repo-wide — the three single-character shortcuts are the complete affected set, and there is no manual `event.code` keyboard handling anywhere else.

Resolves RND-11340.

*— Authored by Claude*