### PR TITLE
Install eval-estree-expression from npm instead of a GitHub commit

### DIFF
--- a/.changeset/expr-eval-estree-from-npm.md
+++ b/.changeset/expr-eval-estree-from-npm.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/expr": patch
+---
+
+Depend on `eval-estree-expression` from the npm registry (`^3.0.1`) instead of a pinned GitHub commit. The published `3.0.1` release is built from the exact commit the package was pinned to, so the code is unchanged — this only removes the fragile git/tarball dependency so consumers install it from npm like any other package.

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "acorn-walk": "^8.3.4",
         "assert-never": "catalog:",
         "escodegen": "^2.1.0",
-        "eval-estree-expression": "github:jonschlinkert/eval-estree-expression#fb0246a",
+        "eval-estree-expression": "^3.0.1",
       },
       "devDependencies": {
         "@tsconfig/node20": "catalog:",
@@ -2274,7 +2274,7 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
-    "eval-estree-expression": ["eval-estree-expression@github:jonschlinkert/eval-estree-expression#fb0246a", {}, "jonschlinkert-eval-estree-expression-fb0246a"],
+    "eval-estree-expression": ["eval-estree-expression@3.0.1", "", {}, "sha512-zTLKGbiVdQYp4rQkSoXPibrFf5ZoPn6jzExegRLEQ13F+FSxu5iLgaRH6hlDs2kWSUa6vp8yD20cdJi0me6pEw=="],
 
     "event-emitter": ["event-emitter@0.3.5", "", { "dependencies": { "d": "1", "es5-ext": "~0.10.14" } }, "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA=="],
 

--- a/packages/expr/package.json
+++ b/packages/expr/package.json
@@ -16,7 +16,7 @@
         "acorn-walk": "^8.3.4",
         "assert-never": "catalog:",
         "escodegen": "^2.1.0",
-        "eval-estree-expression": "github:jonschlinkert/eval-estree-expression#fb0246a"
+        "eval-estree-expression": "^3.0.1"
     },
     "devDependencies": {
         "@tsconfig/strictest": "catalog:",


### PR DESCRIPTION
## Proposed changes

`@gitbook/expr` depended on `eval-estree-expression` through a pinned GitHub commit (`github:jonschlinkert/eval-estree-expression#fb0246a`) instead of the npm registry. A git/tarball reference is fragile for a published package: every consumer (e.g. `gitbook-x`) has to fetch a GitHub codeload tarball just to install `@gitbook/expr`.

That exact commit is now published to npm as `3.0.1`, so we can depend on it normally:

- `npm view eval-estree-expression@3.0.1 gitHead` → `fb0246a93e45f5d7417c6754424764fee543ecfa` — the commit we were pinned to.
- The published `index.js` + `lib/*.js` are **byte-identical** to the pinned checkout (verified with `npm pack` + `diff`).

This PR swaps the dependency to `^3.0.1`. No source code changes — the build keeps it external (`import evalESTreeExpr from "eval-estree-expression"`), so consumers resolve it from npm like any other dependency. `gitbook-x` can pick up the git dependency removal after the next `@gitbook/expr` release.

**Verified:** `tsc --noEmit`, `bun test` (85 pass / 3 skip / 0 fail — unchanged), and the `tsdown` build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
