### PR TITLE
Improve language selector on mobile

### DIFF
--- a/packages/gitbook/src/components/Header/Header.tsx
+++ b/packages/gitbook/src/components/Header/Header.tsx
@@ -196,7 +196,7 @@ export async function Header(props: {
                                             ) ?? siteSpace
                                         }
                                         siteSpaces={variants.translations}
-                                        className="flex! site-header:theme-bold:text-header-link hover:site-header:theme-bold:bg-header-link/3 focus-visible:site-header:theme-bold:bg-header-link/3 aria-expanded:site-header:theme-bold:bg-header-link/5"
+                                        className="flex! -mx-3 site-header:theme-bold:text-header-link hover:site-header:theme-bold:bg-header-link/3 focus-visible:site-header:theme-bold:bg-header-link/3 aria-expanded:site-header:theme-bold:bg-header-link/5"
                                     />
                                 ) : null}
                             </HeaderLinks>
@@ -217,7 +217,7 @@ export async function Header(props: {
                                     ) ?? siteSpace
                                 }
                                 siteSpaces={variants.translations}
-                                className="my-1.5 ml-2 self-start"
+                                className="-mx-3 my-1.5 ml-2 self-start"
                             />
                         ) : null}
                     </SiteSectionTabs>

--- a/packages/gitbook/src/components/Header/SpacesDropdown.tsx
+++ b/packages/gitbook/src/components/Header/SpacesDropdown.tsx
@@ -14,15 +14,15 @@ function startsWithEmoji(text: string): boolean {
     return EMOJI_REGEX.test(text);
 }
 
-export function SpacesDropdown(props: {
-    context: GitBookSiteContext;
-    siteSpace: SiteSpace;
-    siteSpaces: SiteSpace[];
-    className?: string;
-    variant?: ButtonProps['variant'];
-    icon?: IconName;
-}) {
-    const { context, siteSpace, siteSpaces, className, variant = 'secondary', icon } = props;
+export function SpacesDropdown(
+    props: {
+        context: GitBookSiteContext;
+        siteSpace: SiteSpace;
+        siteSpaces: SiteSpace[];
+        className?: string;
+    } & ButtonProps
+) {
+    const { context, siteSpace, siteSpaces, className, ...buttonProps } = props;
     const currentLanguage = context.locale;
 
     const dropdownClassName = tcls(
@@ -41,8 +41,8 @@ export function SpacesDropdown(props: {
     return (
         <SpacesDropdownClient
             title={getLocalizedTitle(siteSpace, currentLanguage)}
-            icon={icon}
-            variant={variant}
+            icon={buttonProps.icon as IconName}
+            variant={buttonProps.variant ?? 'secondary'}
             className={className}
             dropdownClassName={dropdownClassName}
             slimSpaces={slimSpaces}
@@ -51,13 +51,15 @@ export function SpacesDropdown(props: {
     );
 }
 
-export function TranslationsDropdown(props: {
-    context: GitBookSiteContext;
-    siteSpace: SiteSpace;
-    siteSpaces: SiteSpace[];
-    className?: string;
-}) {
-    const { context, siteSpace, siteSpaces, className } = props;
+export function TranslationsDropdown(
+    props: {
+        context: GitBookSiteContext;
+        siteSpace: SiteSpace;
+        siteSpaces: SiteSpace[];
+        className?: string;
+    } & ButtonProps
+) {
+    const { context, siteSpace, siteSpaces, className, ...buttonProps } = props;
 
     const title = getLocalizedTitle(siteSpace, context.locale);
     const hasEmojiPrefix = startsWithEmoji(title);
@@ -70,12 +72,13 @@ export function TranslationsDropdown(props: {
             siteSpaces={siteSpaces}
             variant="blank"
             className={tcls(
-                '-mx-3 bg-transparent lg:max-w-64 max-md:[&_.button-content]:hidden',
+                'bg-transparent lg:max-w-64 max-md:[&_.button-content]:hidden',
                 hasEmojiPrefix
                     ? 'md:[&_.button-leading-icon]:hidden' // If the title starts with an emoji, don't show the icon (on desktop)
                     : '',
                 className
             )}
+            {...buttonProps}
         />
     );
 }

--- a/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
+++ b/packages/gitbook/src/components/SpaceLayout/SpaceLayout.tsx
@@ -171,7 +171,7 @@ export function SpaceLayout(props: SpaceLayoutProps) {
                                     // On bold themes also color the TOC header so the logo looks correct.
                                     'site-header:theme-bold:bg-header-background',
                                     'site-header:theme-bold:m-[-1.5rem_-1px_-0.5rem_-2rem]',
-                                    'site-header:theme-bold:p-[1rem_0_1rem_2rem]'
+                                    'site-header:theme-bold:p-[1rem_1rem_1rem_2rem]'
                                 )}
                             >
                                 <HeaderLogo context={context} />
@@ -185,6 +185,7 @@ export function SpaceLayout(props: SpaceLayoutProps) {
                                         }
                                         siteSpaces={variants.translations}
                                         className="[&_.button-leading-icon]:block! ml-auto py-2 [&_.button-content]:hidden"
+                                        variant="header"
                                     />
                                 ) : null}
                             </div>


### PR DESCRIPTION
Makes it easier to pass props into the language selector, and fixes some visual regressions for the language selector on some sites on mobile.

# Before

<img width="1014" height="574" alt="CleanShot 2026-07-03 at 13 26 56@2x" src="https://github.com/user-attachments/assets/77f68996-d541-412a-a5d6-8ff77dce6681" />
<img width="1014" height="574" alt="CleanShot 2026-07-03 at 13 27 07@2x" src="https://github.com/user-attachments/assets/8c60f44c-5b85-40af-a104-2366592adff0" />


# After

<img width="1014" height="574" alt="CleanShot 2026-07-03 at 13 25 00@2x" src="https://github.com/user-attachments/assets/42362a54-402f-40c4-932d-04940e537b8c" />
<img width="918" height="494" alt="CleanShot 2026-07-03 at 13 23 32@2x" src="https://github.com/user-attachments/assets/a8d39896-68d1-4639-b658-0202c99bda9d" />
