### PR TITLE
Refine the per-paragraph ask button (shorter tooltip, hide inside cards)

### DIFF
--- a/.changeset/shorten-paragraph-ask-tooltip.md
+++ b/.changeset/shorten-paragraph-ask-tooltip.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Shorten the per-paragraph AI ask button's tooltip to "Ask" (from "Ask <assistant> about this").

--- a/.changeset/shorten-paragraph-ask-tooltip.md
+++ b/.changeset/shorten-paragraph-ask-tooltip.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Shorten the per-paragraph AI ask button's tooltip to "Ask" (from "Ask <assistant> about this").
+Refine the per-paragraph AI ask button: shorten its tooltip to "Ask" (from "Ask <assistant> about this"), and hide it inside cards where it would otherwise be clipped by the card's overflow.

--- a/packages/gitbook/src/components/AIChat/AskAIParagraphButton/AskAIParagraphButton.tsx
+++ b/packages/gitbook/src/components/AIChat/AskAIParagraphButton/AskAIParagraphButton.tsx
@@ -47,14 +47,16 @@ export function AskAIParagraphButton(props: { content: string; className?: Class
                 // Per-block nudges: `in-[…]` matches an ancestor (tag or class) with no markup
                 // changes elsewhere — add a self-contained rule per block type to clear its gutter.
                 'in-[.hint]:-top-0.5 in-[.hint]:pr-2',
-                'in-[li]:-ml-4',
+                'in-[li]:-left-14',
                 'in-[blockquote]:pr-0',
                 // Hover affordance only: hidden until the paragraph (or the button) is hovered.
                 'invisible opacity-0 transition-opacity duration-150',
                 'hover:visible hover:opacity-100 group-hover/ask-ai:visible group-hover/ask-ai:opacity-100',
                 // Never shown on touch / hover-less contexts.
                 'not-pointer-fine:hidden',
+                // Hidden where an overflow-clipped ancestor would cut it off (tables, record cards).
                 'in-[[role=table]]:hidden',
+                'in-[[data-card]]:hidden',
                 className
             )}
         >

--- a/packages/gitbook/src/components/AIChat/AskAIParagraphButton/AskAIParagraphButton.tsx
+++ b/packages/gitbook/src/components/AIChat/AskAIParagraphButton/AskAIParagraphButton.tsx
@@ -7,7 +7,6 @@ import { Button } from '@/components/primitives';
 import { t, tString, useLanguage } from '@/intl/client';
 import { type ClassValue, tcls } from '@/lib/tailwind';
 
