### PR TITLE
Remove external link button from link tooltip hover card

### DIFF
--- a/.changeset/link-tooltip-external-button.md
+++ b/.changeset/link-tooltip-external-button.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Remove the external link button from the link tooltip hover card, as its arrow read as clickable even though the preview card isn't interactive.

--- a/packages/gitbook/src/components/DocumentView/InlineLink/InlineLink.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineLink/InlineLink.tsx
@@ -151,10 +151,7 @@ function InlineLinkTooltipWrapper(props: {
         <InlineLinkTooltip
             breadcrumbs={breadcrumbs}
             isExternal={isExternal}
-            isSamePage={isSamePage}
-            openInNewTabLabel={tString(language, 'open_in_new_tab')}
             target={{
-                href: resolved.href,
                 text: resolved.text,
                 subText: resolved.subText,
                 icon: resolved.icon,

--- a/packages/gitbook/src/components/DocumentView/InlineLink/InlineLinkTooltip.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineLink/InlineLinkTooltip.tsx
@@ -2,91 +2,69 @@
 import { tcls } from '@/lib/tailwind';
 import { Icon } from '@gitbook/icons';
 import { Fragment } from 'react';
-import { Button, HoverCard, HoverCardRoot, HoverCardTrigger, StyledLink } from '../../primitives';
+import { HoverCard, HoverCardRoot, HoverCardTrigger, StyledLink } from '../../primitives';
 
 export function InlineLinkTooltip(props: {
-    isSamePage: boolean;
     isExternal: boolean;
     breadcrumbs: Array<{ href?: string; label: string; icon?: React.ReactNode }>;
     target: {
-        href: string;
         text: string;
         subText?: string;
         icon?: React.ReactNode;
     };
-    openInNewTabLabel: string;
     children: React.ReactNode;
 }) {
-    const { isSamePage, isExternal, openInNewTabLabel, target, breadcrumbs, children } = props;
+    const { isExternal, target, breadcrumbs, children } = props;
 
     return (
         <HoverCardRoot>
             <HoverCardTrigger>{children}</HoverCardTrigger>
             <HoverCard className="p-4">
-                <div className="flex items-start gap-4">
-                    <div className="flex flex-col">
-                        {breadcrumbs && breadcrumbs.length > 0 ? (
-                            <div className="mb-1 flex grow flex-wrap items-center gap-x-2 gap-y-0.5 font-semibold text-tint text-xs uppercase leading-tight tracking-wide">
-                                {breadcrumbs.map((crumb, index) => {
-                                    const Tag = crumb.href ? StyledLink : 'div';
+                <div className="flex flex-col">
+                    {breadcrumbs && breadcrumbs.length > 0 ? (
+                        <div className="mb-1 flex grow flex-wrap items-center gap-x-2 gap-y-0.5 font-semibold text-tint text-xs uppercase leading-tight tracking-wide">
+                            {breadcrumbs.map((crumb, index) => {
+                                const Tag = crumb.href ? StyledLink : 'div';
 
-                                    return (
-                                        <Fragment key={crumb.label}>
-                                            {index !== 0 ? (
-                                                <Icon
-                                                    icon="chevron-right"
-                                                    className="size-3 text-tint-subtle"
-                                                />
+                                return (
+                                    <Fragment key={crumb.label}>
+                                        {index !== 0 ? (
+                                            <Icon
+                                                icon="chevron-right"
+                                                className="size-3 text-tint-subtle"
+                                            />
+                                        ) : null}
+                                        <Tag
+                                            className={tcls(
+                                                'flex gap-1',
+                                                crumb.href &&
+                                                    'links-default:text-tint no-underline hover:underline contrast-more:underline contrast-more:decoration-current'
+                                            )}
+                                            href={crumb.href ?? '#'}
+                                        >
+                                            {crumb.icon ? (
+                                                <span className="mt-0.5 text-tint-subtle empty:hidden">
+                                                    {crumb.icon}
+                                                </span>
                                             ) : null}
-                                            <Tag
-                                                className={tcls(
-                                                    'flex gap-1',
-                                                    crumb.href &&
-                                                        'links-default:text-tint no-underline hover:underline contrast-more:underline contrast-more:decoration-current'
-                                                )}
-                                                href={crumb.href ?? '#'}
-                                            >
-                                                {crumb.icon ? (
-                                                    <span className="mt-0.5 text-tint-subtle empty:hidden">
-                                                        {crumb.icon}
-                                                    </span>
-                                                ) : null}
-                                                {crumb.label}
-                                            </Tag>
-                                        </Fragment>
-                                    );
-                                })}
-                            </div>
-                        ) : null}
-                        <div
-                            className={tcls(
-                                'flex gap-2 leading-snug',
-                                isExternal && 'wrap-anywhere text-sm'
-                            )}
-                        >
-                            {target.icon ? (
-                                <div className="mt-1 text-tint-subtle empty:hidden">
-                                    {target.icon}
-                                </div>
-                            ) : null}
-                            <h5 className="font-semibold">{target.text}</h5>
+                                            {crumb.label}
+                                        </Tag>
+                                    </Fragment>
+                                );
+                            })}
                         </div>
-                    </div>
-                    {!isSamePage && target.href ? (
-                        <Button
-                            className={tcls(
-                                '-mx-2 -my-2 ml-auto',
-                                breadcrumbs?.length === 0 ? 'place-self-center' : null
-                            )}
-                            variant="blank"
-                            href={target.href}
-                            target="_blank"
-                            label={openInNewTabLabel}
-                            size="small"
-                            icon="arrow-up-right-from-square"
-                            iconOnly={true}
-                        />
                     ) : null}
+                    <div
+                        className={tcls(
+                            'flex gap-2 leading-snug',
+                            isExternal && 'wrap-anywhere text-sm'
+                        )}
+                    >
+                        {target.icon ? (
+                            <div className="mt-1 text-tint-subtle empty:hidden">{target.icon}</div>
+                        ) : null}
+                        <h5 className="font-semibold">{target.text}</h5>
+                    </div>
                 </div>
                 {target.subText ? <p className="mt-1 text-sm text-tint">{target.subText}</p> : null}
             </HoverCard>


### PR DESCRIPTION
## What & why

The link tooltip in published docs is a [Radix Hover Card](https://www.radix-ui.com/primitives/docs/components/hover-card) — its purpose is purely to **preview** the content behind a link for sighted users; the card itself is not hoverable or clickable.

The external-link arrow in the card's corner (`arrow-up-right-from-square`, opening in a new tab) read as a clickable affordance and was misleading, especially since same-tab links make it redundant. This removes it.

## Changes

- **`InlineLinkTooltip.tsx`** — remove the external-link `Button` and its import; drop the props it was the sole consumer of (`isSamePage`, `openInNewTabLabel`, and `target.href`); collapse the redundant `flex items-start gap-4` row (it only existed to seat the button beside the content) into the single `flex flex-col` column.
- **`InlineLink.tsx`** — stop passing the removed props. `isSamePage` is still computed and used for the breadcrumb label, so that logic is unchanged.
- Added a changeset.

## Verification

- `biome check` clean on both files.
- `tsc --noEmit` on `packages/gitbook` reports no errors in the touched files (the two pre-existing `PageActionsDropdown.tsx` errors are unrelated and present on `main`).
- No other callers of `InlineLinkTooltip`; no remaining `openInNewTabLabel` references. The `open_in_new_tab` translation key is left in place for other consumers.

Fixes RND-11324

*— Authored by Claude*