### PR TITLE
RND-11788: hide unlabelled button from screen readers

### DIFF
--- a/.changeset/strict-jokes-play.md
+++ b/.changeset/strict-jokes-play.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Hide unfocusable unlabelled button from screen readers

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -172,6 +172,7 @@ function Toggler(props: {
             size="xsmall"
             iconOnly
             variant="blank"
+            aria-hidden="true" // The button has no label or focus so hiding it from screen readers.
             className="-my-0.5 ml-auto min-h-6 min-w-6 text-current hover:bg-tint-base"
             tabIndex={-1} // Prevent focus on the button since it's already inside a clickable link that performs the same toggle action.
         />


### PR DESCRIPTION
The expand button in the nav is not focusable and has no label. Some screen readers ignore it, some announce it as unlabelled button. Adding aria-hidden so it is ignored by screen readers.