### PR TITLE
Reduce oversized `searchDocumentation` MCP responses

### DIFF
--- a/.changeset/mcp-search-best-section.md
+++ b/.changeset/mcp-search-best-section.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Reduce the size of `searchDocumentation` MCP responses by returning only the best-matching section per page instead of concatenating every section body.

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
@@ -5,6 +5,7 @@ import { getExposableError, throwIfDataError } from '@/lib/data';
 import { getMarkdownForPageInSpace } from '@/lib/markdownPage';
 import { resolvePagePath } from '@/lib/pages';
 import { joinPathWithBaseURL } from '@/lib/paths';
+import { getBestScoredResult } from '@/lib/search';
 import { findSiteSpaceBy, findSiteSpaceByUrl } from '@/lib/sites';
 import { trackServerInsightsEvents } from '@/lib/tracking';
 import { waitUntil } from '@/lib/waitUntil';
@@ -128,9 +129,9 @@ export async function handleMcpRequest(
                                     )
                                 );
 
-                                const body = pageResult.sections
-                                    ?.map((section) => section.body)
-                                    .join('\n');
+                                const body = getBestScoredResult(
+                                    (pageResult.sections ?? []).filter((section) => section.body)
+                                )?.body;
 
                                 return {
                                     type: 'text',

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
@@ -8,6 +8,7 @@ import { throwIfDataError } from '@/lib/data';
 import { toEmbeddableLinkForPublishedContent } from '@/lib/embeddable-linker';
 import { getSiteURLDataFromMiddleware } from '@/lib/middleware';
 import { joinPathWithBaseURL } from '@/lib/paths';
+import { getBestScoredResult } from '@/lib/search';
 import { getServerActionBaseContext } from '@/lib/server-actions';
 import { findSiteSpaceBy, getLocalizedTitle } from '@/lib/sites';
 import type {
@@ -187,10 +188,7 @@ function transformSitePageResult(args: {
             }) ?? [];
 
     // Find the best-scoring section to use as a body preview on the page result.
-    const bestSection = pageSections.reduce<ComputedSectionResult | undefined>(
-        (best, section) => (!best || section.score > best.score ? section : best),
-        undefined
-    );
+    const bestSection = getBestScoredResult(pageSections);
     if (bestSection) {
         page.bestSection = {
             href: bestSection.href,

--- a/packages/gitbook/src/lib/search.ts
+++ b/packages/gitbook/src/lib/search.ts
@@ -1,0 +1,11 @@
+/**
+ * Return the highest-scoring item in the list, or undefined when empty.
+ */
+export function getBestScoredResult<T extends { score: number }>(
+    items: readonly T[]
+): T | undefined {
+    return items.reduce<T | undefined>(
+        (best, item) => (best === undefined || item.score > best.score ? item : best),
+        undefined
+    );
+}


### PR DESCRIPTION
## What

The `searchDocumentation` MCP tool concatenated **every** matched section body of **every** matched page into a single response, which could balloon to very large payloads (~94k tokens observed) and blow up the client's context window.

This returns only the **highest-scoring section per page** as the content preview — the same behavior the site's own search UI already uses (`bestSection`). Each matched page is still returned; only the per-page body is trimmed to its most relevant snippet. The `getPage` MCP tool remains available to fetch full page content when needed.

## Changes

- Extract the "best-scoring result" logic into a shared `getBestScoredResult` helper (`lib/search.ts`) and reuse it in both the MCP handler and the site search route (DRY).
- `searchDocumentation` now emits one best-matching, non-empty section body per page instead of concatenating all sections.