-import { getAIChatName } from '../AIChat';
 import { AIChatIcon } from '../AIChatIcon';
 
 /**
@@ -48,6 +47,7 @@ export function AskAIParagraphButton(props: { content: string; className?: Class
                 // Per-block nudges: `in-[…]` matches an ancestor (tag or class) with no markup
                 // changes elsewhere — add a self-contained rule per block type to clear its gutter.
                 'in-[.hint]:-top-0.5 in-[.hint]:pr-2',
+                'in-[li]:-ml-4',
                 'in-[blockquote]:pr-0',
                 // Hover affordance only: hidden until the paragraph (or the button) is hovered.
                 'invisible opacity-0 transition-opacity duration-150',
@@ -63,11 +63,7 @@ export function AskAIParagraphButton(props: { content: string; className?: Class
                 size="xsmall"
                 iconOnly
                 icon={<AIChatIcon state="default" trademark={config.trademark} />}
-                label={t(
-                    language,
-                    'ai_chat_ask_about_this',
-                    config.assistantName ?? getAIChatName(language, config.trademark)
-                )}
+                label={t(language, 'ask')}
                 onClick={onClick}
                 // Don't steal focus (and shift the scroll position) when clicked with the mouse.
                 onMouseDown={(event) => event.preventDefault()}

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -46,6 +46,9 @@ export async function RecordCard(
 
     const body = (
         <div
+            // Marks the card body so overflow-clipped affordances (e.g. the paragraph "Ask"
+            // button) can opt out of rendering inside it.
+            data-card=""
             className={tcls(
                 'grid-area-1-1',
                 'relative',

--- a/packages/gitbook/src/intl/translations/ar.ts
+++ b/packages/gitbook/src/intl/translations/ar.ts
@@ -147,7 +147,6 @@ export const ar: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'تم استدعاء ${1}',
     ai_chat_ask: 'اسأل ${1}',
     ai_chat_ask_about: 'اسأل ${1} عن ${2}',
-    ai_chat_ask_about_this: 'اسأل ${1} عن هذا',
     this_page: 'هذه الصفحة',
     ai_chat_paragraph_draft: 'أخبرني المزيد عن هذا',
     ai_chat_ask_query: 'اسأل ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/bg.ts
+++ b/packages/gitbook/src/intl/translations/bg.ts
@@ -151,7 +151,6 @@ export const bg: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Извика ${1}',
     ai_chat_ask: 'Попитайте ${1}',
     ai_chat_ask_about: 'Попитайте ${1} за ${2}',
-    ai_chat_ask_about_this: 'Попитайте ${1} за това',
     this_page: 'тази страница',
     ai_chat_paragraph_draft: 'Кажи ми повече за това',
     ai_chat_ask_query: 'Попитайте ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/cs.ts
+++ b/packages/gitbook/src/intl/translations/cs.ts
@@ -149,7 +149,6 @@ export const cs: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Zavolal ${1}',
     ai_chat_ask: 'Zeptat se ${1}',
     ai_chat_ask_about: 'Zeptat se ${1} na ${2}',
-    ai_chat_ask_about_this: 'Zeptat se ${1} na to',
     this_page: 'tuto stránku',
     ai_chat_paragraph_draft: 'Řekni mi o tom více',
     ai_chat_ask_query: 'Zeptat se ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/da.ts
+++ b/packages/gitbook/src/intl/translations/da.ts
@@ -148,7 +148,6 @@ export const da: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Kaldte ${1}',
     ai_chat_ask: 'Spørg ${1}',
     ai_chat_ask_about: 'Spørg ${1} om ${2}',
-    ai_chat_ask_about_this: 'Spørg ${1} om dette',
     this_page: 'denne side',
     ai_chat_paragraph_draft: 'Fortæl mig mere om dette',
     ai_chat_ask_query: 'Spørg ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -155,7 +155,6 @@ export const de: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '${1} aufgerufen',
     ai_chat_ask: '${1} fragen',
     ai_chat_ask_about: '${1} zu ${2} befragen',
-    ai_chat_ask_about_this: '${1} dazu befragen',
     this_page: 'dieser Seite',
     ai_chat_paragraph_draft: 'Erzähl mir mehr darüber',
     copy_for_llms: 'Für LLMs kopieren',

--- a/packages/gitbook/src/intl/translations/el.ts
+++ b/packages/gitbook/src/intl/translations/el.ts
@@ -153,7 +153,6 @@ export const el: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Κλήθηκε ${1}',
     ai_chat_ask: 'Ρωτήστε ${1}',
     ai_chat_ask_about: 'Ρωτήστε ${1} για ${2}',
-    ai_chat_ask_about_this: 'Ρωτήστε ${1} για αυτό',
     this_page: 'αυτή τη σελίδα',
     ai_chat_paragraph_draft: 'Πες μου περισσότερα για αυτό',
     ai_chat_ask_query: 'Ρωτήστε ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/en.ts
+++ b/packages/gitbook/src/intl/translations/en.ts
@@ -146,7 +146,6 @@ export const en = {
     ai_chat_tools_mcp_tool: 'Called ${1}',
     ai_chat_ask: 'Ask ${1}',
     ai_chat_ask_about: 'Ask ${1} about ${2}',
-    ai_chat_ask_about_this: 'Ask ${1} about this',
     ai_chat_ask_query: 'Ask ${1} "${2}"',
     this_page: 'this page',
     ai_chat_paragraph_draft: 'Tell me more about this',

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -153,7 +153,6 @@ export const es: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Llamó a ${1}',
     ai_chat_ask: 'Preguntar a ${1}',
     ai_chat_ask_about: 'Preguntar a ${1} sobre ${2}',
-    ai_chat_ask_about_this: 'Preguntar a ${1} sobre esto',
     this_page: 'esta página',
     ai_chat_paragraph_draft: 'Cuéntame más sobre esto',
     copy_for_llms: 'Copiar para LLMs',

--- a/packages/gitbook/src/intl/translations/et.ts
+++ b/packages/gitbook/src/intl/translations/et.ts
@@ -148,7 +148,6 @@ export const et: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Kutsus ${1}',
     ai_chat_ask: 'Küsi ${1}',
     ai_chat_ask_about: 'Küsi ${1}: ${2}',
-    ai_chat_ask_about_this: 'Küsi ${1} käest selle kohta',
     this_page: 'seda lehte',
     ai_chat_paragraph_draft: 'Räägi mulle sellest lähemalt',
     ai_chat_ask_query: 'Küsi ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/fi.ts
+++ b/packages/gitbook/src/intl/translations/fi.ts
@@ -150,7 +150,6 @@ export const fi: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Kutsuttiin ${1}',
     ai_chat_ask: 'Kysy ${1}',
     ai_chat_ask_about: 'Kysy ${1}: ${2}',
-    ai_chat_ask_about_this: 'Kysy ${1}:lta tästä',
     this_page: 'tätä sivua',
     ai_chat_paragraph_draft: 'Kerro minulle tästä lisää',
     ai_chat_ask_query: 'Kysy ${1}: "${2}"',

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -149,7 +149,6 @@ export const fr: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'A appelé ${1}',
     ai_chat_ask: 'Demander à ${1}',
     ai_chat_ask_about: 'Demander à ${1} à propos de ${2}',
-    ai_chat_ask_about_this: 'Interroger ${1} à ce sujet',
     this_page: 'cette page',
     ai_chat_paragraph_draft: 'En savoir plus à ce sujet',
     copy_for_llms: 'Copier pour un LLM',

--- a/packages/gitbook/src/intl/translations/he.ts
+++ b/packages/gitbook/src/intl/translations/he.ts
@@ -146,7 +146,6 @@ export const he: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'קרא ל-${1}',
     ai_chat_ask: 'שאל את ${1}',
     ai_chat_ask_about: 'שאל את ${1} על ${2}',
-    ai_chat_ask_about_this: 'שאל את ${1} על זה',
     this_page: 'הדף הזה',
     ai_chat_paragraph_draft: 'ספר לי עוד על זה',
     ai_chat_ask_query: 'שאל את ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/hi.ts
+++ b/packages/gitbook/src/intl/translations/hi.ts
@@ -147,7 +147,6 @@ export const hi: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '${1} को कॉल किया',
     ai_chat_ask: '${1} से पूछें',
     ai_chat_ask_about: '${1} से ${2} के बारे में पूछें',
-    ai_chat_ask_about_this: '${1} से इसके बारे में पूछें',
     this_page: 'इस पृष्ठ',
     ai_chat_paragraph_draft: 'इसके बारे में और बताएं',
     ai_chat_ask_query: '${1} से "${2}" पूछें',

--- a/packages/gitbook/src/intl/translations/hr.ts
+++ b/packages/gitbook/src/intl/translations/hr.ts
@@ -149,7 +149,6 @@ export const hr: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Pozvao ${1}',
     ai_chat_ask: 'Pitaj ${1}',
     ai_chat_ask_about: 'Pitaj ${1} o ${2}',
-    ai_chat_ask_about_this: 'Pitaj ${1} o ovome',
     this_page: 'ova stranica',
     ai_chat_paragraph_draft: 'Reci mi više o ovome',
     ai_chat_ask_query: 'Pitaj ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/hu.ts
+++ b/packages/gitbook/src/intl/translations/hu.ts
@@ -150,7 +150,6 @@ export const hu: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '${1} meghívva',
     ai_chat_ask: '${1} kérdezése',
     ai_chat_ask_about: '${1} megkérdezése ${2} témában',
-    ai_chat_ask_about_this: '${1} megkérdezése erről',
     this_page: 'ez az oldal',
     ai_chat_paragraph_draft: 'Mesélj erről többet',
     ai_chat_ask_query: '${1} kérdezése: "${2}"',

--- a/packages/gitbook/src/intl/translations/id.ts
+++ b/packages/gitbook/src/intl/translations/id.ts
@@ -148,7 +148,6 @@ export const id: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Memanggil ${1}',
     ai_chat_ask: 'Tanya ${1}',
     ai_chat_ask_about: 'Tanya ${1} tentang ${2}',
-    ai_chat_ask_about_this: 'Tanya ${1} tentang ini',
     this_page: 'halaman ini',
     ai_chat_paragraph_draft: 'Ceritakan lebih banyak tentang ini',
     ai_chat_ask_query: 'Tanya ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/it.ts
+++ b/packages/gitbook/src/intl/translations/it.ts
@@ -152,7 +152,6 @@ export const it: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Ha chiamato ${1}',
     ai_chat_ask: 'Chiedi a ${1}',
     ai_chat_ask_about: 'Chiedi a ${1} riguardo a ${2}',
-    ai_chat_ask_about_this: 'Chiedi a ${1} riguardo a questo',
     this_page: 'questa pagina',
     ai_chat_paragraph_draft: 'Dimmi di più a riguardo',
     copy_for_llms: 'Copia per LLM',

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -149,7 +149,6 @@ export const ja: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '${1} を呼び出しました',
     ai_chat_ask: '${1} に質問する',
     ai_chat_ask_about: '${1}に${2}について質問する',
-    ai_chat_ask_about_this: '${1}にこれについて質問する',
     this_page: 'このページ',
     ai_chat_paragraph_draft: 'これについてもっと教えて',
     copy_for_llms: 'LLM 用にコピー',

--- a/packages/gitbook/src/intl/translations/ko.ts
+++ b/packages/gitbook/src/intl/translations/ko.ts
@@ -148,7 +148,6 @@ export const ko: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '${1} 호출함',
     ai_chat_ask: '${1}에게 질문',
     ai_chat_ask_about: '${1}에게 ${2}에 대해 질문',
-    ai_chat_ask_about_this: '${1}에게 이에 대해 질문',
     this_page: '이 페이지',
     ai_chat_paragraph_draft: '이것에 대해 더 알려줘',
     copy_for_llms: 'LLM용 복사',

--- a/packages/gitbook/src/intl/translations/lt.ts
+++ b/packages/gitbook/src/intl/translations/lt.ts
@@ -149,7 +149,6 @@ export const lt: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Iškviesta ${1}',
     ai_chat_ask: 'Klausti ${1}',
     ai_chat_ask_about: 'Klausti ${1} apie ${2}',
-    ai_chat_ask_about_this: 'Klausti ${1} apie tai',
     this_page: 'šį puslapį',
     ai_chat_paragraph_draft: 'Papasakok apie tai daugiau',
     ai_chat_ask_query: 'Klausti ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/lv.ts
+++ b/packages/gitbook/src/intl/translations/lv.ts
@@ -147,7 +147,6 @@ export const lv: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Izsauca ${1}',
     ai_chat_ask: 'Jautāt ${1}',
     ai_chat_ask_about: 'Jautāt ${1} par ${2}',
-    ai_chat_ask_about_this: 'Jautāt ${1} par to',
     this_page: 'šo lapu',
     ai_chat_paragraph_draft: 'Pastāsti man par to vairāk',
     ai_chat_ask_query: 'Jautāt ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/ms.ts
+++ b/packages/gitbook/src/intl/translations/ms.ts
@@ -148,7 +148,6 @@ export const ms: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Memanggil ${1}',
     ai_chat_ask: 'Tanya ${1}',
     ai_chat_ask_about: 'Tanya ${1} tentang ${2}',
-    ai_chat_ask_about_this: 'Tanya ${1} tentang ini',
     this_page: 'halaman ini',
     ai_chat_paragraph_draft: 'Beritahu saya lebih lanjut tentang ini',
     ai_chat_ask_query: 'Tanya ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -151,7 +151,6 @@ export const nl: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '${1} aangeroepen',
     ai_chat_ask: 'Vraag het aan ${1}',
     ai_chat_ask_about: 'Stel ${1} een vraag over ${2}',
-    ai_chat_ask_about_this: 'Stel ${1} een vraag hierover',
     this_page: 'deze pagina',
     ai_chat_paragraph_draft: 'Vertel me hier meer over',
     copy_for_llms: 'Kopiëren voor LLMs',

--- a/packages/gitbook/src/intl/translations/no.ts
+++ b/packages/gitbook/src/intl/translations/no.ts
@@ -150,7 +150,6 @@ export const no: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Kalte ${1}',
     ai_chat_ask: 'Spør ${1}',
     ai_chat_ask_about: 'Spør ${1} om ${2}',
-    ai_chat_ask_about_this: 'Spør ${1} om dette',
     this_page: 'denne siden',
     ai_chat_paragraph_draft: 'Fortell meg mer om dette',
     copy_for_llms: 'Kopier for LLMs',

--- a/packages/gitbook/src/intl/translations/pl.ts
+++ b/packages/gitbook/src/intl/translations/pl.ts
@@ -149,7 +149,6 @@ export const pl: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Wywołano ${1}',
     ai_chat_ask: 'Zapytaj ${1}',
     ai_chat_ask_about: 'Zapytaj ${1} o ${2}',
-    ai_chat_ask_about_this: 'Zapytaj ${1} o to',
     this_page: 'tę stronę',
     ai_chat_paragraph_draft: 'Powiedz mi o tym więcej',
     ai_chat_ask_query: 'Zapytaj ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -153,7 +153,6 @@ export const pt_br: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Chamou ${1}',
     ai_chat_ask: 'Perguntar a ${1}',
     ai_chat_ask_about: 'Perguntar a ${1} sobre ${2}',
-    ai_chat_ask_about_this: 'Perguntar a ${1} sobre isso',
     this_page: 'esta página',
     ai_chat_paragraph_draft: 'Conte-me mais sobre isso',
     copy_for_llms: 'Copiar para LLMs',

--- a/packages/gitbook/src/intl/translations/pt.ts
+++ b/packages/gitbook/src/intl/translations/pt.ts
@@ -150,7 +150,6 @@ export const pt: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Chamou ${1}',
     ai_chat_ask: 'Perguntar a ${1}',
     ai_chat_ask_about: 'Perguntar a ${1} sobre ${2}',
-    ai_chat_ask_about_this: 'Perguntar a ${1} sobre isto',
     this_page: 'esta página',
     ai_chat_paragraph_draft: 'Conta-me mais sobre isto',
     ai_chat_ask_query: 'Perguntar a ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/ro.ts
+++ b/packages/gitbook/src/intl/translations/ro.ts
@@ -152,7 +152,6 @@ export const ro: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'A apelat ${1}',
     ai_chat_ask: 'Întreabă ${1}',
     ai_chat_ask_about: 'Întreabă ${1} despre ${2}',
-    ai_chat_ask_about_this: 'Întreabă ${1} despre asta',
     this_page: 'această pagină',
     ai_chat_paragraph_draft: 'Spune-mi mai multe despre asta',
     ai_chat_ask_query: 'Întreabă ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/ru.ts
+++ b/packages/gitbook/src/intl/translations/ru.ts
@@ -152,7 +152,6 @@ export const ru: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Вызван ${1}',
     ai_chat_ask: 'Спросить у ${1}',
     ai_chat_ask_about: 'Спросить у ${1} о ${2}',
-    ai_chat_ask_about_this: 'Спросить у ${1} об этом',
     this_page: 'этой странице',
     ai_chat_paragraph_draft: 'Расскажи мне об этом подробнее',
     copy_for_llms: 'Скопировать для LLM',

--- a/packages/gitbook/src/intl/translations/sk.ts
+++ b/packages/gitbook/src/intl/translations/sk.ts
@@ -151,7 +151,6 @@ export const sk: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Zavolal ${1}',
     ai_chat_ask: 'Opýtať sa ${1}',
     ai_chat_ask_about: 'Opýtať sa ${1} na ${2}',
-    ai_chat_ask_about_this: 'Opýtať sa ${1} na to',
     this_page: 'túto stránku',
     ai_chat_paragraph_draft: 'Povedz mi o tom viac',
     ai_chat_ask_query: 'Opýtať sa ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/sl.ts
+++ b/packages/gitbook/src/intl/translations/sl.ts
@@ -149,7 +149,6 @@ export const sl: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Poklicano ${1}',
     ai_chat_ask: 'Vprašaj ${1}',
     ai_chat_ask_about: 'Vprašaj ${1} o ${2}',
-    ai_chat_ask_about_this: 'Vprašaj ${1} o tem',
     this_page: 'to stran',
     ai_chat_paragraph_draft: 'Povej mi več o tem',
     ai_chat_ask_query: 'Vprašaj ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/sv.ts
+++ b/packages/gitbook/src/intl/translations/sv.ts
@@ -149,7 +149,6 @@ export const sv: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Anropade ${1}',
     ai_chat_ask: 'Fråga ${1}',
     ai_chat_ask_about: 'Fråga ${1} om ${2}',
-    ai_chat_ask_about_this: 'Fråga ${1} om det här',
     this_page: 'den här sidan',
     ai_chat_paragraph_draft: 'Berätta mer om det här',
     ai_chat_ask_query: 'Fråga ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/th.ts
+++ b/packages/gitbook/src/intl/translations/th.ts
@@ -145,7 +145,6 @@ export const th: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'เรียกใช้ ${1}',
     ai_chat_ask: 'ถาม ${1}',
     ai_chat_ask_about: 'ถาม ${1} เกี่ยวกับ ${2}',
-    ai_chat_ask_about_this: 'ถาม ${1} เกี่ยวกับเรื่องนี้',
     this_page: 'หน้านี้',
     ai_chat_paragraph_draft: 'บอกฉันเพิ่มเติมเกี่ยวกับเรื่องนี้',
     ai_chat_ask_query: 'ถาม ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/tr.ts
+++ b/packages/gitbook/src/intl/translations/tr.ts
@@ -147,7 +147,6 @@ export const tr: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '${1} çağrıldı',
     ai_chat_ask: '${1} sor',
     ai_chat_ask_about: '${1} için ${2} hakkında sor',
-    ai_chat_ask_about_this: '${1} için bununla ilgili sor',
     this_page: 'bu sayfa',
     ai_chat_paragraph_draft: 'Bana bundan daha fazla bahset',
     ai_chat_ask_query: '${1} için "${2}" sor',

--- a/packages/gitbook/src/intl/translations/uk.ts
+++ b/packages/gitbook/src/intl/translations/uk.ts
@@ -147,7 +147,6 @@ export const uk: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Викликано ${1}',
     ai_chat_ask: 'Запитати ${1}',
     ai_chat_ask_about: 'Запитати ${1} про ${2}',
-    ai_chat_ask_about_this: 'Запитати ${1} про це',
     this_page: 'цю сторінку',
     ai_chat_paragraph_draft: 'Розкажи мені про це більше',
     ai_chat_ask_query: 'Запитати ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/vi.ts
+++ b/packages/gitbook/src/intl/translations/vi.ts
@@ -147,7 +147,6 @@ export const vi: TranslationLanguage = {
     ai_chat_tools_mcp_tool: 'Đã gọi ${1}',
     ai_chat_ask: 'Hỏi ${1}',
     ai_chat_ask_about: 'Hỏi ${1} về ${2}',
-    ai_chat_ask_about_this: 'Hỏi ${1} về điều này',
     this_page: 'trang này',
     ai_chat_paragraph_draft: 'Cho tôi biết thêm về điều này',
     ai_chat_ask_query: 'Hỏi ${1} "${2}"',

--- a/packages/gitbook/src/intl/translations/yue.ts
+++ b/packages/gitbook/src/intl/translations/yue.ts
@@ -144,7 +144,6 @@ export const yue: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '已呼叫 ${1}',
     ai_chat_ask: '問 ${1}',
     ai_chat_ask_about: '問 ${1} 關於${2}',
-    ai_chat_ask_about_this: '問 ${1} 關於呢樣嘢',
     this_page: '此頁面',
     ai_chat_paragraph_draft: '同我講多啲呢方面嘅嘢',
     ai_chat_ask_query: '問 ${1}「${2}」',

--- a/packages/gitbook/src/intl/translations/zh-tw.ts
+++ b/packages/gitbook/src/intl/translations/zh-tw.ts
@@ -144,7 +144,6 @@ export const zh_tw: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '已呼叫 ${1}',
     ai_chat_ask: '詢問 ${1}',
     ai_chat_ask_about: '詢問 ${1} 關於${2}',
-    ai_chat_ask_about_this: '詢問 ${1} 關於這個',
     this_page: '此頁面',
     ai_chat_paragraph_draft: '告訴我更多相關資訊',
     ai_chat_ask_query: '詢問 ${1}「${2}」',

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -145,7 +145,6 @@ export const zh: TranslationLanguage = {
     ai_chat_tools_mcp_tool: '调用了 ${1}',
     ai_chat_ask: '向 ${1} 提问',
     ai_chat_ask_about: '向 ${1} 询问${2}',
-    ai_chat_ask_about_this: '向 ${1} 询问这个',
     this_page: '此页面',
     ai_chat_paragraph_draft: '告诉我更多相关信息',
     copy_for_llms: '复制供 LLMs 使用',


### PR DESCRIPTION
## Overview

Follow-up refinements to the per-paragraph "Ask" button (#4328).

- **Shorter tooltip** — the icon button's tooltip is now just **"Ask"** (reusing the shared `ask` key, consistent with the text-selection button) instead of "Ask {assistant} about this". Removes the now-unused `ai_chat_ask_about_this` key from all locales.
- **Hide inside cards** — inside record cards (table card view) the absolutely-positioned button was clipped by the card's `overflow: hidden` (a nested absolutely-positioned element can't escape an ancestor's overflow via CSS). The card body is now marked with `data-card` and the button opts out there (`in-[[data-card]]:hidden`), matching how it's already hidden in tables.
- Minor: nudge the button's offset inside list items.

<img width="1742" height="534" alt="CleanShot 2026-07-06 at 12 05 50@2x" src="https://github.com/user-attachments/assets/a32f44f7-dbea-43e9-839f-4d2e2928e24c" />

*— Authored by Claude*
