### PR TITLE
Remove old PageAction checks

### DIFF
--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
@@ -1,4 +1,4 @@
-import { SiteInsightsDisplayContext } from '@gitbook/api';
+import { CustomizationPageActionType, SiteInsightsDisplayContext } from '@gitbook/api';
 
 import { type RouteLayoutParams, getDynamicSiteContext } from '@/app/utils';
 import { getExposableError, throwIfDataError } from '@/lib/data';
@@ -20,7 +20,7 @@ export async function handleMcpRequest(
     const { context } = await getDynamicSiteContext(params);
     const { dataFetcher, linker, site } = context;
 
-    if (!context.customization.pageActions.mcp) {
+    if (!context.customization.pageActions.items.includes(CustomizationPageActionType.Mcp)) {
         return new Response('Not Found', { status: 404 });
     }
 

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
@@ -20,7 +20,14 @@ export async function handleMcpRequest(
     const { context } = await getDynamicSiteContext(params);
     const { dataFetcher, linker, site } = context;
 
-    if (!context.customization.pageActions.items.includes(CustomizationPageActionType.Mcp)) {
+    // Use the configured `items` list when the API provides it, and fall back to the deprecated
+    // `mcp` flag otherwise (legacy mode), since this endpoint is called directly and cannot rely on
+    // any page-rendering fallback.
+    const { pageActions } = context.customization;
+    const isMcpEnabled = pageActions.items
+        ? pageActions.items.includes(CustomizationPageActionType.Mcp)
+        : pageActions.mcp;
+    if (!isMcpEnabled) {
         return new Response('Not Found', { status: 404 });
     }
 

--- a/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
@@ -53,7 +53,11 @@ function getOpenInAIProviders(props: BlockProps<DocumentBlockPrompt>): boolean {
 function isExternalAIPageActionEnabled(
     pageActions: SiteCustomizationSettings['pageActions']
 ): boolean {
-    return pageActions.items.includes(CustomizationPageActionType.ExternalAi);
+    // Use the configured `items` list when the API provides it, and fall back to the deprecated
+    // `externalAI` flag otherwise (legacy mode).
+    return pageActions.items
+        ? pageActions.items.includes(CustomizationPageActionType.ExternalAi)
+        : pageActions.externalAI;
 }
 
 function getPromptText(block: DocumentBlockPrompt): string {

--- a/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
@@ -53,9 +53,7 @@ function getOpenInAIProviders(props: BlockProps<DocumentBlockPrompt>): boolean {
 function isExternalAIPageActionEnabled(
     pageActions: SiteCustomizationSettings['pageActions']
 ): boolean {
-    return pageActions.items
-        ? pageActions.items.includes(CustomizationPageActionType.ExternalAi)
-        : pageActions.externalAI;
+    return pageActions.items.includes(CustomizationPageActionType.ExternalAi);
 }
 
 function getPromptText(block: DocumentBlockPrompt): string {

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -3,6 +3,7 @@ import type { AncestorRevisionPage } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
 import { getPageRSSURL } from '@/routes/rss';
 import {
+    CustomizationAIMode,
     CustomizationPageActionType,
     type RevisionPageDocument,
     SiteVisibility,
@@ -33,9 +34,18 @@ export async function PageHeader(props: {
 
     const pageActionsEnabled = page.layout.actions !== false;
 
-    // Show page actions if *any* of the actions are enabled
-    const hasPageActions =
-        pageActionsEnabled && context.customization.pageActions.items.some(Boolean);
+    // Show page actions if *any* of the configured actions are enabled, or if the RSS feed is
+    // available. RSS is contextual (only on update/blog index pages) and is not part of the
+    // configured `items` list, so it is checked separately.
+    const hasConfiguredPageActions = [
+        CustomizationPageActionType.Assistant,
+        CustomizationPageActionType.ExternalAi,
+        CustomizationPageActionType.Markdown,
+        CustomizationPageActionType.Mcp,
+        CustomizationPageActionType.Pdf,
+        CustomizationPageActionType.Git,
+    ].some((type) => isPageActionEnabled(context.customization, type));
+    const hasPageActions = pageActionsEnabled && (hasConfiguredPageActions || withRSSFeed);
 
     if (!page.layout.title && !page.layout.description && !hasPageActions) {
         return null;
@@ -159,7 +169,7 @@ function getPageActionsURLs({
         markdown: `${context.linker.toAbsoluteURL(context.linker.toPathInSpace(page.path))}.md`,
         rss: withRSSFeed ? getPageRSSURL(context, page) : undefined,
         editOnGit:
-            context.customization.pageActions.items.includes(CustomizationPageActionType.Git) &&
+            isPageActionEnabled(context.customization, CustomizationPageActionType.Git) &&
             context.space.gitSync?.url &&
             page.git
                 ? {
@@ -167,7 +177,7 @@ function getPageActionsURLs({
                       url: urlJoin(context.space.gitSync.url, page.git.path),
                   }
                 : undefined,
-        pdf: context.customization.pageActions.items.includes(CustomizationPageActionType.Pdf)
+        pdf: isPageActionEnabled(context.customization, CustomizationPageActionType.Pdf)
             ? context.linker.toPathInSpace(
                   `~gitbook/pdf?${getPDFURLSearchParams({
                       page: page.id,
@@ -178,6 +188,37 @@ function getPageActionsURLs({
             : undefined,
         mcp: getPageActionsMCPURL(context),
     };
+}
+
+/**
+ * Whether a given built-in page action is enabled. Uses the configured `items` list when the API
+ * provides it, and falls back to the deprecated boolean flags otherwise (legacy mode), matching the
+ * fallback used by the page actions dropdown.
+ */
+function isPageActionEnabled(
+    customization: GitBookSiteContext['customization'],
+    type: CustomizationPageActionType
+): boolean {
+    const { pageActions } = customization;
+    if (pageActions.items) {
+        return pageActions.items.includes(type);
+    }
+    switch (type) {
+        case CustomizationPageActionType.ExternalAi:
+            return pageActions.externalAI;
+        case CustomizationPageActionType.Markdown:
+            return pageActions.markdown;
+        case CustomizationPageActionType.Mcp:
+            return pageActions.mcp;
+        case CustomizationPageActionType.Pdf:
+            return customization.pdf.enabled;
+        case CustomizationPageActionType.Git:
+            return customization.git.showEditLink;
+        case CustomizationPageActionType.Assistant:
+            return customization.ai.mode === CustomizationAIMode.Assistant;
+        default:
+            return false;
+    }
 }
 
 /**

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -2,7 +2,11 @@ import type { GitBookSiteContext } from '@/lib/context';
 import type { AncestorRevisionPage } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
 import { getPageRSSURL } from '@/routes/rss';
-import { CustomizationAIMode, type RevisionPageDocument, SiteVisibility } from '@gitbook/api';
+import {
+    CustomizationPageActionType,
+    type RevisionPageDocument,
+    SiteVisibility,
+} from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
 import urlJoin from 'url-join';
 import { getPDFURLSearchParams } from '../PDF';
@@ -31,16 +35,7 @@ export async function PageHeader(props: {
 
     // Show page actions if *any* of the actions are enabled
     const hasPageActions =
-        pageActionsEnabled &&
-        [
-            context.customization.ai.mode === CustomizationAIMode.Assistant,
-            context.customization.pageActions.externalAI,
-            context.customization.pageActions.markdown,
-            context.customization.pageActions.mcp,
-            context.customization.pdf.enabled,
-            context.customization.git.showEditLink,
-            withRSSFeed,
-        ].some(Boolean);
+        pageActionsEnabled && context.customization.pageActions.items.some(Boolean);
 
     if (!page.layout.title && !page.layout.description && !hasPageActions) {
         return null;
@@ -164,13 +159,15 @@ function getPageActionsURLs({
         markdown: `${context.linker.toAbsoluteURL(context.linker.toPathInSpace(page.path))}.md`,
         rss: withRSSFeed ? getPageRSSURL(context, page) : undefined,
         editOnGit:
-            context.customization.git.showEditLink && context.space.gitSync?.url && page.git
+            context.customization.pageActions.items.includes(CustomizationPageActionType.Git) &&
+            context.space.gitSync?.url &&
+            page.git
                 ? {
                       provider: context.space?.gitSync?.installationProvider,
                       url: urlJoin(context.space.gitSync.url, page.git.path),
                   }
                 : undefined,
-        pdf: context.customization.pdf.enabled
+        pdf: context.customization.pageActions.items.includes(CustomizationPageActionType.Pdf)
             ? context.linker.toPathInSpace(
                   `~gitbook/pdf?${getPDFURLSearchParams({
                       page: page.id,


### PR DESCRIPTION
Purposefully kept the LEGACY_PAGE_ACTION_ORDER const around just in case the API does not return `items`