### PR TITLE
docs: fix typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We recommend adding as many relevant links, minimal reproductions of the issue, 
 
 ### Solve an issue
 
-If you're interested in solving an issue in our repository, start by scanning through it's exisiting issues to find one that you're interested in working on. If you find an issue to work on, you are welcome to open a PR with a fix. See the following sections below for more information on contributing for specific sections.
+If you're interested in solving an issue in our repository, start by scanning through it's existing issues to find one that you're interested in working on. If you find an issue to work on, you are welcome to open a PR with a fix. See the following sections below for more information on contributing for specific sections.
 
 ### Documentation
 
@@ -93,7 +93,7 @@ You can visit any published GitBook site behind your development server. Please 
 
 [Commit your changes](https://github.com/git-guides/git-commit) once you are happy with them. See [Atom's contributing guide](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#git-commit-messages) to know how to use emoji for commit messages!
 
-Once your changes are ready, don't forget to self-review your code to double check that your chagnes are ready to be added.
+Once your changes are ready, don't forget to self-review your code to double check that your changes are ready to be added.
 
 ### Pull Request
 

--- a/packages/gitbook/src/components/DocumentView/InlineImage.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineImage.tsx
@@ -29,7 +29,7 @@ export async function InlineImage(props: InlineProps<DocumentInlineImage>) {
     const sizes = await getImageSizes(context.contentContext, size, src);
 
     return (
-        /* Ensure images dont expand to the size of the container where this Image may be nested in. Now it's always nested in a size-restricted container */
+        /* Ensure images don't expand to the size of the container where this Image may be nested in. Now it's always nested in a size-restricted container */
         <span
             className={tcls(
                 size !== 'line' ? ['inline-flex', 'max-w-[300px]', 'align-middle'] : null

--- a/packages/gitbook/src/components/hooks/useHash.tsx
+++ b/packages/gitbook/src/components/hooks/useHash.tsx
@@ -99,7 +99,7 @@ export const NavigationStatusProvider: React.FC<React.PropsWithChildren> = ({ ch
 /**
  * Hook to get the current hash from the URL. The hash is set on navigation clicks **NOT** on hashchange events or on navigation end.
  * @see https://github.com/vercel/next.js/discussions/49465
- * We use a different hack than this one, because for same page link it don't work
+ * We use a different hack than this one, because for same page link it doesn't work
  * We can't use the `hashChange` event because it doesn't fire for `replaceState` and `pushState` which are used by Next.js.
  * Since we have a single Link component that handles all links, we can use a context to share the hash.
  */

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -161,7 +161,7 @@ export function Link(props: LinkProps) {
     // client router cache to be used properly.
     //
     // However, we need to disable prefetch for links with query params that
-    // can trigger server-side side effects, such as persisting visitor claims in a
+    // can trigger server-side effects, such as persisting visitor claims in a
     // cookie or starting the assistant. Automatic RSC prefetch requests can otherwise
     // trigger those effects without user intent.
     const _prefetch = hasSideEffectQueryParams(href) ? false : (prefetch ?? true);
@@ -181,7 +181,7 @@ export function Link(props: LinkProps) {
 }
 
 /**
- * Whether the given href carries query params that have a server-side side effect when fetched:
+ * Whether the given href carries query params that have a server-side effect when fetched:
  *   - `visitor.*` params persist unsigned visitor claims into the `gitbook-visitor-public` cookie.
  *   - `ask` triggers the assistant & `q` the search.
  *

--- a/packages/gitbook/src/lib/visitors.ts
+++ b/packages/gitbook/src/lib/visitors.ts
@@ -296,7 +296,7 @@ export function getResponseCookiesForVisitorAuth(
     }
 
     /**
-     * If the visitor token has been retrieve from the URL, or if its a VA cookie and the basePath is the same, set it
+     * If the visitor token has been retrieved from the URL, or if its a VA cookie and the basePath is the same, set it
      * as a cookie on the response.
      *
      * Note that we do not re-store the gitbook-visitor-cookie in another cookie, to maintain a single source of truth.


### PR DESCRIPTION
Summary

- Fixed spelling mistakes in documentation
- No functional changes