### PR TITLE
Add search and filters to table blocks

### DIFF
--- a/.changeset/table-block-search.md
+++ b/.changeset/table-block-search.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add a client-side search field to table blocks, with per-column filters for select and checkbox columns

--- a/packages/gitbook/src/components/DocumentView/DocumentView.tsx
+++ b/packages/gitbook/src/components/DocumentView/DocumentView.tsx
@@ -36,6 +36,11 @@ export interface DocumentContext {
      * @default false
      */
     withLinkPreviews?: boolean;
+
+    /**
+     * Optional table row search query.
+     */
+    tableSearchQuery?: string;
 }
 
 export interface DocumentContextProps {

--- a/packages/gitbook/src/components/DocumentView/DocumentView.tsx
+++ b/packages/gitbook/src/components/DocumentView/DocumentView.tsx
@@ -36,11 +36,6 @@ export interface DocumentContext {
      * @default false
      */
     withLinkPreviews?: boolean;
-
-    /**
-     * Optional table row search query.
-     */
-    tableSearchQuery?: string;
 }
 
 export interface DocumentContextProps {

--- a/packages/gitbook/src/components/DocumentView/Table/RecordRow.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordRow.tsx
@@ -4,6 +4,7 @@ import { tcls } from '@/lib/tailwind';
 
 import { RecordColumnValue } from './RecordColumnValue';
 import type { TableRecordKV, TableViewProps } from './Table';
+import { TableSearchRecord } from './TableSearch';
 import { getColumnWidth } from './layout';
 import { getColumnVerticalAlignment } from './utils';
 
@@ -14,19 +15,21 @@ export function RecordRow(
         fixedColumns: string[];
     }
 ) {
-    const { view, autoSizedColumns, fixedColumns, block, context } = props;
+    const { view, record, autoSizedColumns, fixedColumns, block, context } = props;
     const stickyFirstColumn = context.mode !== 'print' && view.stickyFirstColumn === true;
     const firstVisibleColumn = view.columns[0];
 
     return (
-        <div
+        <TableSearchRecord
+            role="row"
+            recordId={record[0]}
+            visibleClassName="flex"
             className={tcls(
-                'group/row flex',
+                'group/row',
                 'border-tint-subtle',
                 'transition-colors',
                 'hover:bg-tint-hover'
             )}
-            role="row"
         >
             {view.columns.map((column) => {
                 const columnWidth = getColumnWidth({
@@ -63,6 +66,6 @@ export function RecordRow(
                     </div>
                 );
             })}
-        </div>
+        </TableSearchRecord>
     );
 }

--- a/packages/gitbook/src/components/DocumentView/Table/Table.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/Table.tsx
@@ -1,4 +1,4 @@
-import type { DocumentBlockTable, DocumentTableRecord } from '@gitbook/api';
+import type { DocumentBlockTable } from '@gitbook/api';
 import assertNever from 'assert-never';
 
 import { tcls } from '@/lib/tailwind';
@@ -9,8 +9,9 @@ import { StickyViewGrid } from './StickyViewGrid';
 import { ViewCards } from './ViewCards';
 import { ViewGrid, ViewGridHeader } from './ViewGrid';
 import { getViewGridLayout, hasVisibleHeader } from './layout';
+import { type TableRecordKV, filterTableRecordsBySearchTerm } from './search';
 
-export type TableRecordKV = [string, DocumentTableRecord];
+export type { TableRecordKV };
 
 export interface TableViewProps<View> extends BlockProps<DocumentBlockTable> {
     view: View;
@@ -22,9 +23,15 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
     const { block, ancestorBlocks, document, context, style } = props;
     const isOffscreen = isBlockOffscreen({ block, ancestorBlocks, document });
 
-    const records: TableRecordKV[] = Object.entries(block.data.records).sort((a, b) => {
-        return a[1].orderIndex.localeCompare(b[1].orderIndex);
-    });
+    const records: TableRecordKV[] = Object.entries(block.data.records).sort((a, b) =>
+        a[1].orderIndex.localeCompare(b[1].orderIndex)
+    );
+
+    const filteredRecords = filterTableRecordsBySearchTerm(
+        block,
+        records,
+        context.tableSearchQuery
+    );
 
     switch (block.data.view.type) {
         case 'cards':
@@ -32,7 +39,7 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
                 <ViewCards
                     view={block.data.view}
                     isOffscreen={isOffscreen}
-                    records={records}
+                    records={filteredRecords}
                     {...props}
                 />
             );
@@ -41,7 +48,7 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
                 ...props,
                 view: block.data.view,
                 isOffscreen,
-                records,
+                records: filteredRecords,
             };
             const { tableWidth } = getViewGridLayout({
                 block,

--- a/packages/gitbook/src/components/DocumentView/Table/Table.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/Table.tsx
@@ -22,7 +22,7 @@ export type { TableRecordKV };
 /**
  * Only show the table search once there are enough records that searching is useful.
  */
-const MIN_RECORDS_FOR_SEARCH = 4;
+const MIN_RECORDS_FOR_SEARCH = 7;
 
 export interface TableViewProps<View> extends BlockProps<DocumentBlockTable> {
     view: View;

--- a/packages/gitbook/src/components/DocumentView/Table/Table.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/Table.tsx
@@ -6,12 +6,23 @@ import { tcls } from '@/lib/tailwind';
 import type { BlockProps } from '../Block';
 import { isBlockOffscreen } from '../utils';
 import { StickyViewGrid } from './StickyViewGrid';
+import { TableSearchEmpty, TableSearchInput, TableSearchProvider } from './TableSearch';
 import { ViewCards } from './ViewCards';
 import { ViewGrid, ViewGridHeader } from './ViewGrid';
 import { getViewGridLayout, hasVisibleHeader } from './layout';
-import { type TableRecordKV, filterTableRecordsBySearchTerm } from './search';
+import {
+    type TableRecordKV,
+    getTableCheckboxColumns,
+    getTableRecordSearchData,
+    getTableSelectColumns,
+} from './search';
 
 export type { TableRecordKV };
+
+/**
+ * Only show the table search once there are enough records that searching is useful.
+ */
+const MIN_RECORDS_FOR_SEARCH = 4;
 
 export interface TableViewProps<View> extends BlockProps<DocumentBlockTable> {
     view: View;
@@ -27,11 +38,36 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
         a[1].orderIndex.localeCompare(b[1].orderIndex)
     );
 
-    const filteredRecords = filterTableRecordsBySearchTerm(
-        block,
-        records,
-        context.tableSearchQuery
+    const showSearch = context.mode !== 'print' && records.length >= MIN_RECORDS_FOR_SEARCH;
+    const searchRecords = showSearch
+        ? records.map(([id, record]) => ({ id, ...getTableRecordSearchData(block, record) }))
+        : [];
+
+    return (
+        <TableSearchProvider records={searchRecords}>
+            <div className={tcls(style, 'flex flex-col gap-3')}>
+                {showSearch ? (
+                    <TableSearchInput
+                        selectColumns={getTableSelectColumns(block)}
+                        checkboxColumns={getTableCheckboxColumns(block)}
+                    />
+                ) : null}
+                <TableView {...props} isOffscreen={isOffscreen} records={records} />
+                <TableSearchEmpty />
+            </div>
+        </TableSearchProvider>
     );
+}
+
+/**
+ * Renders the table itself (grid or cards view) for the given records.
+ */
+function TableView({
+    isOffscreen,
+    records,
+    ...props
+}: BlockProps<DocumentBlockTable> & { isOffscreen: boolean; records: TableRecordKV[] }) {
+    const { block, context, style } = props;
 
     switch (block.data.view.type) {
         case 'cards':
@@ -39,7 +75,7 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
                 <ViewCards
                     view={block.data.view}
                     isOffscreen={isOffscreen}
-                    records={filteredRecords}
+                    records={records}
                     {...props}
                 />
             );
@@ -48,7 +84,7 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
                 ...props,
                 view: block.data.view,
                 isOffscreen,
-                records: filteredRecords,
+                records,
             };
             const { tableWidth } = getViewGridLayout({
                 block,

--- a/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { Button, Checkbox, DropdownMenu, DropdownMenuItem, Input } from '@/components/primitives';
+import { tString, useLanguage } from '@/intl/client';
+import { type ClassValue, tcls } from '@/lib/tailwind';
+import { Icon } from '@gitbook/icons';
+import React from 'react';
+import type { TableCheckboxColumn, TableSelectColumn } from './search';
+import { type SelectedOptions, recordMatches } from './searchMatch';
+
+/**
+ * Client-side table search.
+ *
+ * Site pages are statically rendered and can't read `searchParams`, so filtering happens entirely
+ * on the client rather than round-tripping through the server. The provider matches every record
+ * once and exposes the set of visible ids; each row/card just looks itself up by id.
+ */
+
+/** Per-record matching data, computed on the server. */
+export interface TableSearchRecordData {
+    /** Record key, matching the `key` passed to `<TableSearchRecord>`. */
+    id: string;
+    searchText: string;
+    selectValues?: Record<string, string[]>;
+    checkboxValues?: Record<string, boolean>;
+}
+
+type TableSearchContextValue = {
+    query: string;
+    setQuery: (query: string) => void;
+    selectedOptions: SelectedOptions;
+    toggleOption: (column: string, value: string) => void;
+    /** Checkbox columns whose filter is currently enabled. */
+    checkedColumns: ReadonlySet<string>;
+    toggleCheckbox: (column: string) => void;
+    /**
+     * Ids of the records matching the active filters, or `null` when no filter is active
+     * (in which case every record is shown).
+     */
+    visibleIds: ReadonlySet<string> | null;
+    /** True when there are records but the active filters match none of them. */
+    isEmpty: boolean;
+};
+
+const TableSearchContext = React.createContext<TableSearchContextValue | null>(null);
+
+/**
+ * Holds the search query and active filters for a single table.
+ */
+export function TableSearchProvider(props: {
+    records?: TableSearchRecordData[];
+    children: React.ReactNode;
+}) {
+    const { records = [] } = props;
+    const [query, setQuery] = React.useState('');
+    const [selectedOptions, setSelectedOptions] = React.useState<SelectedOptions>(() => ({}));
+    const [checkedColumns, setCheckedColumns] = React.useState<ReadonlySet<string>>(
+        () => new Set()
+    );
+
+    const toggleOption = React.useCallback((column: string, value: string) => {
+        setSelectedOptions((previous) => {
+            const values = new Set(previous[column]);
+            if (values.has(value)) {
+                values.delete(value);
+            } else {
+                values.add(value);
+            }
+
+            const next = { ...previous };
+            if (values.size === 0) {
+                delete next[column];
+            } else {
+                next[column] = values;
+            }
+            return next;
+        });
+    }, []);
+
+    const toggleCheckbox = React.useCallback((column: string) => {
+        setCheckedColumns((previous) => {
+            const next = new Set(previous);
+            if (next.has(column)) {
+                next.delete(column);
+            } else {
+                next.add(column);
+            }
+            return next;
+        });
+    }, []);
+
+    const hasActiveFilters =
+        query.trim() !== '' || Object.keys(selectedOptions).length > 0 || checkedColumns.size > 0;
+
+    // Match every record once, here, rather than in each row — rows just look themselves up by id.
+    const visibleIds = React.useMemo(() => {
+        if (!hasActiveFilters) {
+            return null;
+        }
+
+        const ids = new Set<string>();
+        for (const record of records) {
+            if (
+                recordMatches(
+                    record.searchText,
+                    record.selectValues,
+                    record.checkboxValues,
+                    query,
+                    selectedOptions,
+                    checkedColumns
+                )
+            ) {
+                ids.add(record.id);
+            }
+        }
+        return ids;
+    }, [records, query, selectedOptions, checkedColumns, hasActiveFilters]);
+
+    const isEmpty = visibleIds !== null && records.length > 0 && visibleIds.size === 0;
+
+    const value = React.useMemo(
+        () => ({
+            query,
+            setQuery,
+            selectedOptions,
+            toggleOption,
+            checkedColumns,
+            toggleCheckbox,
+            visibleIds,
+            isEmpty,
+        }),
+        [query, selectedOptions, toggleOption, checkedColumns, toggleCheckbox, visibleIds, isEmpty]
+    );
+
+    return (
+        <TableSearchContext.Provider value={value}>{props.children}</TableSearchContext.Provider>
+    );
+}
+
+function useTableSearch(): TableSearchContextValue {
+    const context = React.useContext(TableSearchContext);
+    if (!context) {
+        throw new Error('useTableSearch must be used within a <TableSearchProvider>');
+    }
+    return context;
+}
+
+/**
+ * The search form rendered above a table, with a multi-select filter dropdown per select column.
+ */
+export function TableSearchInput(props: {
+    selectColumns?: TableSelectColumn[];
+    checkboxColumns?: TableCheckboxColumn[];
+    className?: ClassValue;
+}) {
+    const { selectColumns = [], checkboxColumns = [] } = props;
+    const language = useLanguage();
+    const { query, setQuery } = useTableSearch();
+    const hasFilters = selectColumns.length > 0 || checkboxColumns.length > 0;
+
+    return (
+        <Input
+            label={tString(language, 'search')}
+            value={query}
+            onValueChange={setQuery}
+            leading="magnifying-glass"
+            clearButton
+            sizing="small"
+            keyboardShortcut={false}
+            className={tcls('w-full', props.className)}
+            trailing={
+                hasFilters ? (
+                    // Stop clicks from bubbling to the input container, which would refocus the input.
+                    <div
+                        className="flex items-center gap-1"
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        {selectColumns.map((column) => (
+                            <SelectFilterDropdown key={column.id} column={column} />
+                        ))}
+                        {checkboxColumns.map((column) => (
+                            <CheckboxFilter key={column.id} column={column} />
+                        ))}
+                    </div>
+                ) : undefined
+            }
+        />
+    );
+}
+
+/**
+ * Shown below the table when the active filters match no records.
+ */
+export function TableSearchEmpty(props: { className?: ClassValue }) {
+    const language = useLanguage();
+    const { query, isEmpty } = useTableSearch();
+
+    if (!isEmpty) {
+        return null;
+    }
+
+    const trimmed = query.trim();
+    return (
+        <div className={tcls('mx-auto text-center text-sm text-tint', props.className)}>
+            {trimmed
+                ? tString(language, 'search_no_results_for', trimmed)
+                : tString(language, 'search_no_results')}
+        </div>
+    );
+}
+
+/**
+ * A blank multi-select dropdown button for a single select column. Becomes `active` while any
+ * of its options are selected.
+ */
+function SelectFilterDropdown(props: { column: TableSelectColumn }) {
+    const { column } = props;
+    const language = useLanguage();
+    const { selectedOptions, toggleOption } = useTableSearch();
+    const selectedValues = selectedOptions[column.id];
+    const activeCount = selectedValues?.size ?? 0;
+    // Fall back to a generic "Filter" label when the column title is hidden/empty.
+    const label = column.label.trim() || tString(language, 'search_scope_title');
+
+    return (
+        <DropdownMenu
+            align="end"
+            button={
+                <Button
+                    variant="blank"
+                    size="xsmall"
+                    active={activeCount > 0}
+                    label={activeCount > 1 ? `${label} · ${activeCount}` : label}
+                    trailing={<Icon icon="chevron-down" className="size-3" />}
+                />
+            }
+        >
+            {column.options.map((option) => {
+                const selected = selectedValues?.has(option.value) ?? false;
+                return (
+                    <DropdownMenuItem
+                        key={option.value}
+                        active={selected}
+                        leadingIcon={selected ? 'check' : undefined}
+                        onSelect={(event) => {
+                            // Keep the menu open so several options can be toggled at once.
+                            event.preventDefault();
+                            toggleOption(column.id, option.value);
+                        }}
+                    >
+                        {option.label || option.value}
+                    </DropdownMenuItem>
+                );
+            })}
+        </DropdownMenu>
+    );
+}
+
+/**
+ * A checkbox control filtering the table to records where the given checkbox column is checked.
+ */
+function CheckboxFilter(props: { column: TableCheckboxColumn }) {
+    const { column } = props;
+    const language = useLanguage();
+    const { checkedColumns, toggleCheckbox } = useTableSearch();
+    const checked = checkedColumns.has(column.id);
+    const id = `table-search-checkbox-${column.id}`;
+    // Fall back to a generic "Filter" label when the column title is hidden/empty.
+    const label = column.label.trim() || tString(language, 'search_scope_title');
+
+    return (
+        <label
+            htmlFor={id}
+            className="flex cursor-pointer select-none items-center gap-1.5 px-2 text-sm text-tint"
+        >
+            <Checkbox
+                id={id}
+                size="small"
+                checked={checked}
+                onCheckedChange={() => toggleCheckbox(column.id)}
+            />
+            {label}
+        </label>
+    );
+}
+
+type TableSearchRecordProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'className'> & {
+    /** Record id, matching the `id` of the data passed to `<TableSearchProvider>`. */
+    recordId: string;
+    /** Display utility applied when the record matches (e.g. `flex` for rows, `contents` for cards). */
+    visibleClassName: string;
+    className?: ClassValue;
+    children: React.ReactNode;
+};
+
+/**
+ * Wraps a single table record (a grid row or a card) and hides it when it doesn't match
+ * the current filters. Matching happens once in the provider; here we just look up the id.
+ */
+export function TableSearchRecord(props: TableSearchRecordProps) {
+    const { recordId, visibleClassName, className, children, ...rest } = props;
+    const { visibleIds } = useTableSearch();
+    const matches = visibleIds === null || visibleIds.has(recordId);
+
+    return (
+        <div className={tcls(matches ? visibleClassName : 'hidden', className)} {...rest}>
+            {children}
+        </div>
+    );
+}

--- a/packages/gitbook/src/components/DocumentView/Table/ViewCards.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/ViewCards.tsx
@@ -4,6 +4,7 @@ import { tcls } from '@/lib/tailwind';
 
 import { RecordCard } from './RecordCard';
 import type { TableViewProps } from './Table';
+import { TableSearchRecord } from './TableSearch';
 
 export function ViewCards(props: TableViewProps<DocumentTableViewCards>) {
     const { block, view, records, style } = props;
@@ -21,7 +22,15 @@ export function ViewCards(props: TableViewProps<DocumentTableViewCards>) {
             )}
         >
             {records.map((record) => {
-                return <RecordCard key={record[0]} {...props} record={record} />;
+                return (
+                    <TableSearchRecord
+                        key={record[0]}
+                        recordId={record[0]}
+                        visibleClassName="contents"
+                    >
+                        <RecordCard {...props} record={record} />
+                    </TableSearchRecord>
+                );
             })}
         </div>
     );

--- a/packages/gitbook/src/components/DocumentView/Table/search.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/search.ts
@@ -1,25 +1,92 @@
-import type { DocumentBlockTable, DocumentTableRecord } from '@gitbook/api';
+import type {
+    DocumentBlockTable,
+    DocumentTableRecord,
+    DocumentTableSelectOption,
+} from '@gitbook/api';
 
 import { getNodeFragmentByName, getNodeText } from '@/lib/document';
 
 export type TableRecordKV = [string, DocumentTableRecord];
 
-export function filterTableRecordsBySearchTerm(
-    block: DocumentBlockTable,
-    records: TableRecordKV[],
-    searchTerm: string | undefined
-): TableRecordKV[] {
-    const trimmedSearchTerm = searchTerm?.trim();
-    if (!trimmedSearchTerm) {
-        return records;
+export interface TableSelectColumn {
+    /** Column id (the column key in `block.data.definition`). */
+    id: string;
+    /** Column title, shown on the filter button. */
+    label: string;
+    /** Available options for the column. */
+    options: DocumentTableSelectOption[];
+}
+
+/**
+ * List the visible "select" columns of a table along with their options.
+ * Used to render the per-column filter dropdowns next to the search input.
+ */
+export function getTableSelectColumns(block: DocumentBlockTable): TableSelectColumn[] {
+    return block.data.view.columns.flatMap((column) => {
+        const definition = block.data.definition[column];
+        if (definition?.type !== 'select') {
+            return [];
+        }
+
+        return [{ id: column, label: definition.title, options: definition.options }];
+    });
+}
+
+export interface TableCheckboxColumn {
+    /** Column id. */
+    id: string;
+    /** Column title, shown next to the checkbox. */
+    label: string;
+}
+
+/**
+ * List the visible "checkbox" columns of a table.
+ * Used to render a filter checkbox per column next to the search input.
+ */
+export function getTableCheckboxColumns(block: DocumentBlockTable): TableCheckboxColumn[] {
+    return block.data.view.columns.flatMap((column) => {
+        const definition = block.data.definition[column];
+        if (definition?.type !== 'checkbox') {
+            return [];
+        }
+
+        return [{ id: column, label: definition.title }];
+    });
+}
+
+/**
+ * Build the search data for a record (searchable text + select/checkbox values) in a single
+ * pass over its columns. Used to feed the client-side table search (see `TableSearch`).
+ */
+export function getTableRecordSearchData(block: DocumentBlockTable, record: DocumentTableRecord) {
+    const searchText: string[] = [];
+    const selectValues: Record<string, string[]> = {};
+    const checkboxValues: Record<string, boolean> = {};
+
+    for (const column of block.data.view.columns) {
+        const text = getTableCellSearchText(block, record, column);
+        if (text) {
+            searchText.push(text);
+        }
+
+        const value = record.values[column];
+        switch (block.data.definition[column]?.type) {
+            case 'select':
+                if (Array.isArray(value)) {
+                    selectValues[column] = value.filter(
+                        (item): item is string => typeof item === 'string'
+                    );
+                }
+                break;
+            case 'checkbox':
+                if (typeof value === 'boolean') {
+                    checkboxValues[column] = value;
+                }
+                break;
+        }
     }
 
-    return records.filter(([, record]) =>
-        block.data.view.columns.some((column) => {
-            const text = getTableCellSearchText(block, record, column);
-            return new RegExp(trimmedSearchTerm, 'iu').test(text);
-        })
-    );
+    return { searchText: searchText.join(' '), selectValues, checkboxValues };
 }
 
 function getTableCellSearchText(

--- a/packages/gitbook/src/components/DocumentView/Table/search.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/search.ts
@@ -133,10 +133,9 @@ function getTableCellSearchText(
         case 'checkbox': {
             return typeof value === 'boolean' ? `${value}` : '';
         }
-        case 'files':
-        case 'users': {
-            return Array.isArray(value) ? normalizeSearchText(value.join(' ')) : '';
-        }
+        // Reference-like columns (files, users, content-ref, image) render resolved names/text
+        // asynchronously in `RecordColumnValue`. We only have raw ids here, so indexing them would
+        // never match the visible text — leave them out rather than search opaque ids.
         default:
             return '';
     }

--- a/packages/gitbook/src/components/DocumentView/Table/search.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/search.ts
@@ -1,0 +1,80 @@
+import type { DocumentBlockTable, DocumentTableRecord } from '@gitbook/api';
+
+import { getNodeFragmentByName, getNodeText } from '@/lib/document';
+
+export type TableRecordKV = [string, DocumentTableRecord];
+
+export function filterTableRecordsBySearchTerm(
+    block: DocumentBlockTable,
+    records: TableRecordKV[],
+    searchTerm: string | undefined
+): TableRecordKV[] {
+    const trimmedSearchTerm = searchTerm?.trim();
+    if (!trimmedSearchTerm) {
+        return records;
+    }
+
+    return records.filter(([, record]) =>
+        block.data.view.columns.some((column) => {
+            const text = getTableCellSearchText(block, record, column);
+            return new RegExp(trimmedSearchTerm, 'iu').test(text);
+        })
+    );
+}
+
+function getTableCellSearchText(
+    block: DocumentBlockTable,
+    record: DocumentTableRecord,
+    column: string
+): string {
+    const definition = block.data.definition[column];
+    const value = record.values[column];
+
+    if (!definition || value === null || value === undefined) {
+        return '';
+    }
+
+    switch (definition.type) {
+        case 'text': {
+            if (typeof value !== 'string') {
+                return '';
+            }
+
+            const fragment = getNodeFragmentByName(block, value);
+            return normalizeSearchText(fragment ? getNodeText(fragment) : '');
+        }
+        case 'select': {
+            if (!Array.isArray(value)) {
+                return '';
+            }
+
+            return normalizeSearchText(
+                value
+                    .map((selectId) => {
+                        return (
+                            definition.options.find((option) => option.value === selectId)?.label ??
+                            selectId
+                        );
+                    })
+                    .join(' ')
+            );
+        }
+        case 'number':
+        case 'rating': {
+            return typeof value === 'number' ? `${value}` : '';
+        }
+        case 'checkbox': {
+            return typeof value === 'boolean' ? `${value}` : '';
+        }
+        case 'files':
+        case 'users': {
+            return Array.isArray(value) ? normalizeSearchText(value.join(' ')) : '';
+        }
+        default:
+            return '';
+    }
+}
+
+function normalizeSearchText(text: string): string {
+    return text.replace(/\s+/g, ' ').trim();
+}

--- a/packages/gitbook/src/components/DocumentView/Table/searchMatch.test.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/searchMatch.test.ts
@@ -38,9 +38,10 @@ describe('matchesText', () => {
         expect(matchesText('Hello World', 'nope')).toBe(false);
     });
 
-    it('falls back to a substring match for invalid regex patterns', () => {
-        expect(matchesText('a (b) c', '(')).toBe(true);
-        expect(matchesText('abc', '(')).toBe(false);
+    it('matches regex metacharacters literally', () => {
+        expect(matchesText('value a+b here', 'a+b')).toBe(true);
+        expect(matchesText('v1x2', 'v1.2')).toBe(false);
+        expect(matchesText('a (b) c', '(b)')).toBe(true);
     });
 });
 

--- a/packages/gitbook/src/components/DocumentView/Table/searchMatch.test.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/searchMatch.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'bun:test';
+
+import { type SelectedOptions, matchesText, recordMatches } from './searchMatch';
+
+const NO_OPTIONS: SelectedOptions = {};
+const NO_CHECKBOXES: ReadonlySet<string> = new Set();
+
+function match(
+    record: {
+        searchText?: string;
+        selectValues?: Record<string, string[]>;
+        checkboxValues?: Record<string, boolean>;
+    },
+    filters: {
+        query?: string;
+        selectedOptions?: SelectedOptions;
+        checkedColumns?: ReadonlySet<string>;
+    }
+): boolean {
+    return recordMatches(
+        record.searchText ?? '',
+        record.selectValues,
+        record.checkboxValues,
+        filters.query ?? '',
+        filters.selectedOptions ?? NO_OPTIONS,
+        filters.checkedColumns ?? NO_CHECKBOXES
+    );
+}
+
+describe('matchesText', () => {
+    it('matches everything when the query is empty', () => {
+        expect(matchesText('anything', '')).toBe(true);
+        expect(matchesText('', '   ')).toBe(true);
+    });
+
+    it('matches case-insensitively', () => {
+        expect(matchesText('Hello World', 'hello')).toBe(true);
+        expect(matchesText('Hello World', 'nope')).toBe(false);
+    });
+
+    it('falls back to a substring match for invalid regex patterns', () => {
+        expect(matchesText('a (b) c', '(')).toBe(true);
+        expect(matchesText('abc', '(')).toBe(false);
+    });
+});
+
+describe('recordMatches', () => {
+    it('shows every record when no filter is active', () => {
+        expect(match({ searchText: 'whatever' }, {})).toBe(true);
+    });
+
+    it('applies the text filter', () => {
+        expect(match({ searchText: 'Ace AI' }, { query: 'ace' })).toBe(true);
+        expect(match({ searchText: 'Ace AI' }, { query: 'discrete' })).toBe(false);
+    });
+
+    describe('select columns', () => {
+        const selectedStatus: SelectedOptions = { status: new Set(['active', 'pending']) };
+
+        it('ORs multiple values within a single column', () => {
+            expect(
+                match(
+                    { selectValues: { status: ['pending'] } },
+                    { selectedOptions: selectedStatus }
+                )
+            ).toBe(true);
+            expect(
+                match(
+                    { selectValues: { status: ['archived'] } },
+                    { selectedOptions: selectedStatus }
+                )
+            ).toBe(false);
+        });
+
+        it('ANDs across different columns', () => {
+            const filters: SelectedOptions = {
+                status: new Set(['active']),
+                tier: new Set(['gold']),
+            };
+            expect(
+                match(
+                    { selectValues: { status: ['active'], tier: ['gold'] } },
+                    { selectedOptions: filters }
+                )
+            ).toBe(true);
+            // Matches one column but not the other → excluded.
+            expect(
+                match(
+                    { selectValues: { status: ['active'], tier: ['silver'] } },
+                    { selectedOptions: filters }
+                )
+            ).toBe(false);
+        });
+
+        it('excludes records missing the column entirely', () => {
+            expect(match({ selectValues: {} }, { selectedOptions: selectedStatus })).toBe(false);
+        });
+    });
+
+    describe('checkbox columns', () => {
+        const featured: ReadonlySet<string> = new Set(['featured']);
+
+        it('keeps only records checked for the enabled column', () => {
+            expect(
+                match({ checkboxValues: { featured: true } }, { checkedColumns: featured })
+            ).toBe(true);
+            expect(
+                match({ checkboxValues: { featured: false } }, { checkedColumns: featured })
+            ).toBe(false);
+            expect(match({ checkboxValues: {} }, { checkedColumns: featured })).toBe(false);
+        });
+
+        it('ANDs multiple enabled checkbox columns', () => {
+            const both: ReadonlySet<string> = new Set(['featured', 'inStock']);
+            expect(
+                match(
+                    { checkboxValues: { featured: true, inStock: true } },
+                    { checkedColumns: both }
+                )
+            ).toBe(true);
+            expect(
+                match(
+                    { checkboxValues: { featured: true, inStock: false } },
+                    { checkedColumns: both }
+                )
+            ).toBe(false);
+        });
+    });
+
+    it('ANDs the text, select and checkbox filters together', () => {
+        const record = {
+            searchText: 'Ace AI',
+            selectValues: { status: ['active'] },
+            checkboxValues: { featured: true },
+        };
+        const filters = {
+            query: 'ace',
+            selectedOptions: { status: new Set(['active']) } satisfies SelectedOptions,
+            checkedColumns: new Set(['featured']),
+        };
+
+        expect(match(record, filters)).toBe(true);
+        // Each individual filter failing flips the result to false.
+        expect(match(record, { ...filters, query: 'discrete' })).toBe(false);
+        expect(
+            match(record, { ...filters, selectedOptions: { status: new Set(['archived']) } })
+        ).toBe(false);
+        expect(match({ ...record, checkboxValues: { featured: false } }, filters)).toBe(false);
+    });
+});

--- a/packages/gitbook/src/components/DocumentView/Table/searchMatch.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/searchMatch.ts
@@ -50,10 +50,10 @@ export function recordMatches(
 }
 
 /**
- * Whether a record's searchable text matches the query.
+ * Whether a record's searchable text contains the query.
  *
- * Treats the query as a case-insensitive regex, but falls back to a plain substring match for
- * incomplete patterns the user might type while searching live (e.g. a lone `(`).
+ * Plain case-insensitive substring match: the field is a free-text search, so regex
+ * metacharacters (`.`, `+`, `(`, …) are matched literally rather than treated as patterns.
  */
 export function matchesText(searchText: string, query: string): boolean {
     const trimmed = query.trim();
@@ -61,9 +61,5 @@ export function matchesText(searchText: string, query: string): boolean {
         return true;
     }
 
-    try {
-        return new RegExp(trimmed, 'iu').test(searchText);
-    } catch {
-        return searchText.toLowerCase().includes(trimmed.toLowerCase());
-    }
+    return searchText.toLowerCase().includes(trimmed.toLowerCase());
 }

--- a/packages/gitbook/src/components/DocumentView/Table/searchMatch.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/searchMatch.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure matching logic for the client-side table search.
+ *
+ * Kept free of React/client dependencies so it can be unit-tested in isolation and shared
+ * between the search UI and (potentially) other callers.
+ */
+
+/** Selected option values per select column, keyed by column id. */
+export type SelectedOptions = Readonly<Record<string, ReadonlySet<string>>>;
+
+/**
+ * Whether a record passes the current filters.
+ *
+ * The text query, each select column and each enabled checkbox column are combined with AND:
+ * a record must match the text (when present), satisfy every column that has a selection, and
+ * be checked for every enabled checkbox column. Within a single select column the selected
+ * values are combined with OR — the record matches the column if it has any of them.
+ */
+export function recordMatches(
+    searchText: string,
+    selectValues: Record<string, string[]> | undefined,
+    checkboxValues: Record<string, boolean> | undefined,
+    query: string,
+    selectedOptions: SelectedOptions,
+    checkedColumns: ReadonlySet<string>
+): boolean {
+    if (query.trim() !== '' && !matchesText(searchText, query)) {
+        return false;
+    }
+
+    for (const [column, values] of Object.entries(selectedOptions)) {
+        if (values.size === 0) {
+            continue;
+        }
+
+        const recordValues = selectValues?.[column];
+        const matchesColumn = !!recordValues && recordValues.some((value) => values.has(value));
+        if (!matchesColumn) {
+            return false;
+        }
+    }
+
+    for (const column of checkedColumns) {
+        if (checkboxValues?.[column] !== true) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Whether a record's searchable text matches the query.
+ *
+ * Treats the query as a case-insensitive regex, but falls back to a plain substring match for
+ * incomplete patterns the user might type while searching live (e.g. a lone `(`).
+ */
+export function matchesText(searchText: string, query: string): boolean {
+    const trimmed = query.trim();
+    if (!trimmed) {
+        return true;
+    }
+
+    try {
+        return new RegExp(trimmed, 'iu').test(searchText);
+    } catch {
+        return searchText.toLowerCase().includes(trimmed.toLowerCase());
+    }
+}


### PR DESCRIPTION
## Overview

Adds an interactive search field above table blocks so readers can quickly find rows in larger tables.

- Renders a search field above a table (both **grid** and **cards** views) once it has at least 7 rows; hidden in print/PDF.
- **Free-text search** matches across every column.
- Each **select** column gets a multi-select filter dropdown (the button highlights as `active` while a value is selected).
- Each **checkbox** column gets a filter toggle.
- The text query and each column filter combine with **AND**; multiple values within one select column combine with **OR**. A **"No results"** message shows when nothing matches.
- Filtering runs entirely on the client (site pages are statically rendered, so we can't round-trip through the server without making them dynamic) — mirroring the existing `UpdatesFilter` pattern. The previously-added, unused server-side `tableSearchQuery` hook is removed.
- The pure matching logic is extracted to `searchMatch.ts` and covered by unit tests.

## Demo

Two examples of string matching + filter options

https://github.com/user-attachments/assets/51b1b710-c03d-4ead-a223-c5f0f2b27793

https://github.com/user-attachments/assets/5b41cc66-5b39-4bb7-b903-d8de7b4cd2f5

*— Authored by Claude*
