### PR TITLE
Adds the prompt block

### DIFF
--- a/.changeset/lovely-cameras-sip.md
+++ b/.changeset/lovely-cameras-sip.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add a Prompt block

--- a/bun.lock
+++ b/bun.lock
@@ -360,7 +360,7 @@
     "react-dom": "catalog:",
   },
   "catalog": {
-    "@gitbook/api": "0.184.0",
+    "@gitbook/api": "0.185.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -756,7 +756,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.184.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-yPoQqLLik6IihFcwVVbuEAIyDA7F2q80HprNRuj10m+O2XULlm4+bW5R71r5/GCjDKSf5QfmRXmYh4OopljPKw=="],
+    "@gitbook/api": ["@gitbook/api@0.185.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-RrFZSHI7W79ri5jHd/gp01ZbuxfOPOFEqnom956wNUfUf/CIQDZcCNzmvLIWzuYesI7Snq3NLi+U5XzOsJhC4g=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
         "clean": "turbo run clean"
     },
     "workspaces": {
-        "packages": ["packages/*"],
+        "packages": [
+            "packages/*"
+        ],
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
-            "@gitbook/api": "0.184.0",
+            "@gitbook/api": "0.185.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
         "clean": "turbo run clean"
     },
     "workspaces": {
-        "packages": [
-            "packages/*"
-        ],
+        "packages": ["packages/*"],
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",

--- a/packages/gitbook/src/components/DocumentView/Block.tsx
+++ b/packages/gitbook/src/components/DocumentView/Block.tsx
@@ -28,6 +28,8 @@ import { ListItem } from './ListItem';
 import { BlockMath } from './Math';
 import { OpenAPIOperation, OpenAPISchemas, OpenAPIWebhook } from './OpenAPI';
 import { Paragraph } from './Paragraph';
+import { Prompt } from './Prompt';
+import type { PromptBlock } from './Prompt/types';
 import { Quote } from './Quote';
 import { ReusableContent } from './ReusableContent';
 import { Stepper } from './Stepper';
@@ -37,7 +39,9 @@ import { Tabs } from './Tabs';
 import { Update } from './Update';
 import { Updates } from './Updates';
 
-export interface BlockProps<Block extends DocumentBlock> extends DocumentContextProps {
+type SupportedDocumentBlock = DocumentBlock | PromptBlock;
+
+export interface BlockProps<Block extends SupportedDocumentBlock> extends DocumentContextProps {
     block: Block;
     document: JSONDocument;
     ancestorBlocks: DocumentBlock[];
@@ -47,7 +51,7 @@ export interface BlockProps<Block extends DocumentBlock> extends DocumentContext
     style?: ClassValue;
 }
 
-export function Block<T extends DocumentBlock>(props: BlockProps<T>) {
+export function Block<T extends SupportedDocumentBlock>(props: BlockProps<T>) {
     const { block } = props;
 
     const content = (() => {
@@ -111,6 +115,8 @@ export function Block<T extends DocumentBlock>(props: BlockProps<T>) {
                 return <Updates {...props} block={block} />;
             case 'update':
                 return <Update {...props} block={block} />;
+            case 'prompt':
+                return <Prompt {...props} block={block} />;
             case 'if':
                 // If block should be processed by the API.
                 return null;

--- a/packages/gitbook/src/components/DocumentView/Block.tsx
+++ b/packages/gitbook/src/components/DocumentView/Block.tsx
@@ -29,7 +29,6 @@ import { BlockMath } from './Math';
 import { OpenAPIOperation, OpenAPISchemas, OpenAPIWebhook } from './OpenAPI';
 import { Paragraph } from './Paragraph';
 import { Prompt } from './Prompt';
-import type { PromptBlock } from './Prompt/types';
 import { Quote } from './Quote';
 import { ReusableContent } from './ReusableContent';
 import { Stepper } from './Stepper';
@@ -39,9 +38,7 @@ import { Tabs } from './Tabs';
 import { Update } from './Update';
 import { Updates } from './Updates';
 
-type SupportedDocumentBlock = DocumentBlock | PromptBlock;
-
-export interface BlockProps<Block extends SupportedDocumentBlock> extends DocumentContextProps {
+export interface BlockProps<Block extends DocumentBlock> extends DocumentContextProps {
     block: Block;
     document: JSONDocument;
     ancestorBlocks: DocumentBlock[];
@@ -51,7 +48,7 @@ export interface BlockProps<Block extends SupportedDocumentBlock> extends Docume
     style?: ClassValue;
 }
 
-export function Block<T extends SupportedDocumentBlock>(props: BlockProps<T>) {
+export function Block<T extends DocumentBlock>(props: BlockProps<T>) {
     const { block } = props;
 
     const content = (() => {
@@ -157,6 +154,7 @@ export function BlockSkeleton(props: { block: DocumentBlock; style: ClassValue }
         case 'hint':
         case 'tabs':
         case 'stepper-step':
+        case 'prompt':
         case 'if':
             return <SkeletonParagraph id={id} className={style} />;
         case 'expandable':

--- a/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
@@ -1,0 +1,68 @@
+import { tcls } from '@/lib/tailwind';
+import {
+    CustomizationPageActionType,
+    type DocumentBlock,
+    type SiteCustomizationSettings,
+} from '@gitbook/api';
+import { validateIconName } from '@gitbook/icons/icons';
+import type { BlockProps } from '../Block';
+import { getPlainCodeBlock } from '../CodeBlock/highlight';
+import { PromptClient } from './PromptClient';
+import type { PromptBlock } from './types';
+
+type PromptProps = Omit<BlockProps<DocumentBlock>, 'block'> & {
+    block: PromptBlock;
+};
+
+export function Prompt(props: PromptProps) {
+    const { block } = props;
+    const contentIcon =
+        block.data.icon && validateIconName(block.data.icon) ? block.data.icon : null;
+
+    return (
+        <div
+            className={tcls(
+                'relative flex w-full flex-col overflow-hidden',
+                'border border-tint-subtle bg-tint-subtle theme-bold-tint:bg-tint-base theme-muted:bg-tint-base text-tint-strong contrast-more:border-tint contrast-more:bg-tint-base',
+                'circular-corners:rounded-2xl rounded-corners:rounded-xl straight-corners:rounded-xs',
+                'depth-subtle:shadow-xs'
+            )}
+        >
+            <PromptClient
+                contentIcon={contentIcon}
+                description={block.data.description ?? ''}
+                prompt={getPromptText(block)}
+                openInAIProviders={getOpenInAIProviders(props)}
+            />
+        </div>
+    );
+}
+
+function getOpenInAIProviders(props: PromptProps): boolean {
+    const { block, context } = props;
+    const { openInAIProviders } = block.data;
+
+    if (openInAIProviders !== undefined) {
+        return openInAIProviders;
+    }
+
+    const contentContext = context.contentContext;
+    if (contentContext && 'customization' in contentContext) {
+        const { pageActions } = contentContext.customization;
+        return isExternalAIPageActionEnabled(pageActions);
+    }
+
+    return false;
+}
+
+function isExternalAIPageActionEnabled(
+    pageActions: SiteCustomizationSettings['pageActions']
+): boolean {
+    return pageActions.items
+        ? pageActions.items.includes(CustomizationPageActionType.ExternalAi)
+        : pageActions.externalAI;
+}
+
+function getPromptText(block: PromptBlock): string {
+    return (block.nodes ?? []).map((node) => getPlainCodeBlock(node)).join('\n');
+}

--- a/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
@@ -1,20 +1,15 @@
 import { tcls } from '@/lib/tailwind';
 import {
     CustomizationPageActionType,
-    type DocumentBlock,
+    type DocumentBlockPrompt,
     type SiteCustomizationSettings,
 } from '@gitbook/api';
 import { validateIconName } from '@gitbook/icons/icons';
 import type { BlockProps } from '../Block';
 import { getPlainCodeBlock } from '../CodeBlock/highlight';
 import { PromptClient } from './PromptClient';
-import type { PromptBlock } from './types';
 
-type PromptProps = Omit<BlockProps<DocumentBlock>, 'block'> & {
-    block: PromptBlock;
-};
-
-export function Prompt(props: PromptProps) {
+export function Prompt(props: BlockProps<DocumentBlockPrompt>) {
     const { block } = props;
     const contentIcon =
         block.data.icon && validateIconName(block.data.icon) ? block.data.icon : null;
@@ -38,7 +33,7 @@ export function Prompt(props: PromptProps) {
     );
 }
 
-function getOpenInAIProviders(props: PromptProps): boolean {
+function getOpenInAIProviders(props: BlockProps<DocumentBlockPrompt>): boolean {
     const { block, context } = props;
     const { openInAIProviders } = block.data;
 
@@ -63,6 +58,6 @@ function isExternalAIPageActionEnabled(
         : pageActions.externalAI;
 }
 
-function getPromptText(block: PromptBlock): string {
+function getPromptText(block: DocumentBlockPrompt): string {
     return (block.nodes ?? []).map((node) => getPlainCodeBlock(node)).join('\n');
 }

--- a/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
@@ -25,7 +25,7 @@ export function Prompt(props: BlockProps<DocumentBlockPrompt>) {
         >
             <PromptClient
                 contentIcon={contentIcon}
-                description={block.data.description ?? ''}
+                description={block.data.description}
                 prompt={getPromptText(block)}
                 openInAIProviders={getOpenInAIProviders(props)}
             />

--- a/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { Button, ButtonGroup } from '@/components/primitives/Button';
-import { DropdownMenu, DropdownMenuItem } from '@/components/primitives/DropdownMenu';
-import { ToggleChevron } from '@/components/primitives/ToggleChevron';
+import {
+    Button,
+    ButtonGroup,
+    DropdownMenu,
+    DropdownMenuItem,
+    ToggleChevron,
+} from '@/components/primitives';
 import { tString, useLanguage } from '@/intl/client';
 import { tcls } from '@/lib/tailwind';
 import { Icon, type IconName } from '@gitbook/icons';

--- a/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { Button, ButtonGroup } from '@/components/primitives/Button';
+import { DropdownMenu, DropdownMenuItem } from '@/components/primitives/DropdownMenu';
+import { ToggleChevron } from '@/components/primitives/ToggleChevron';
+import { tString, useLanguage } from '@/intl/client';
+import { tcls } from '@/lib/tailwind';
+import { Icon, type IconName } from '@gitbook/icons';
+import React from 'react';
+
+const OPEN_IN_AI_PROVIDERS = ['claude', 'chatgpt', 'cursor'] as const;
+type AIProviders = (typeof OPEN_IN_AI_PROVIDERS)[number];
+
+export function PromptClient(props: {
+    contentIcon: IconName | null;
+    description: string;
+    prompt: string;
+    openInAIProviders: boolean;
+}) {
+    const { contentIcon, description, prompt, openInAIProviders } = props;
+    const language = useLanguage();
+    const promptId = React.useId();
+    const [open, setOpen] = React.useState(false);
+    const [headerHasFocus, setHeaderHasFocus] = React.useState(false);
+    return (
+        <>
+            <div className="group/prompt-header relative flex min-h-9 flex-row items-center justify-between gap-4 px-3 py-2">
+                <button
+                    type="button"
+                    aria-controls={promptId}
+                    aria-expanded={open}
+                    aria-label={tString(language, 'view')}
+                    className={tcls(
+                        'absolute inset-0 z-10 cursor-pointer outline-hidden',
+                        'focus-visible:ring-2 focus-visible:ring-primary-hover'
+                    )}
+                    disabled={!prompt}
+                    onBlur={() => setHeaderHasFocus(false)}
+                    onClick={() => setOpen((prev) => !prev)}
+                    onFocus={() => setHeaderHasFocus(true)}
+                />
+                <div className="pointer-events-none relative z-0 flex min-w-0 flex-row items-center gap-2 text-tint-strong">
+                    <PromptDisclosureIcon
+                        contentIcon={contentIcon}
+                        headerHasFocus={headerHasFocus}
+                        open={open}
+                    />
+                    <span className="min-w-0 truncate">{description}</span>
+                </div>
+                <PromptActions prompt={prompt} openInAIProviders={openInAIProviders} />
+            </div>
+            {open ? (
+                <div id={promptId} className="border-tint-subtle border-t bg-tint-base">
+                    <pre className="overflow-auto p-4 text-sm text-tint-strong">
+                        <code className="language-markdown whitespace-pre-wrap font-mono">
+                            {prompt}
+                        </code>
+                    </pre>
+                </div>
+            ) : null}
+        </>
+    );
+}
+
+function PromptDisclosureIcon(props: {
+    contentIcon: IconName | null;
+    headerHasFocus: boolean;
+    open: boolean;
+}) {
+    const { contentIcon, headerHasFocus, open } = props;
+    return (
+        <span className="relative flex size-4 shrink-0 items-center justify-center">
+            {contentIcon ? (
+                <>
+                    <span
+                        className={tcls(
+                            'flex items-center transition-opacity duration-150 group-hover/prompt-header:opacity-0',
+                            headerHasFocus && 'opacity-0'
+                        )}
+                    >
+                        <Icon icon={contentIcon} className="size-4 shrink-0" />
+                    </span>
+                    <span
+                        className={tcls(
+                            'absolute inset-0 flex items-center justify-center text-tint-subtle opacity-0 transition-opacity duration-150 group-hover/prompt-header:opacity-100',
+                            headerHasFocus && 'opacity-100'
+                        )}
+                    >
+                        <ToggleChevron open={open} orientation="right-to-down" className="size-3" />
+                    </span>
+                </>
+            ) : (
+                <ToggleChevron
+                    open={open}
+                    orientation="right-to-down"
+                    className="size-3 text-tint-subtle"
+                />
+            )}
+        </span>
+    );
+}
+
+function PromptActions(props: { prompt: string; openInAIProviders: boolean }) {
+    const { prompt, openInAIProviders } = props;
+
+    return (
+        <ButtonGroup className="relative z-20 shrink-0 overflow-visible">
+            <CopyPromptButton prompt={prompt} />
+            {openInAIProviders ? <OpenPromptDropdown prompt={prompt} /> : null}
+        </ButtonGroup>
+    );
+}
+
+// time in milliseconds to show the "Copied" message after copying a prompt
+const COPIED_MESSAGE_DURATION = 1000;
+
+function CopyPromptButton(props: { prompt: string }) {
+    const { prompt } = props;
+    const language = useLanguage();
+    const [copied, setCopied] = React.useState(false);
+
+    React.useEffect(() => {
+        if (!copied) {
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            setCopied(false);
+        }, COPIED_MESSAGE_DURATION);
+
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, [copied]);
+
+    return (
+        <Button
+            variant="secondary"
+            size="xsmall"
+            icon={copied ? 'check' : 'copy'}
+            label={copied ? tString(language, 'code_copied') : tString(language, 'prompt_copy')}
+            className="bg-tint-base"
+            disabled={!prompt}
+            onClick={() => {
+                navigator.clipboard.writeText(prompt);
+                setCopied(true);
+            }}
+        />
+    );
+}
+
+function OpenPromptDropdown(props: { prompt: string }) {
+    const { prompt } = props;
+    const language = useLanguage();
+
+    return (
+        <DropdownMenu
+            align="end"
+            className="!min-w-48 max-w-max"
+            button={
+                <Button
+                    icon={<ToggleChevron className="size-text-sm" />}
+                    label={tString(language, 'open')}
+                    iconOnly
+                    size="xsmall"
+                    variant="secondary"
+                    className="bg-tint-base"
+                    disabled={!prompt}
+                />
+            }
+        >
+            {OPEN_IN_AI_PROVIDERS.map((provider) => {
+                const definition = getPromptOpenActionDefinition(provider, prompt);
+
+                return (
+                    <DropdownMenuItem
+                        key={provider}
+                        href={definition.href}
+                        target="_blank"
+                        leadingIcon={definition.icon}
+                    >
+                        {tString(language, 'open_in', definition.label)}
+                    </DropdownMenuItem>
+                );
+            })}
+        </DropdownMenu>
+    );
+}
+
+function getPromptOpenActionDefinition(
+    action: AIProviders,
+    prompt: string
+): { href: string; icon: IconName; label: string } {
+    const encodedPrompt = encodeURIComponent(prompt);
+
+    switch (action) {
+        case 'cursor':
+            return {
+                href: `${CURSOR_PROMPT_URL}?text=${encodedPrompt}`,
+                icon: 'cursor',
+                label: 'Cursor',
+            };
+        case 'claude':
+            return {
+                href: `${CLAUDE_PROMPT_URL}?q=${encodedPrompt}`,
+                icon: 'claude',
+                label: 'Claude',
+            };
+        case 'chatgpt':
+            return {
+                href: `${CHATGPT_PROMPT_URL}?q=${encodedPrompt}`,
+                icon: 'chatgpt',
+                label: 'ChatGPT',
+            };
+    }
+}
+
+const CLAUDE_PROMPT_URL = 'https://claude.ai/new';
+const CHATGPT_PROMPT_URL = 'https://chat.openai.com/';
+const CURSOR_PROMPT_URL = 'https://cursor.com/link/prompt';

--- a/packages/gitbook/src/components/DocumentView/Prompt/index.ts
+++ b/packages/gitbook/src/components/DocumentView/Prompt/index.ts
@@ -1,0 +1,2 @@
+export * from './Prompt';
+export type * from './types';

--- a/packages/gitbook/src/components/DocumentView/Prompt/types.ts
+++ b/packages/gitbook/src/components/DocumentView/Prompt/types.ts
@@ -1,0 +1,14 @@
+import type { DocumentBlockCode } from '@gitbook/api';
+
+export type PromptBlock = {
+    object: 'block';
+    type: 'prompt';
+    key?: string;
+    data: {
+        icon?: string;
+        description?: string;
+        openInAIProviders?: boolean;
+    };
+    nodes?: DocumentBlockCode[];
+    isVoid?: false;
+};

--- a/packages/gitbook/src/intl/translations/ar.ts
+++ b/packages/gitbook/src/intl/translations/ar.ts
@@ -56,6 +56,7 @@ export const ar: TranslationLanguage = {
     annotation_button_label: 'فتح التعليق التوضيحي',
     code_copied: 'تم النسخ!',
     code_copy: 'نسخ',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'عرض كل الأسطر ${1}',
     code_block_expanded: 'عرض أقل',
     table_of_contents_button_label: 'فتح جدول المحتويات',

--- a/packages/gitbook/src/intl/translations/ar.ts
+++ b/packages/gitbook/src/intl/translations/ar.ts
@@ -56,7 +56,7 @@ export const ar: TranslationLanguage = {
     annotation_button_label: 'فتح التعليق التوضيحي',
     code_copied: 'تم النسخ!',
     code_copy: 'نسخ',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'نسخ الموجّه',
     code_block_collapsed: 'عرض كل الأسطر ${1}',
     code_block_expanded: 'عرض أقل',
     table_of_contents_button_label: 'فتح جدول المحتويات',

--- a/packages/gitbook/src/intl/translations/bg.ts
+++ b/packages/gitbook/src/intl/translations/bg.ts
@@ -56,6 +56,7 @@ export const bg: TranslationLanguage = {
     annotation_button_label: 'Отваряне на бележка',
     code_copied: 'Копирано!',
     code_copy: 'Копиране',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Показване на всички ${1} реда',
     code_block_expanded: 'Показване на по-малко',
     table_of_contents_button_label: 'Отваряне на съдържанието',

--- a/packages/gitbook/src/intl/translations/bg.ts
+++ b/packages/gitbook/src/intl/translations/bg.ts
@@ -56,7 +56,7 @@ export const bg: TranslationLanguage = {
     annotation_button_label: 'Отваряне на бележка',
     code_copied: 'Копирано!',
     code_copy: 'Копиране',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Копиране на подканата',
     code_block_collapsed: 'Показване на всички ${1} реда',
     code_block_expanded: 'Показване на по-малко',
     table_of_contents_button_label: 'Отваряне на съдържанието',

--- a/packages/gitbook/src/intl/translations/cs.ts
+++ b/packages/gitbook/src/intl/translations/cs.ts
@@ -56,6 +56,7 @@ export const cs: TranslationLanguage = {
     annotation_button_label: 'Otevřít anotaci',
     code_copied: 'Zkopírováno!',
     code_copy: 'Kopírovat',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Zobrazit všech ${1} řádků',
     code_block_expanded: 'Zobrazit méně',
     table_of_contents_button_label: 'Otevřít obsah',

--- a/packages/gitbook/src/intl/translations/cs.ts
+++ b/packages/gitbook/src/intl/translations/cs.ts
@@ -56,7 +56,7 @@ export const cs: TranslationLanguage = {
     annotation_button_label: 'Otevřít anotaci',
     code_copied: 'Zkopírováno!',
     code_copy: 'Kopírovat',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopírovat výzvu',
     code_block_collapsed: 'Zobrazit všech ${1} řádků',
     code_block_expanded: 'Zobrazit méně',
     table_of_contents_button_label: 'Otevřít obsah',

--- a/packages/gitbook/src/intl/translations/da.ts
+++ b/packages/gitbook/src/intl/translations/da.ts
@@ -56,7 +56,7 @@ export const da: TranslationLanguage = {
     annotation_button_label: 'Åbn kommentar',
     code_copied: 'Kopieret!',
     code_copy: 'Kopiér',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopiér prompten',
     code_block_collapsed: 'Vis alle ${1} linjer',
     code_block_expanded: 'Vis mindre',
     table_of_contents_button_label: 'Åbn indholdsfortegnelse',

--- a/packages/gitbook/src/intl/translations/da.ts
+++ b/packages/gitbook/src/intl/translations/da.ts
@@ -56,6 +56,7 @@ export const da: TranslationLanguage = {
     annotation_button_label: 'Åbn kommentar',
     code_copied: 'Kopieret!',
     code_copy: 'Kopiér',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Vis alle ${1} linjer',
     code_block_expanded: 'Vis mindre',
     table_of_contents_button_label: 'Åbn indholdsfortegnelse',

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -55,7 +55,7 @@ export const de = {
     annotation_button_label: 'Kommentar öffnen',
     code_copied: 'Kopiert!',
     code_copy: 'Kopieren',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Prompt kopieren',
     code_block_collapsed: 'Alle ${1} Zeilen anzeigen',
     code_block_expanded: 'Weniger anzeigen',
     table_of_contents_button_label: 'Inhaltsverzeichnis öffnen',

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -55,6 +55,7 @@ export const de = {
     annotation_button_label: 'Kommentar öffnen',
     code_copied: 'Kopiert!',
     code_copy: 'Kopieren',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Alle ${1} Zeilen anzeigen',
     code_block_expanded: 'Weniger anzeigen',
     table_of_contents_button_label: 'Inhaltsverzeichnis öffnen',

--- a/packages/gitbook/src/intl/translations/el.ts
+++ b/packages/gitbook/src/intl/translations/el.ts
@@ -56,7 +56,7 @@ export const el: TranslationLanguage = {
     annotation_button_label: 'Άνοιγμα σχολίου',
     code_copied: 'Αντιγράφηκε!',
     code_copy: 'Αντιγραφή',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Αντιγραφή προτροπής',
     code_block_collapsed: 'Εμφάνιση όλων των ${1} γραμμών',
     code_block_expanded: 'Εμφάνιση λιγότερων',
     table_of_contents_button_label: 'Άνοιγμα πίνακα περιεχομένων',

--- a/packages/gitbook/src/intl/translations/el.ts
+++ b/packages/gitbook/src/intl/translations/el.ts
@@ -56,6 +56,7 @@ export const el: TranslationLanguage = {
     annotation_button_label: 'Άνοιγμα σχολίου',
     code_copied: 'Αντιγράφηκε!',
     code_copy: 'Αντιγραφή',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Εμφάνιση όλων των ${1} γραμμών',
     code_block_expanded: 'Εμφάνιση λιγότερων',
     table_of_contents_button_label: 'Άνοιγμα πίνακα περιεχομένων',

--- a/packages/gitbook/src/intl/translations/en.ts
+++ b/packages/gitbook/src/intl/translations/en.ts
@@ -54,6 +54,7 @@ export const en = {
     annotation_button_label: 'Open annotation',
     code_copied: 'Copied!',
     code_copy: 'Copy',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Show all ${1} lines',
     code_block_expanded: 'Show less',
     table_of_contents_button_label: 'Open table of contents',

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -57,7 +57,7 @@ export const es: TranslationLanguage = {
     annotation_button_label: 'Abrir anotación',
     code_copied: '¡Copiado!',
     code_copy: 'Copiar',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Copiar prompt',
     code_block_collapsed: 'Mostrar las ${1} líneas',
     code_block_expanded: 'Mostrar menos',
     table_of_contents_button_label: 'Abrir índice de contenidos',

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -57,6 +57,7 @@ export const es: TranslationLanguage = {
     annotation_button_label: 'Abrir anotación',
     code_copied: '¡Copiado!',
     code_copy: 'Copiar',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Mostrar las ${1} líneas',
     code_block_expanded: 'Mostrar menos',
     table_of_contents_button_label: 'Abrir índice de contenidos',

--- a/packages/gitbook/src/intl/translations/et.ts
+++ b/packages/gitbook/src/intl/translations/et.ts
@@ -56,7 +56,7 @@ export const et: TranslationLanguage = {
     annotation_button_label: 'Ava märkus',
     code_copied: 'Kopeeritud!',
     code_copy: 'Kopeeri',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopeeri viip',
     code_block_collapsed: 'Kuva kõik ${1} rida',
     code_block_expanded: 'Kuva vähem',
     table_of_contents_button_label: 'Ava sisukord',

--- a/packages/gitbook/src/intl/translations/et.ts
+++ b/packages/gitbook/src/intl/translations/et.ts
@@ -56,6 +56,7 @@ export const et: TranslationLanguage = {
     annotation_button_label: 'Ava märkus',
     code_copied: 'Kopeeritud!',
     code_copy: 'Kopeeri',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Kuva kõik ${1} rida',
     code_block_expanded: 'Kuva vähem',
     table_of_contents_button_label: 'Ava sisukord',

--- a/packages/gitbook/src/intl/translations/fi.ts
+++ b/packages/gitbook/src/intl/translations/fi.ts
@@ -56,6 +56,7 @@ export const fi: TranslationLanguage = {
     annotation_button_label: 'Avaa huomautus',
     code_copied: 'Kopioitu!',
     code_copy: 'Kopioi',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Näytä kaikki ${1} riviä',
     code_block_expanded: 'Näytä vähemmän',
     table_of_contents_button_label: 'Avaa sisällysluettelo',

--- a/packages/gitbook/src/intl/translations/fi.ts
+++ b/packages/gitbook/src/intl/translations/fi.ts
@@ -56,7 +56,7 @@ export const fi: TranslationLanguage = {
     annotation_button_label: 'Avaa huomautus',
     code_copied: 'Kopioitu!',
     code_copy: 'Kopioi',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopioi kehote',
     code_block_collapsed: 'Näytä kaikki ${1} riviä',
     code_block_expanded: 'Näytä vähemmän',
     table_of_contents_button_label: 'Avaa sisällysluettelo',

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -54,6 +54,7 @@ export const fr = {
     annotation_button_label: 'Afficher l’annotation',
     code_copied: 'Copié !',
     code_copy: 'Copier',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Afficher les ${1} lignes',
     code_block_expanded: 'Afficher moins',
     table_of_contents_button_label: 'Afficher le sommaire',

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -54,7 +54,7 @@ export const fr = {
     annotation_button_label: 'Afficher l’annotation',
     code_copied: 'Copié !',
     code_copy: 'Copier',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Copier l’invite',
     code_block_collapsed: 'Afficher les ${1} lignes',
     code_block_expanded: 'Afficher moins',
     table_of_contents_button_label: 'Afficher le sommaire',

--- a/packages/gitbook/src/intl/translations/he.ts
+++ b/packages/gitbook/src/intl/translations/he.ts
@@ -56,7 +56,7 @@ export const he: TranslationLanguage = {
     annotation_button_label: 'פתיחת הערה',
     code_copied: 'הועתק!',
     code_copy: 'העתקה',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'העתקת ההנחיה',
     code_block_collapsed: 'הצג את כל ${1} השורות',
     code_block_expanded: 'הצג פחות',
     table_of_contents_button_label: 'פתיחת תוכן העניינים',

--- a/packages/gitbook/src/intl/translations/he.ts
+++ b/packages/gitbook/src/intl/translations/he.ts
@@ -56,6 +56,7 @@ export const he: TranslationLanguage = {
     annotation_button_label: 'פתיחת הערה',
     code_copied: 'הועתק!',
     code_copy: 'העתקה',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'הצג את כל ${1} השורות',
     code_block_expanded: 'הצג פחות',
     table_of_contents_button_label: 'פתיחת תוכן העניינים',

--- a/packages/gitbook/src/intl/translations/hi.ts
+++ b/packages/gitbook/src/intl/translations/hi.ts
@@ -56,7 +56,7 @@ export const hi: TranslationLanguage = {
     annotation_button_label: 'टिप्पणी खोलें',
     code_copied: 'कॉपी हो गया!',
     code_copy: 'कॉपी करें',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'प्रॉम्प्ट कॉपी करें',
     code_block_collapsed: 'सभी ${1} पंक्तियां दिखाएं',
     code_block_expanded: 'कम दिखाएं',
     table_of_contents_button_label: 'सामग्री सूची खोलें',

--- a/packages/gitbook/src/intl/translations/hi.ts
+++ b/packages/gitbook/src/intl/translations/hi.ts
@@ -56,6 +56,7 @@ export const hi: TranslationLanguage = {
     annotation_button_label: 'टिप्पणी खोलें',
     code_copied: 'कॉपी हो गया!',
     code_copy: 'कॉपी करें',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'सभी ${1} पंक्तियां दिखाएं',
     code_block_expanded: 'कम दिखाएं',
     table_of_contents_button_label: 'सामग्री सूची खोलें',

--- a/packages/gitbook/src/intl/translations/hr.ts
+++ b/packages/gitbook/src/intl/translations/hr.ts
@@ -56,7 +56,7 @@ export const hr: TranslationLanguage = {
     annotation_button_label: 'Otvori bilješku',
     code_copied: 'Kopirano!',
     code_copy: 'Kopiraj',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopiraj uputu',
     code_block_collapsed: 'Prikaži svih ${1} redaka',
     code_block_expanded: 'Prikaži manje',
     table_of_contents_button_label: 'Otvori sadržaj',

--- a/packages/gitbook/src/intl/translations/hr.ts
+++ b/packages/gitbook/src/intl/translations/hr.ts
@@ -56,6 +56,7 @@ export const hr: TranslationLanguage = {
     annotation_button_label: 'Otvori bilješku',
     code_copied: 'Kopirano!',
     code_copy: 'Kopiraj',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Prikaži svih ${1} redaka',
     code_block_expanded: 'Prikaži manje',
     table_of_contents_button_label: 'Otvori sadržaj',

--- a/packages/gitbook/src/intl/translations/hu.ts
+++ b/packages/gitbook/src/intl/translations/hu.ts
@@ -56,6 +56,7 @@ export const hu: TranslationLanguage = {
     annotation_button_label: 'Jegyzet megnyitása',
     code_copied: 'Másolva!',
     code_copy: 'Másolás',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Mind a(z) ${1} sor megjelenítése',
     code_block_expanded: 'Kevesebb megjelenítése',
     table_of_contents_button_label: 'Tartalomjegyzék megnyitása',

--- a/packages/gitbook/src/intl/translations/hu.ts
+++ b/packages/gitbook/src/intl/translations/hu.ts
@@ -56,7 +56,7 @@ export const hu: TranslationLanguage = {
     annotation_button_label: 'Jegyzet megnyitása',
     code_copied: 'Másolva!',
     code_copy: 'Másolás',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Prompt másolása',
     code_block_collapsed: 'Mind a(z) ${1} sor megjelenítése',
     code_block_expanded: 'Kevesebb megjelenítése',
     table_of_contents_button_label: 'Tartalomjegyzék megnyitása',

--- a/packages/gitbook/src/intl/translations/id.ts
+++ b/packages/gitbook/src/intl/translations/id.ts
@@ -56,7 +56,7 @@ export const id: TranslationLanguage = {
     annotation_button_label: 'Buka anotasi',
     code_copied: 'Disalin!',
     code_copy: 'Salin',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Salin prompt',
     code_block_collapsed: 'Tampilkan semua ${1} baris',
     code_block_expanded: 'Tampilkan lebih sedikit',
     table_of_contents_button_label: 'Buka daftar isi',

--- a/packages/gitbook/src/intl/translations/id.ts
+++ b/packages/gitbook/src/intl/translations/id.ts
@@ -56,6 +56,7 @@ export const id: TranslationLanguage = {
     annotation_button_label: 'Buka anotasi',
     code_copied: 'Disalin!',
     code_copy: 'Salin',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Tampilkan semua ${1} baris',
     code_block_expanded: 'Tampilkan lebih sedikit',
     table_of_contents_button_label: 'Buka daftar isi',

--- a/packages/gitbook/src/intl/translations/it.ts
+++ b/packages/gitbook/src/intl/translations/it.ts
@@ -57,6 +57,7 @@ export const it: TranslationLanguage = {
     annotation_button_label: 'Apri annotazione',
     code_copied: 'Copiato!',
     code_copy: 'Copia',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Mostra tutte le ${1} righe',
     code_block_expanded: 'Mostra meno',
     table_of_contents_button_label: 'Apri indice dei contenuti',

--- a/packages/gitbook/src/intl/translations/it.ts
+++ b/packages/gitbook/src/intl/translations/it.ts
@@ -57,7 +57,7 @@ export const it: TranslationLanguage = {
     annotation_button_label: 'Apri annotazione',
     code_copied: 'Copiato!',
     code_copy: 'Copia',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Copia il prompt',
     code_block_collapsed: 'Mostra tutte le ${1} righe',
     code_block_expanded: 'Mostra meno',
     table_of_contents_button_label: 'Apri indice dei contenuti',

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -57,7 +57,7 @@ export const ja: TranslationLanguage = {
     annotation_button_label: '注釈を開く',
     code_copied: 'コピーしました！',
     code_copy: 'コピー',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'プロンプトをコピー',
     code_block_collapsed: 'すべての ${1} 行を表示',
     code_block_expanded: '折りたたむ',
     table_of_contents_button_label: '目次を開く',

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -57,6 +57,7 @@ export const ja: TranslationLanguage = {
     annotation_button_label: '注釈を開く',
     code_copied: 'コピーしました！',
     code_copy: 'コピー',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'すべての ${1} 行を表示',
     code_block_expanded: '折りたたむ',
     table_of_contents_button_label: '目次を開く',

--- a/packages/gitbook/src/intl/translations/ko.ts
+++ b/packages/gitbook/src/intl/translations/ko.ts
@@ -57,6 +57,7 @@ export const ko: TranslationLanguage = {
     annotation_button_label: '주석 열기',
     code_copied: '복사됨!',
     code_copy: '복사',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: '${1}줄 모두 보기',
     code_block_expanded: '간단히 보기',
     table_of_contents_button_label: '목차 열기',

--- a/packages/gitbook/src/intl/translations/ko.ts
+++ b/packages/gitbook/src/intl/translations/ko.ts
@@ -57,7 +57,7 @@ export const ko: TranslationLanguage = {
     annotation_button_label: '주석 열기',
     code_copied: '복사됨!',
     code_copy: '복사',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: '프롬프트 복사',
     code_block_collapsed: '${1}줄 모두 보기',
     code_block_expanded: '간단히 보기',
     table_of_contents_button_label: '목차 열기',

--- a/packages/gitbook/src/intl/translations/lt.ts
+++ b/packages/gitbook/src/intl/translations/lt.ts
@@ -56,6 +56,7 @@ export const lt: TranslationLanguage = {
     annotation_button_label: 'Atidaryti pastabą',
     code_copied: 'Nukopijuota!',
     code_copy: 'Kopijuoti',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Rodyti visas ${1} eilutes',
     code_block_expanded: 'Rodyti mažiau',
     table_of_contents_button_label: 'Atidaryti turinį',

--- a/packages/gitbook/src/intl/translations/lt.ts
+++ b/packages/gitbook/src/intl/translations/lt.ts
@@ -56,7 +56,7 @@ export const lt: TranslationLanguage = {
     annotation_button_label: 'Atidaryti pastabą',
     code_copied: 'Nukopijuota!',
     code_copy: 'Kopijuoti',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopijuoti raginimą',
     code_block_collapsed: 'Rodyti visas ${1} eilutes',
     code_block_expanded: 'Rodyti mažiau',
     table_of_contents_button_label: 'Atidaryti turinį',

--- a/packages/gitbook/src/intl/translations/lv.ts
+++ b/packages/gitbook/src/intl/translations/lv.ts
@@ -56,7 +56,7 @@ export const lv: TranslationLanguage = {
     annotation_button_label: 'Atvērt anotāciju',
     code_copied: 'Nokopēts!',
     code_copy: 'Kopēt',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopēt uzvedni',
     code_block_collapsed: 'Rādīt visas ${1} rindas',
     code_block_expanded: 'Rādīt mazāk',
     table_of_contents_button_label: 'Atvērt satura rādītāju',

--- a/packages/gitbook/src/intl/translations/lv.ts
+++ b/packages/gitbook/src/intl/translations/lv.ts
@@ -56,6 +56,7 @@ export const lv: TranslationLanguage = {
     annotation_button_label: 'Atvērt anotāciju',
     code_copied: 'Nokopēts!',
     code_copy: 'Kopēt',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Rādīt visas ${1} rindas',
     code_block_expanded: 'Rādīt mazāk',
     table_of_contents_button_label: 'Atvērt satura rādītāju',

--- a/packages/gitbook/src/intl/translations/ms.ts
+++ b/packages/gitbook/src/intl/translations/ms.ts
@@ -56,7 +56,7 @@ export const ms: TranslationLanguage = {
     annotation_button_label: 'Buka anotasi',
     code_copied: 'Disalin!',
     code_copy: 'Salin',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Salin gesaan',
     code_block_collapsed: 'Tunjukkan semua ${1} baris',
     code_block_expanded: 'Tunjukkan kurang',
     table_of_contents_button_label: 'Buka jadual kandungan',

--- a/packages/gitbook/src/intl/translations/ms.ts
+++ b/packages/gitbook/src/intl/translations/ms.ts
@@ -56,6 +56,7 @@ export const ms: TranslationLanguage = {
     annotation_button_label: 'Buka anotasi',
     code_copied: 'Disalin!',
     code_copy: 'Salin',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Tunjukkan semua ${1} baris',
     code_block_expanded: 'Tunjukkan kurang',
     table_of_contents_button_label: 'Buka jadual kandungan',

--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -57,6 +57,7 @@ export const nl: TranslationLanguage = {
     annotation_button_label: 'Annotatie openen',
     code_copied: 'Gekopieerd!',
     code_copy: 'Kopiëren',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Toon alle ${1} regels',
     code_block_expanded: 'Toon minder',
     table_of_contents_button_label: 'Open inhoudsopgave',

--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -57,7 +57,7 @@ export const nl: TranslationLanguage = {
     annotation_button_label: 'Annotatie openen',
     code_copied: 'Gekopieerd!',
     code_copy: 'Kopiëren',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Prompt kopiëren',
     code_block_collapsed: 'Toon alle ${1} regels',
     code_block_expanded: 'Toon minder',
     table_of_contents_button_label: 'Open inhoudsopgave',

--- a/packages/gitbook/src/intl/translations/no.ts
+++ b/packages/gitbook/src/intl/translations/no.ts
@@ -57,7 +57,7 @@ export const no: TranslationLanguage = {
     annotation_button_label: 'Åpne merknad',
     code_copied: 'Kopiert!',
     code_copy: 'Kopier',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopier ledeteksten',
     code_block_collapsed: 'Vis alle ${1} linjer',
     code_block_expanded: 'Vis færre',
     table_of_contents_button_label: 'Åpne innholdsfortegnelse',

--- a/packages/gitbook/src/intl/translations/no.ts
+++ b/packages/gitbook/src/intl/translations/no.ts
@@ -57,6 +57,7 @@ export const no: TranslationLanguage = {
     annotation_button_label: 'Åpne merknad',
     code_copied: 'Kopiert!',
     code_copy: 'Kopier',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Vis alle ${1} linjer',
     code_block_expanded: 'Vis færre',
     table_of_contents_button_label: 'Åpne innholdsfortegnelse',

--- a/packages/gitbook/src/intl/translations/pl.ts
+++ b/packages/gitbook/src/intl/translations/pl.ts
@@ -56,7 +56,7 @@ export const pl: TranslationLanguage = {
     annotation_button_label: 'Otwórz adnotację',
     code_copied: 'Skopiowano!',
     code_copy: 'Kopiuj',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopiuj prompt',
     code_block_collapsed: 'Pokaż wszystkie ${1} wierszy',
     code_block_expanded: 'Pokaż mniej',
     table_of_contents_button_label: 'Otwórz spis treści',

--- a/packages/gitbook/src/intl/translations/pl.ts
+++ b/packages/gitbook/src/intl/translations/pl.ts
@@ -56,6 +56,7 @@ export const pl: TranslationLanguage = {
     annotation_button_label: 'Otwórz adnotację',
     code_copied: 'Skopiowano!',
     code_copy: 'Kopiuj',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Pokaż wszystkie ${1} wierszy',
     code_block_expanded: 'Pokaż mniej',
     table_of_contents_button_label: 'Otwórz spis treści',

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -55,6 +55,7 @@ export const pt_br = {
     annotation_button_label: 'Abrir anotação',
     code_copied: 'Copiado!',
     code_copy: 'Copiar',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Mostrar todas as ${1} linhas',
     code_block_expanded: 'Mostrar menos',
     table_of_contents_button_label: 'Abrir o índice',

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -55,7 +55,7 @@ export const pt_br = {
     annotation_button_label: 'Abrir anotação',
     code_copied: 'Copiado!',
     code_copy: 'Copiar',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Copiar prompt',
     code_block_collapsed: 'Mostrar todas as ${1} linhas',
     code_block_expanded: 'Mostrar menos',
     table_of_contents_button_label: 'Abrir o índice',

--- a/packages/gitbook/src/intl/translations/pt.ts
+++ b/packages/gitbook/src/intl/translations/pt.ts
@@ -56,7 +56,7 @@ export const pt: TranslationLanguage = {
     annotation_button_label: 'Abrir anotação',
     code_copied: 'Copiado!',
     code_copy: 'Copiar',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Copiar prompt',
     code_block_collapsed: 'Mostrar todas as ${1} linhas',
     code_block_expanded: 'Mostrar menos',
     table_of_contents_button_label: 'Abrir índice',

--- a/packages/gitbook/src/intl/translations/pt.ts
+++ b/packages/gitbook/src/intl/translations/pt.ts
@@ -56,6 +56,7 @@ export const pt: TranslationLanguage = {
     annotation_button_label: 'Abrir anotação',
     code_copied: 'Copiado!',
     code_copy: 'Copiar',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Mostrar todas as ${1} linhas',
     code_block_expanded: 'Mostrar menos',
     table_of_contents_button_label: 'Abrir índice',

--- a/packages/gitbook/src/intl/translations/ro.ts
+++ b/packages/gitbook/src/intl/translations/ro.ts
@@ -56,7 +56,7 @@ export const ro: TranslationLanguage = {
     annotation_button_label: 'Deschide adnotarea',
     code_copied: 'Copiat!',
     code_copy: 'Copiază',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Copiază promptul',
     code_block_collapsed: 'Afișează toate cele ${1} linii',
     code_block_expanded: 'Afișează mai puțin',
     table_of_contents_button_label: 'Deschide cuprinsul',

--- a/packages/gitbook/src/intl/translations/ro.ts
+++ b/packages/gitbook/src/intl/translations/ro.ts
@@ -56,6 +56,7 @@ export const ro: TranslationLanguage = {
     annotation_button_label: 'Deschide adnotarea',
     code_copied: 'Copiat!',
     code_copy: 'Copiază',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Afișează toate cele ${1} linii',
     code_block_expanded: 'Afișează mai puțin',
     table_of_contents_button_label: 'Deschide cuprinsul',

--- a/packages/gitbook/src/intl/translations/ru.ts
+++ b/packages/gitbook/src/intl/translations/ru.ts
@@ -55,7 +55,7 @@ export const ru = {
     annotation_button_label: 'Открыть аннотацию',
     code_copied: 'Скопировано!',
     code_copy: 'Копировать',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Скопировать промпт',
     code_block_collapsed: 'Показать все ${1} строк',
     code_block_expanded: 'Показать меньше',
     table_of_contents_button_label: 'Открыть оглавление',

--- a/packages/gitbook/src/intl/translations/ru.ts
+++ b/packages/gitbook/src/intl/translations/ru.ts
@@ -55,6 +55,7 @@ export const ru = {
     annotation_button_label: 'Открыть аннотацию',
     code_copied: 'Скопировано!',
     code_copy: 'Копировать',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Показать все ${1} строк',
     code_block_expanded: 'Показать меньше',
     table_of_contents_button_label: 'Открыть оглавление',

--- a/packages/gitbook/src/intl/translations/sk.ts
+++ b/packages/gitbook/src/intl/translations/sk.ts
@@ -56,6 +56,7 @@ export const sk: TranslationLanguage = {
     annotation_button_label: 'Otvoriť anotáciu',
     code_copied: 'Skopírované!',
     code_copy: 'Kopírovať',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Zobraziť všetkých ${1} riadkov',
     code_block_expanded: 'Zobraziť menej',
     table_of_contents_button_label: 'Otvoriť obsah',

--- a/packages/gitbook/src/intl/translations/sk.ts
+++ b/packages/gitbook/src/intl/translations/sk.ts
@@ -56,7 +56,7 @@ export const sk: TranslationLanguage = {
     annotation_button_label: 'Otvoriť anotáciu',
     code_copied: 'Skopírované!',
     code_copy: 'Kopírovať',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopírovať výzvu',
     code_block_collapsed: 'Zobraziť všetkých ${1} riadkov',
     code_block_expanded: 'Zobraziť menej',
     table_of_contents_button_label: 'Otvoriť obsah',

--- a/packages/gitbook/src/intl/translations/sl.ts
+++ b/packages/gitbook/src/intl/translations/sl.ts
@@ -56,6 +56,7 @@ export const sl: TranslationLanguage = {
     annotation_button_label: 'Odpri opombo',
     code_copied: 'Kopirano!',
     code_copy: 'Kopiraj',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Prikaži vseh ${1} vrstic',
     code_block_expanded: 'Prikaži manj',
     table_of_contents_button_label: 'Odpri kazalo',

--- a/packages/gitbook/src/intl/translations/sl.ts
+++ b/packages/gitbook/src/intl/translations/sl.ts
@@ -56,7 +56,7 @@ export const sl: TranslationLanguage = {
     annotation_button_label: 'Odpri opombo',
     code_copied: 'Kopirano!',
     code_copy: 'Kopiraj',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopiraj poziv',
     code_block_collapsed: 'Prikaži vseh ${1} vrstic',
     code_block_expanded: 'Prikaži manj',
     table_of_contents_button_label: 'Odpri kazalo',

--- a/packages/gitbook/src/intl/translations/sv.ts
+++ b/packages/gitbook/src/intl/translations/sv.ts
@@ -56,6 +56,7 @@ export const sv: TranslationLanguage = {
     annotation_button_label: 'Öppna anteckning',
     code_copied: 'Kopierat!',
     code_copy: 'Kopiera',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Visa alla ${1} rader',
     code_block_expanded: 'Visa mindre',
     table_of_contents_button_label: 'Öppna innehållsförteckning',

--- a/packages/gitbook/src/intl/translations/sv.ts
+++ b/packages/gitbook/src/intl/translations/sv.ts
@@ -56,7 +56,7 @@ export const sv: TranslationLanguage = {
     annotation_button_label: 'Öppna anteckning',
     code_copied: 'Kopierat!',
     code_copy: 'Kopiera',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Kopiera prompten',
     code_block_collapsed: 'Visa alla ${1} rader',
     code_block_expanded: 'Visa mindre',
     table_of_contents_button_label: 'Öppna innehållsförteckning',

--- a/packages/gitbook/src/intl/translations/th.ts
+++ b/packages/gitbook/src/intl/translations/th.ts
@@ -55,7 +55,7 @@ export const th: TranslationLanguage = {
     annotation_button_label: 'เปิดคำอธิบายประกอบ',
     code_copied: 'คัดลอกแล้ว!',
     code_copy: 'คัดลอก',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'คัดลอกพรอมต์',
     code_block_collapsed: 'แสดงทั้งหมด ${1} บรรทัด',
     code_block_expanded: 'แสดงน้อยลง',
     table_of_contents_button_label: 'เปิดสารบัญ',

--- a/packages/gitbook/src/intl/translations/th.ts
+++ b/packages/gitbook/src/intl/translations/th.ts
@@ -55,6 +55,7 @@ export const th: TranslationLanguage = {
     annotation_button_label: 'เปิดคำอธิบายประกอบ',
     code_copied: 'คัดลอกแล้ว!',
     code_copy: 'คัดลอก',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'แสดงทั้งหมด ${1} บรรทัด',
     code_block_expanded: 'แสดงน้อยลง',
     table_of_contents_button_label: 'เปิดสารบัญ',

--- a/packages/gitbook/src/intl/translations/tr.ts
+++ b/packages/gitbook/src/intl/translations/tr.ts
@@ -56,7 +56,7 @@ export const tr: TranslationLanguage = {
     annotation_button_label: 'Açıklamayı aç',
     code_copied: 'Kopyalandı!',
     code_copy: 'Kopyala',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'İstemi kopyala',
     code_block_collapsed: 'Tüm ${1} satırı göster',
     code_block_expanded: 'Daha az göster',
     table_of_contents_button_label: 'İçindekiler tablosunu aç',

--- a/packages/gitbook/src/intl/translations/tr.ts
+++ b/packages/gitbook/src/intl/translations/tr.ts
@@ -56,6 +56,7 @@ export const tr: TranslationLanguage = {
     annotation_button_label: 'Açıklamayı aç',
     code_copied: 'Kopyalandı!',
     code_copy: 'Kopyala',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Tüm ${1} satırı göster',
     code_block_expanded: 'Daha az göster',
     table_of_contents_button_label: 'İçindekiler tablosunu aç',

--- a/packages/gitbook/src/intl/translations/uk.ts
+++ b/packages/gitbook/src/intl/translations/uk.ts
@@ -56,7 +56,7 @@ export const uk: TranslationLanguage = {
     annotation_button_label: 'Відкрити примітку',
     code_copied: 'Скопійовано!',
     code_copy: 'Копіювати',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Скопіювати промпт',
     code_block_collapsed: 'Показати всі ${1} рядків',
     code_block_expanded: 'Показати менше',
     table_of_contents_button_label: 'Відкрити зміст',

--- a/packages/gitbook/src/intl/translations/uk.ts
+++ b/packages/gitbook/src/intl/translations/uk.ts
@@ -56,6 +56,7 @@ export const uk: TranslationLanguage = {
     annotation_button_label: 'Відкрити примітку',
     code_copied: 'Скопійовано!',
     code_copy: 'Копіювати',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Показати всі ${1} рядків',
     code_block_expanded: 'Показати менше',
     table_of_contents_button_label: 'Відкрити зміст',

--- a/packages/gitbook/src/intl/translations/vi.ts
+++ b/packages/gitbook/src/intl/translations/vi.ts
@@ -56,6 +56,7 @@ export const vi: TranslationLanguage = {
     annotation_button_label: 'Mở chú thích',
     code_copied: 'Đã sao chép!',
     code_copy: 'Sao chép',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: 'Hiển thị tất cả ${1} dòng',
     code_block_expanded: 'Hiển thị ít hơn',
     table_of_contents_button_label: 'Mở mục lục',

--- a/packages/gitbook/src/intl/translations/vi.ts
+++ b/packages/gitbook/src/intl/translations/vi.ts
@@ -56,7 +56,7 @@ export const vi: TranslationLanguage = {
     annotation_button_label: 'Mở chú thích',
     code_copied: 'Đã sao chép!',
     code_copy: 'Sao chép',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: 'Sao chép lời nhắc',
     code_block_collapsed: 'Hiển thị tất cả ${1} dòng',
     code_block_expanded: 'Hiển thị ít hơn',
     table_of_contents_button_label: 'Mở mục lục',

--- a/packages/gitbook/src/intl/translations/yue.ts
+++ b/packages/gitbook/src/intl/translations/yue.ts
@@ -55,6 +55,7 @@ export const yue: TranslationLanguage = {
     annotation_button_label: '開啟註解',
     code_copied: '已複製！',
     code_copy: '複製',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: '顯示全部 ${1} 行',
     code_block_expanded: '顯示少啲',
     table_of_contents_button_label: '開啟目錄',

--- a/packages/gitbook/src/intl/translations/yue.ts
+++ b/packages/gitbook/src/intl/translations/yue.ts
@@ -55,7 +55,7 @@ export const yue: TranslationLanguage = {
     annotation_button_label: '開啟註解',
     code_copied: '已複製！',
     code_copy: '複製',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: '複製提示',
     code_block_collapsed: '顯示全部 ${1} 行',
     code_block_expanded: '顯示少啲',
     table_of_contents_button_label: '開啟目錄',

--- a/packages/gitbook/src/intl/translations/zh-tw.ts
+++ b/packages/gitbook/src/intl/translations/zh-tw.ts
@@ -55,6 +55,7 @@ export const zh_tw: TranslationLanguage = {
     annotation_button_label: '開啟註解',
     code_copied: '已複製！',
     code_copy: '複製',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: '顯示全部 ${1} 行',
     code_block_expanded: '顯示較少',
     table_of_contents_button_label: '開啟目錄',

--- a/packages/gitbook/src/intl/translations/zh-tw.ts
+++ b/packages/gitbook/src/intl/translations/zh-tw.ts
@@ -55,7 +55,7 @@ export const zh_tw: TranslationLanguage = {
     annotation_button_label: '開啟註解',
     code_copied: '已複製！',
     code_copy: '複製',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: '複製提示詞',
     code_block_collapsed: '顯示全部 ${1} 行',
     code_block_expanded: '顯示較少',
     table_of_contents_button_label: '開啟目錄',

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -56,7 +56,7 @@ export const zh: TranslationLanguage = {
     annotation_button_label: '打开批注',
     code_copied: '已复制！',
     code_copy: '复制',
-    prompt_copy: 'Copy prompt',
+    prompt_copy: '复制提示词',
     code_block_collapsed: '显示全部 ${1} 行',
     code_block_expanded: '收起',
     table_of_contents_button_label: '打开目录',

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -56,6 +56,7 @@ export const zh: TranslationLanguage = {
     annotation_button_label: '打开批注',
     code_copied: '已复制！',
     code_copy: '复制',
+    prompt_copy: 'Copy prompt',
     code_block_collapsed: '显示全部 ${1} 行',
     code_block_expanded: '收起',
     table_of_contents_button_label: '打开目录',


### PR DESCRIPTION
Add a Prompt block to GitBook. This PR adds rendering for Prompt block.

The Prompt block is designed to display an AI prompt with one-click copy and a palette menu to open the prompt quickly in one of several AI tools.

<img width="823" height="242" alt="Screenshot 2026-06-19 at 16 57 37" src="https://github.com/user-attachments/assets/5db9779e-0900-4dc5-a727-f6a4e5676055" />
<img width="869" height="172" alt="Screenshot 2026-06-19 at 16 57 23" src="https://github.com/user-attachments/assets/78567c35-bf05-4798-aabe-a43d47b814bd" />
<img width="824" height="91" alt="Screenshot 2026-06-19 at 16 57 16" src="https://github.com/user-attachments/assets/d11a289f-9636-48ae-bc36-0d9261cfba33" />
<img width="790" height="161" alt="Screenshot 2026-06-19 at 16 57 07" src="https://github.com/user-attachments/assets/ff5ea424-bd3a-4946-9a67-b2ddebc01bbb" />

