### PR TITLE
Fix NextLink prefetch side effect on unsigned claims persistance

### DIFF
--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -180,13 +180,10 @@ export function Link(props: LinkProps) {
     );
 }
 
-const ASK_QUERY_PARAM = 'ask';
-const VISITOR_PARAM_PREFIX = 'visitor.';
-
 /**
  * Whether the given href carries query params that have a server-side side effect when fetched:
  *   - `visitor.*` params persist unsigned visitor claims into the `gitbook-visitor-public` cookie.
- *   - `ask` triggers the assistant.
+ *   - `ask` triggers the assistant & `q` the search.
  *
  * NextLink automatically prefetches links (RSC requests) on hover/viewport, which would fire those
  * side effects without any user intent, so such links should not be prefetched.
@@ -195,12 +192,12 @@ function hasSideEffectQueryParams(href: string): boolean {
     const baseURL = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
     const linkURL = URL.canParse(href) ? new URL(href) : new URL(href, baseURL);
 
-    if (linkURL.searchParams.get(ASK_QUERY_PARAM)) {
+    if (linkURL.searchParams.get('ask') !== null || linkURL.searchParams.get('q') !== null) {
         return true;
     }
 
     for (const key of linkURL.searchParams.keys()) {
-        if (key.startsWith(VISITOR_PARAM_PREFIX)) {
+        if (key.startsWith('visitor.')) {
             return true;
         }
     }

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -157,9 +157,14 @@ export function Link(props: LinkProps) {
         );
     }
 
-    // Not sure why yet, but it seems necessary to force prefetch to true
-    // default behavior doesn't seem to properly use the client router cache.
-    const _prefetch = prefetch === null || prefetch === undefined ? true : prefetch;
+    // Not sure why yet, but forcing prefetch to true seems necessary for the
+    // client router cache to be used properly.
+    //
+    // However, we need to disable prefetch for links with query params that
+    // can trigger server-side side effects, such as persisting visitor claims in a
+    // cookie or starting the assistant. Automatic RSC prefetch requests can otherwise
+    // trigger those effects without user intent.
+    const _prefetch = hasSideEffectQueryParams(href) ? false : (prefetch ?? true);
 
     return (
         <NextLink
@@ -173,6 +178,34 @@ export function Link(props: LinkProps) {
             {children}
         </NextLink>
     );
+}
+
+const ASK_QUERY_PARAM = 'ask';
+const VISITOR_PARAM_PREFIX = 'visitor.';
+
+/**
+ * Whether the given href carries query params that have a server-side side effect when fetched:
+ *   - `visitor.*` params persist unsigned visitor claims into the `gitbook-visitor-public` cookie.
+ *   - `ask` triggers the assistant.
+ *
+ * NextLink automatically prefetches links (RSC requests) on hover/viewport, which would fire those
+ * side effects without any user intent, so such links should not be prefetched.
+ */
+function hasSideEffectQueryParams(href: string): boolean {
+    const baseURL = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const linkURL = URL.canParse(href) ? new URL(href) : new URL(href, baseURL);
+
+    if (linkURL.searchParams.get(ASK_QUERY_PARAM)) {
+        return true;
+    }
+
+    for (const key of linkURL.searchParams.keys()) {
+        if (key.startsWith(VISITOR_PARAM_PREFIX)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
This PR aims to fix an issue where NextLink prefetch triggering RSC requests for links including `ask` or `visitor.*` query params has a side effect on unsigned claims cookie persistant and on the AI assistant opening/closing multiple times.