### PR TITLE
Fix wide content overflowing hint blocks

### DIFF
--- a/.changeset/hint-wide-content-overflow.md
+++ b/.changeset/hint-wide-content-overflow.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix wide content (such as code blocks and tables) overflowing the edges of hint blocks instead of scrolling within them.

--- a/packages/gitbook/src/components/DocumentView/Hint.tsx
+++ b/packages/gitbook/src/components/DocumentView/Hint.tsx
@@ -92,6 +92,11 @@ export async function Hint({
                     'empty:p-0',
                     '-row-end-1',
                     '-col-end-1',
+                    // Allow the grid track to shrink below its content's min-content size so wide
+                    // nested blocks (e.g. code blocks, tables) scroll internally instead of
+                    // overflowing the hint. Without this, the `1fr` column keeps its default
+                    // `min-width: auto` and grows past the hint's width.
+                    'min-w-0',
                     'space-y-3',
                     '[&_.hint]:border',
                     '[&_pre]:border',


### PR DESCRIPTION
## Overview

- A code block (or other wide block) nested inside a hint could grow past the hint's edge instead of scrolling within it — reported on [Gravitee's docs](https://documentation.gravitee.io/gravitee-cloud/self-hosted/register-installations) for the *"Connecting through an HTTP proxy"* info block (RND-11337).
- Root cause: the hint lays its content out in a `grid` `1fr` track, which keeps its default `min-width: auto` and so refuses to shrink below the nested block's min-content width. The code block's `<code>` element is `table` + `w-fit` + `min-w-full`, sizing itself to its longest line, which pushed the track ~25px past the hint's right edge.
- Fix: add `min-w-0` to the hint's content cell so the track can shrink, letting wide nested content scroll inside its own `overflow-auto` container instead of overflowing.
- Verified at 1440px and 375px: content cell overflow 40px → 0, code block overflow +25px → contained, and the code block now scrolls horizontally on its own. No page-level horizontal scroll on mobile.

## Demo

_Before_

<img width="1538" height="810" alt="CleanShot 2026-06-17 at 13 18 23@2x" src="https://github.com/user-attachments/assets/c386ac13-fe2d-4853-a509-7853b38d9df3" />

_Fixed: the `gravitee.yaml` code sample is contained within the info block with its own horizontal scrollbar for the long lines._

<img width="1536" height="858" alt="image-1781695093513" src="https://github.com/user-attachments/assets/e7894e60-1be4-4996-94d0-90722ba5289e" />


*— Authored by Claude*