### PR TITLE
Scrap recommended questions from Search e2e test

### DIFF
--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -185,17 +185,8 @@ const searchTestCases: Test[] = [
             await waitForCookiesDialog(page);
             const searchInput = page.locator('css=[data-testid="search-input"]');
 
-            // Focus search input, expecting recommended questions
-            await searchInput.focus();
-            await expect(page.getByTestId('search-results')).toBeVisible({
-                timeout: 30_000,
-            });
-            const recommendedQuestions = await page
-                .getByTestId('search-recommended-question')
-                .all();
-            await expect(recommendedQuestions.length).toBeGreaterThanOrEqual(1); // Expect at least 1 question
-
             // Fill search input, expecting AI search option
+            await searchInput.focus();
             await searchInput.fill(AI_PROMPT);
             const aiSearchResult = page.getByTestId('search-ask-question');
             await expect(aiSearchResult).toBeVisible();


### PR DESCRIPTION
The recommended questions often time out. While we fix that issue, let's not block CI.