### PR TITLE
Support per-table search override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -360,7 +360,7 @@
     "react-dom": "catalog:",
   },
   "catalog": {
-    "@gitbook/api": "0.185.0",
+    "@gitbook/api": "0.186.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -756,7 +756,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.185.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-RrFZSHI7W79ri5jHd/gp01ZbuxfOPOFEqnom956wNUfUf/CIQDZcCNzmvLIWzuYesI7Snq3NLi+U5XzOsJhC4g=="],
+    "@gitbook/api": ["@gitbook/api@0.186.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-UAF+tVtstqyA8s9OYXoYhgHfOUQaaQBRjQX4WLEB1YxcYtJZ9YM/EM8Ouj38Tg4qW3tr76t1/OESZipCE6t8cw=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
-            "@gitbook/api": "0.185.0",
+            "@gitbook/api": "0.186.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -1364,8 +1364,6 @@ const testCases: TestsCase[] = [
                 name: 'Without page actions',
                 url: getCustomizationURL({
                     pageActions: {
-                        markdown: false,
-                        externalAI: false,
                         items: [],
                     },
                 }),

--- a/packages/gitbook/e2e/util.ts
+++ b/packages/gitbook/e2e/util.ts
@@ -390,9 +390,6 @@ export function getCustomizationURL(partial: DeepPartial<SiteCustomizationSettin
             default: CustomizationDefaultThemeMode.System,
             toggeable: true,
         },
-        pdf: {
-            enabled: true,
-        },
         feedback: {
             enabled: false,
         },
@@ -405,20 +402,16 @@ export function getCustomizationURL(partial: DeepPartial<SiteCustomizationSettin
         advancedCustomization: {
             enabled: true,
         },
-        git: {
-            showEditLink: false,
-        },
         pagination: {
             enabled: true,
         },
         pageActions: {
-            externalAI: true,
-            markdown: true,
-            mcp: true,
             items: [
+                CustomizationPageActionType.Assistant,
                 CustomizationPageActionType.Markdown,
                 CustomizationPageActionType.ExternalAi,
                 CustomizationPageActionType.Mcp,
+                CustomizationPageActionType.Pdf,
             ],
         },
         trademark: {

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
@@ -20,13 +20,8 @@ export async function handleMcpRequest(
     const { context } = await getDynamicSiteContext(params);
     const { dataFetcher, linker, site } = context;
 
-    // Use the configured `items` list when the API provides it, and fall back to the deprecated
-    // `mcp` flag otherwise (legacy mode), since this endpoint is called directly and cannot rely on
-    // any page-rendering fallback.
     const { pageActions } = context.customization;
-    const isMcpEnabled = pageActions.items
-        ? pageActions.items.includes(CustomizationPageActionType.Mcp)
-        : pageActions.mcp;
+    const isMcpEnabled = pageActions.items.includes(CustomizationPageActionType.Mcp);
     if (!isMcpEnabled) {
         return new Response('Not Found', { status: 404 });
     }

--- a/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
@@ -53,11 +53,7 @@ function getOpenInAIProviders(props: BlockProps<DocumentBlockPrompt>): boolean {
 function isExternalAIPageActionEnabled(
     pageActions: SiteCustomizationSettings['pageActions']
 ): boolean {
-    // Use the configured `items` list when the API provides it, and fall back to the deprecated
-    // `externalAI` flag otherwise (legacy mode).
-    return pageActions.items
-        ? pageActions.items.includes(CustomizationPageActionType.ExternalAi)
-        : pageActions.externalAI;
+    return pageActions.items.includes(CustomizationPageActionType.ExternalAi);
 }
 
 function getPromptText(block: DocumentBlockPrompt): string {

--- a/packages/gitbook/src/components/DocumentView/Table/Table.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/Table.tsx
@@ -16,13 +16,9 @@ import {
     getTableRecordSearchData,
     getTableSelectColumns,
 } from './search';
+import { shouldShowTableSearch } from './shouldShowSearch';
 
 export type { TableRecordKV };
-
-/**
- * Only show the table search once there are enough records that searching is useful.
- */
-const MIN_RECORDS_FOR_SEARCH = 7;
 
 export interface TableViewProps<View> extends BlockProps<DocumentBlockTable> {
     view: View;
@@ -38,10 +34,16 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
         a[1].orderIndex.localeCompare(b[1].orderIndex)
     );
 
-    const showSearch =
-        context.mode !== 'print' &&
-        records.length >= MIN_RECORDS_FOR_SEARCH &&
-        block.data.view.type === 'grid'; // Tables only for now
+    // Authors can override the smart default per block with `search: true | false`; `undefined`
+    // keeps the default (search on grid tables with enough rows, off on cards). See the helper.
+    // TODO: read `block.data.search` directly once the published `@gitbook/api` includes the field.
+    const searchOverride = (block.data as { search?: boolean }).search;
+    const showSearch = shouldShowTableSearch({
+        recordCount: records.length,
+        viewType: block.data.view.type,
+        searchOverride,
+        isPrint: context.mode === 'print',
+    });
     const searchRecords = showSearch
         ? records.map(([id, record]) => ({ id, ...getTableRecordSearchData(block, record) }))
         : [];

--- a/packages/gitbook/src/components/DocumentView/Table/Table.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/Table.tsx
@@ -36,12 +36,10 @@ export function Table(props: BlockProps<DocumentBlockTable>) {
 
     // Authors can override the smart default per block with `search: true | false`; `undefined`
     // keeps the default (search on grid tables with enough rows, off on cards). See the helper.
-    // TODO: read `block.data.search` directly once the published `@gitbook/api` includes the field.
-    const searchOverride = (block.data as { search?: boolean }).search;
     const showSearch = shouldShowTableSearch({
         recordCount: records.length,
         viewType: block.data.view.type,
-        searchOverride,
+        searchOverride: block.data.search,
         isPrint: context.mode === 'print',
     });
     const searchRecords = showSearch

--- a/packages/gitbook/src/components/DocumentView/Table/search.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/search.ts
@@ -18,11 +18,24 @@ export interface TableSelectColumn {
 }
 
 /**
- * List the visible "select" columns of a table along with their options.
+ * All column ids of a table: visible columns first (in view order), then any hidden ones (defined
+ * but not shown). The filter input offers every column, so hidden select/checkbox fields are
+ * filterable too even though they aren't displayed.
+ */
+function getTableColumnIds(block: DocumentBlockTable): string[] {
+    const visible = block.data.view.columns;
+    return [
+        ...visible,
+        ...Object.keys(block.data.definition).filter((id) => !visible.includes(id)),
+    ];
+}
+
+/**
+ * List the "select" columns of a table along with their options, including hidden fields.
  * Used to render the per-column filter dropdowns next to the search input.
  */
 export function getTableSelectColumns(block: DocumentBlockTable): TableSelectColumn[] {
-    return block.data.view.columns.flatMap((column) => {
+    return getTableColumnIds(block).flatMap((column) => {
         const definition = block.data.definition[column];
         if (definition?.type !== 'select') {
             return [];
@@ -40,11 +53,11 @@ export interface TableCheckboxColumn {
 }
 
 /**
- * List the visible "checkbox" columns of a table.
+ * List the "checkbox" columns of a table, including hidden fields.
  * Used to render a filter checkbox per column next to the search input.
  */
 export function getTableCheckboxColumns(block: DocumentBlockTable): TableCheckboxColumn[] {
-    return block.data.view.columns.flatMap((column) => {
+    return getTableColumnIds(block).flatMap((column) => {
         const definition = block.data.definition[column];
         if (definition?.type !== 'checkbox') {
             return [];
@@ -63,10 +76,15 @@ export function getTableRecordSearchData(block: DocumentBlockTable, record: Docu
     const selectValues: Record<string, string[]> = {};
     const checkboxValues: Record<string, boolean> = {};
 
-    for (const column of block.data.view.columns) {
-        const text = getTableCellSearchText(block, record, column);
-        if (text) {
-            searchText.push(text);
+    // Free-text search only covers visible columns; select/checkbox filters also cover hidden
+    // columns, since those are offered in the filter input.
+    const visibleColumns = new Set(block.data.view.columns);
+    for (const column of getTableColumnIds(block)) {
+        if (visibleColumns.has(column)) {
+            const text = getTableCellSearchText(block, record, column);
+            if (text) {
+                searchText.push(text);
+            }
         }
 
         const value = record.values[column];

--- a/packages/gitbook/src/components/DocumentView/Table/shouldShowSearch.test.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/shouldShowSearch.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+
+import { MIN_RECORDS_FOR_SEARCH, shouldShowTableSearch } from './shouldShowSearch';
+
+describe('shouldShowTableSearch', () => {
+    describe('default (no override)', () => {
+        it('shows search on a grid table once it reaches the row threshold', () => {
+            expect(
+                shouldShowTableSearch({
+                    recordCount: MIN_RECORDS_FOR_SEARCH,
+                    viewType: 'grid',
+                    searchOverride: undefined,
+                    isPrint: false,
+                })
+            ).toBe(true);
+        });
+
+        it('hides search on a grid table below the row threshold', () => {
+            expect(
+                shouldShowTableSearch({
+                    recordCount: MIN_RECORDS_FOR_SEARCH - 1,
+                    viewType: 'grid',
+                    searchOverride: undefined,
+                    isPrint: false,
+                })
+            ).toBe(false);
+        });
+
+        it('hides search on cards regardless of row count', () => {
+            expect(
+                shouldShowTableSearch({
+                    recordCount: 100,
+                    viewType: 'cards',
+                    searchOverride: undefined,
+                    isPrint: false,
+                })
+            ).toBe(false);
+        });
+    });
+
+    describe('explicit override', () => {
+        it('forces search on for a small grid table', () => {
+            expect(
+                shouldShowTableSearch({
+                    recordCount: 1,
+                    viewType: 'grid',
+                    searchOverride: true,
+                    isPrint: false,
+                })
+            ).toBe(true);
+        });
+
+        it('forces search on for cards', () => {
+            expect(
+                shouldShowTableSearch({
+                    recordCount: 1,
+                    viewType: 'cards',
+                    searchOverride: true,
+                    isPrint: false,
+                })
+            ).toBe(true);
+        });
+
+        it('forces search off for a large grid table', () => {
+            expect(
+                shouldShowTableSearch({
+                    recordCount: 1000,
+                    viewType: 'grid',
+                    searchOverride: false,
+                    isPrint: false,
+                })
+            ).toBe(false);
+        });
+    });
+
+    it('never shows search when printing, even when forced on', () => {
+        expect(
+            shouldShowTableSearch({
+                recordCount: 1000,
+                viewType: 'grid',
+                searchOverride: true,
+                isPrint: true,
+            })
+        ).toBe(false);
+    });
+});

--- a/packages/gitbook/src/components/DocumentView/Table/shouldShowSearch.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/shouldShowSearch.ts
@@ -1,0 +1,32 @@
+import type { DocumentBlockTable } from '@gitbook/api';
+
+/**
+ * Number of records a grid table needs before the search bar is shown by default.
+ */
+export const MIN_RECORDS_FOR_SEARCH = 7;
+
+/**
+ * Decide whether to render the search bar for a table block.
+ *
+ * Authors can force search on or off per block via `block.data.search`. When that override is left
+ * unset, we fall back to a smart default: search appears on grid tables once they have enough rows,
+ * and stays off on cards. Search is never shown when printing, regardless of the override.
+ */
+export function shouldShowTableSearch(args: {
+    /** Number of records in the table. */
+    recordCount: number;
+    /** The table view type (`grid` or `cards`). */
+    viewType: DocumentBlockTable['data']['view']['type'];
+    /** Explicit per-block override, from `block.data.search`; `undefined` defers to the default. */
+    searchOverride: boolean | undefined;
+    /** Whether the document is being rendered for print/PDF, where search is never shown. */
+    isPrint: boolean;
+}): boolean {
+    if (args.isPrint) {
+        return false;
+    }
+
+    const showByDefault = args.recordCount >= MIN_RECORDS_FOR_SEARCH && args.viewType === 'grid';
+
+    return args.searchOverride ?? showByDefault;
+}

--- a/packages/gitbook/src/components/DocumentView/Table/shouldShowSearch.ts
+++ b/packages/gitbook/src/components/DocumentView/Table/shouldShowSearch.ts
@@ -2,6 +2,10 @@ import type { DocumentBlockTable } from '@gitbook/api';
 
 /**
  * Number of records a grid table needs before the search bar is shown by default.
+ *
+ * Duplicated in `@gitbook/doc-core` (`table/search.ts`) so the editor preview matches this default.
+ * There's no shared module for it — GBO consumes the published `@gitbook/api`, not `doc-core` — so
+ * the two copies must be kept in sync by hand when changing the default behaviour.
  */
 export const MIN_RECORDS_FOR_SEARCH = 7;
 

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -30,27 +30,6 @@ import {
  */
 type PageActionType = `${CustomizationPageActionType}`;
 
-/**
- * Order used to derive the list of actions from the deprecated boolean flags when the API does not
- * provide `items` yet. It matches the order the page actions menu used before the `items` model, so
- * existing sites keep the same dropdown ordering until they are migrated.
- */
-const LEGACY_PAGE_ACTION_ORDER: PageActionType[] = [
-    'assistant',
-    'markdown',
-    'external-ai',
-    'mcp',
-    'git',
-    'pdf',
-];
-
-/**
- * Default-button priority used in legacy mode (no `items`). It reproduces the previous behavior,
- * which only ever surfaced the assistant, the Git edit link or the markdown copy as the default
- * action — never ChatGPT, MCP or PDF.
- */
-const LEGACY_DEFAULT_ACTION_PRIORITY: PageActionType[] = ['assistant', 'git', 'markdown'];
-
 export type PageActionsDropdownURLs = {
     html: string;
     markdown: string;
@@ -88,11 +67,7 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
     const assistants = useAI().assistants.filter(
         (assistant) => assistant.ui === true && assistant.pageAction
     );
-    // `items` is the source of truth when the API provides it. Until then (legacy mode), we derive
-    // the list from the deprecated boolean flags using the previous ordering.
-    const configuredItems = getConfiguredPageActionItems(props.actions);
-    const isLegacy = configuredItems === null;
-    const items = configuredItems ?? deriveLegacyPageActionItems(props.actions);
+    const items = props.actions.items;
 
     let defaultAction: ReactNode = null;
     let markdownIsDefault = false;
@@ -102,12 +77,8 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
         // present, as a contextual override of the configured list.
         defaultAction = <ActionViewAsRSS url={urls.rss} type="button" />;
     } else {
-        // The default button is the first available action. With `items`, that is simply the first
-        // entry of the configured list. In legacy mode we keep the previous default-action priority
-        // (assistant → Git → markdown), so existing sites don't suddenly surface ChatGPT/MCP/PDF.
-        const defaultPriority = isLegacy ? LEGACY_DEFAULT_ACTION_PRIORITY : items;
-        const defaultActionType = defaultPriority.find(
-            (type) => items.includes(type) && isActionTypeAvailable(type, urls, assistants)
+        const defaultActionType = items.find(
+            (type) => items?.includes(type) && isActionTypeAvailable(type, urls, assistants)
         );
         if (defaultActionType) {
             defaultAction = renderDefaultActionForType(defaultActionType, {
@@ -123,17 +94,19 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
     // Build the dropdown menu items, grouped by action type. RSS is appended as its own group
     // since it is not part of the configurable `items` list.
     const groups: { key: string; items: ReactNode[] }[] = items
-        .map((type) => ({
-            key: type,
-            items: renderDropdownActionsForType(type, {
-                siteTitle,
-                urls,
-                markdownIsDefault,
-                assistants,
-                page: props.page,
-            }),
-        }))
-        .filter((group) => group.items.length > 0);
+        ? items
+              .map((type) => ({
+                  key: type,
+                  items: renderDropdownActionsForType(type, {
+                      siteTitle,
+                      urls,
+                      markdownIsDefault,
+                      assistants,
+                      page: props.page,
+                  }),
+              }))
+              .filter((group) => group.items.length > 0)
+        : [];
 
     if (urls.rss) {
         groups.push({
@@ -176,43 +149,6 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
             ) : null}
         </ButtonGroup>
     ) : null;
-}
-
-/**
- * Return the configured ordered list of enabled page actions, or `null` when the API does not
- * provide it yet (legacy mode).
- */
-function getConfiguredPageActionItems(
-    actions: SiteCustomizationSettings['pageActions']
-): PageActionType[] | null {
-    return actions.items ?? null;
-}
-
-/**
- * Derive the ordered list of enabled page actions from the deprecated boolean flags, following the
- * ordering used before the `items` model. Used only when the API does not provide `items`.
- */
-function deriveLegacyPageActionItems(
-    actions: SiteCustomizationSettings['pageActions']
-): PageActionType[] {
-    return LEGACY_PAGE_ACTION_ORDER.filter((type) => {
-        switch (type) {
-            case 'external-ai':
-                return actions.externalAI;
-            case 'markdown':
-                return actions.markdown;
-            case 'mcp':
-                return actions.mcp;
-            // `assistant` is governed by the AI mode setting, and `git`/`pdf` are not represented
-            // by the legacy `pageActions` flags; all three are gated by availability at render time.
-            case 'assistant':
-            case 'git':
-            case 'pdf':
-                return true;
-            default:
-                return false;
-        }
-    });
 }
 
 /**

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -3,7 +3,6 @@ import type { AncestorRevisionPage } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
 import { getPageRSSURL } from '@/routes/rss';
 import {
-    CustomizationAIMode,
     CustomizationPageActionType,
     type RevisionPageDocument,
     SiteVisibility,
@@ -191,9 +190,7 @@ function getPageActionsURLs({
 }
 
 /**
- * Whether a given built-in page action is enabled. Uses the configured `items` list when the API
- * provides it, and falls back to the deprecated boolean flags otherwise (legacy mode), matching the
- * fallback used by the page actions dropdown.
+ * Whether a given built-in page action is enabled.
  */
 function isPageActionEnabled(
     customization: GitBookSiteContext['customization'],
@@ -203,22 +200,7 @@ function isPageActionEnabled(
     if (pageActions.items) {
         return pageActions.items.includes(type);
     }
-    switch (type) {
-        case CustomizationPageActionType.ExternalAi:
-            return pageActions.externalAI;
-        case CustomizationPageActionType.Markdown:
-            return pageActions.markdown;
-        case CustomizationPageActionType.Mcp:
-            return pageActions.mcp;
-        case CustomizationPageActionType.Pdf:
-            return customization.pdf.enabled;
-        case CustomizationPageActionType.Git:
-            return customization.git.showEditLink;
-        case CustomizationPageActionType.Assistant:
-            return customization.ai.mode === CustomizationAIMode.Assistant;
-        default:
-            return false;
-    }
+    return false;
 }
 
 /**

--- a/packages/gitbook/src/lib/utils.ts
+++ b/packages/gitbook/src/lib/utils.ts
@@ -54,9 +54,6 @@ export function defaultCustomization(): api.SiteCustomizationSettings {
             default: api.CustomizationDefaultThemeMode.Light,
             toggeable: true,
         },
-        pdf: {
-            enabled: true,
-        },
         feedback: {
             enabled: false,
         },
@@ -69,20 +66,16 @@ export function defaultCustomization(): api.SiteCustomizationSettings {
         advancedCustomization: {
             enabled: true,
         },
-        git: {
-            showEditLink: false,
-        },
         pagination: {
             enabled: true,
         },
         pageActions: {
-            externalAI: true,
-            markdown: true,
-            mcp: true,
             items: [
+                CustomizationPageActionType.Assistant,
                 CustomizationPageActionType.Markdown,
                 CustomizationPageActionType.ExternalAi,
                 CustomizationPageActionType.Mcp,
+                CustomizationPageActionType.Pdf,
             ],
         },
         trademark: {


### PR DESCRIPTION
## Proposed changes

- Honor the new per-block `search` option on table/card blocks: when an author sets it, it forces the search bar on or off; when it's unset we keep the current smart default (search on grid tables once they hit the row threshold, off on cards).
- Pull the show/hide decision out of `Table.tsx` into a pure `shouldShowTableSearch` helper, with unit tests covering the default, the explicit overrides, and print mode.
- Add support for filtering by hidden fields
- Remove legacy `pageActions` checks to make typing work with the new API.