### PR TITLE
Fix empty grouped section dropdown in embedded sites

### DIFF
--- a/.changeset/section-dropdown-embedded-empty.md
+++ b/.changeset/section-dropdown-embedded-empty.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix grouped top-nav section dropdowns rendering empty when the site is embedded in an iframe (visitor-auth embeds, editor preview) or shown in the embeddable view. The dropdown viewport is composited and animated, and a clipped composited layer fails to rasterize its text in Chromium when painted inside a sub compositing root; the rounded-corner clipping is now done on an inner wrapper so the viewport itself is no longer clipped.

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -135,7 +135,8 @@ export function SiteSectionTabs(props: {
                                         >
                                             <div
                                                 className={tcls(
-                                                    'max-h-[calc(100vh-8rem)] w-full overflow-y-auto overflow-x-hidden'
+                                                    // Clip here, not on the viewport (see note below).
+                                                    'max-h-[calc(100vh-8rem)] w-full overflow-y-auto overflow-x-hidden circular-corners:rounded-3xl rounded-corners:rounded-xl'
                                                 )}
                                             >
                                                 <SectionGroupTileList
@@ -173,7 +174,11 @@ export function SiteSectionTabs(props: {
             >
                 <NavigationMenu.Viewport
                     className={tcls(
-                        'relative origin-[center_top] overflow-hidden circular-corners:rounded-3xl rounded-corners:rounded-xl border border-tint bg-tint-base shadow-lg',
+                        // No `overflow-hidden` here: this layer is composited (translateZ) and
+                        // animated, and Chromium fails to paint a clipped composited layer's text
+                        // inside an iframe or `overflow-hidden` ancestor (RND-11448). Clipping is
+                        // done on the inner content wrapper instead.
+                        'relative origin-[center_top] circular-corners:rounded-3xl rounded-corners:rounded-xl border border-tint bg-tint-base shadow-lg',
                         '-mt-0.5 h-(--radix-navigation-menu-viewport-height) w-full max-w-full md:w-(--radix-navigation-menu-viewport-width)',
                         'max-h-[calc(100vh-8rem)] data-[state=closed]:animate-scale-out data-[state=open]:animate-scale-in',
                         'ease has-[&[data-motion]]:transition-[left,width,height] has-[&[data-motion]]:duration-300'

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -133,12 +133,7 @@ export function SiteSectionTabs(props: {
                                                 'data-[motion=from-start]:*:animate-[enterFromLeft_300ms_ease_both] data-[motion=to-end]:*:animate-[exitToRight_300ms_ease_both] data-[motion=to-start]:*:animate-[exitToLeft_300ms_ease_both] motion-safe:data-[motion=from-end]:*:animate-[enterFromRight_300ms_ease_both]',
                                             ])}
                                         >
-                                            <div
-                                                className={tcls(
-                                                    // Clip here, not on the viewport (see note below).
-                                                    'max-h-[calc(100vh-8rem)] w-full overflow-y-auto overflow-x-hidden circular-corners:rounded-3xl rounded-corners:rounded-xl'
-                                                )}
-                                            >
+                                            <div className="max-h-[calc(100vh-8rem)] w-full overflow-y-auto overflow-x-hidden circular-corners:rounded-3xl rounded-corners:rounded-xl">
                                                 <SectionGroupTileList
                                                     items={structureItem.children}
                                                     currentSection={currentSection}
@@ -174,10 +169,8 @@ export function SiteSectionTabs(props: {
             >
                 <NavigationMenu.Viewport
                     className={tcls(
-                        // No `overflow-hidden` here: this layer is composited (translateZ) and
-                        // animated, and Chromium fails to paint a clipped composited layer's text
-                        // inside an iframe or `overflow-hidden` ancestor (RND-11448). Clipping is
-                        // done on the inner content wrapper instead.
+                        // Note: this layer is composited (translateZ) and animated. Chromium fails to paint a clipped composited layer's text
+                        // inside an iframe or `overflow-hidden` ancestor. Clipping is done on the inner content wrapper instead.
                         'relative origin-[center_top] circular-corners:rounded-3xl rounded-corners:rounded-xl border border-tint bg-tint-base shadow-lg',
                         '-mt-0.5 h-(--radix-navigation-menu-viewport-height) w-full max-w-full md:w-(--radix-navigation-menu-viewport-width)',
                         'max-h-[calc(100vh-8rem)] data-[state=closed]:animate-scale-out data-[state=open]:animate-scale-in',


### PR DESCRIPTION
## Overview

- Grouped top-nav section dropdowns rendered empty (items not painted, though present and clickable in the DOM) when the site was embedded in an iframe — visitor-auth embeds, the editor preview — or shown in the embeddable view (`~gitbook/embed/`). Resolves RND-11448.
- Root cause: the dropdown viewport is both composited (the `translateZ` Safari stacking hack) and animated, and it also clipped itself with `overflow: hidden` for its rounded corners. Chromium fails to rasterize a clipped composited layer's text when it's painted inside a sub compositing root — an iframe boundary, or under `overflow: hidden` ancestors — so the menu stayed blank. The site's other dropdowns are unaffected because Radix portals them to `document.body`, escaping those clipping contexts.
- Fix: move the rounded-corner clipping onto the inner content wrapper so the animated viewport is no longer self-clipping. The open/close animation is preserved in every context (embed, iframe, and top-level), and no iframe/embed detection is needed.

## Demo

Embedded view (`~gitbook/embed/`) — the `Group-test` dropdown now shows `Sales`:

<!-- drag screenshot here -->

Published site inside an iframe — same dropdown, now rendering:

<!-- drag screenshot here -->

*— Authored by Claude*
