### PR TITLE
Stabilize Playwright Chrome text rendering across platforms

### DIFF
--- a/packages/gitbook/playwright.config.ts
+++ b/packages/gitbook/playwright.config.ts
@@ -18,6 +18,16 @@ export default defineConfig({
             use: {
                 ...devices['Desktop Chrome'],
                 channel: 'chrome',
+                launchOptions: {
+                    args: [
+                        // Disable subpixel (LCD) text so glyphs always render with
+                        // grayscale antialiasing — removes the red/blue edge fringing
+                        // that varies between macOS (local) and Linux (CI) runs.
+                        '--disable-lcd-text',
+                        // Disable font hinting so glyph rasterization is platform-independent.
+                        '--font-render-hinting=none',
+                    ],
+                },
             },
         },
     ],


### PR DESCRIPTION
Disable LCD text rendering and font hinting in Playwright Chrome configuration to ensure consistent glyph rendering across macOS and Linux environments. LCD text rendering with red/blue edge fringing varies between platforms, and font hinting differences also cause inconsistencies. These launch options ensure grayscale antialiasing and platform-independent glyph rasterization.