### PR TITLE
Fix centered paragraphs shifting left with the paragraph ask button

### DIFF
--- a/.changeset/fix-ask-button-centered-paragraph.md
+++ b/.changeset/fix-ask-button-centered-paragraph.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix center- and end-aligned paragraphs shifting left on wide/no-TOC pages when the AI Assistant is enabled, caused by the per-paragraph ask-button wrapper not inheriting the block alignment.

--- a/packages/gitbook/src/components/DocumentView/Paragraph.tsx
+++ b/packages/gitbook/src/components/DocumentView/Paragraph.tsx
@@ -33,8 +33,16 @@ export function Paragraph(props: BlockProps<DocumentBlockParagraph>) {
 
     const text = aiAssistantEnabled ? getNodeText(block) : '';
     if (aiAssistantEnabled && text.trim()) {
+        // The wrapper is now the flex child, so it must carry the block alignment (notably
+        // `self-center`/`self-end`) — otherwise centered paragraphs pin left on wide/no-TOC pages.
         return (
-            <div className={tcls('group/ask-ai relative', style)}>
+            <div
+                className={tcls(
+                    'group/ask-ai relative',
+                    style,
+                    getTextAlignment(block.data?.align)
+                )}
+            >
                 {paragraph}
                 <AskAIParagraphButton content={text} />
             </div>


### PR DESCRIPTION
## Overview

Follow-up fix to #4328 (per-paragraph "Ask" button).

- The ask-button wrapper (`div.group/ask-ai`) became the paragraph's flex child, but the block alignment from `getTextAlignment` — `self-center` / `self-end` — was only applied to the inner `<p>`, where `align-self` has no effect. So on wide / no-TOC pages, center- and end-aligned paragraphs pinned to the left.
- Fix: apply `getTextAlignment(block.data?.align)` to the wrapper as well, so the flex child carries the alignment. Left-aligned paragraphs are unchanged.

## Demo

_Before — centered intro pinned left (guides landing):_

<img width="2704" height="872" alt="CleanShot 2026-07-02 at 11 55 33@2x" src="https://github.com/user-attachments/assets/7d9605d7-069b-4a7d-800c-102865f10719" />

_After — intro centered again:_

<img width="2398" height="684" alt="CleanShot 2026-07-02 at 12 10 44@2x" src="https://github.com/user-attachments/assets/41815bab-9713-438d-885f-b38b4d08613f" />

*— Authored by Claude*
