### PR TITLE
Keep the page outline and Ask button in view while scrolling API reference pages

### DIFF
--- a/.changeset/sticky-api-page-actions.md
+++ b/.changeset/sticky-api-page-actions.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Keep the "On this page" and "Ask" buttons pinned below the header while scrolling on desktop API reference pages, so the page outline stays reachable throughout long operations.

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -178,10 +178,13 @@ button.openapi-mcp {
 }
 
 .openapi-column-preview {
-    /* Only on the 2-column layout is the preview a sticky pane capped to the viewport so both panels fit
-       (max-height accounts for the top offset + a 1.5rem bottom margin). On mobile (single column) it flows
-       normally, each block bounded by max-h-96, so the response isn't crammed into the viewport. */
-    @apply flex flex-col flex-1 scroll-mt-4 lg:sticky lg:self-start lg:max-h-[calc(100vh-var(--toc-top-offset)-3rem)] lg:top-[calc(var(--toc-top-offset)+1.5rem)];
+    /* Only on the 2-column layout is the preview a sticky pane capped to the viewport so both panels fit.
+       The top offset clears the site header (--toc-top-offset) plus the sticky page-actions bar pinned just
+       below it on desktop API pages (~3rem: its 1rem gap under the header + the button row), landing 4rem
+       down with a small gap beneath the bar. The max-height subtracts that same 4rem top offset plus a
+       1.5rem bottom margin. On mobile (single column) it flows normally, each block bounded by max-h-96, so
+       the response isn't crammed into the viewport. */
+    @apply flex flex-col flex-1 scroll-mt-4 lg:sticky lg:self-start lg:max-h-[calc(100vh-var(--toc-top-offset)-5.5rem)] lg:top-[calc(var(--toc-top-offset)+4rem)];
 }
 
 .openapi-column-preview-body {

--- a/packages/gitbook/src/components/PageBody/PageBody.tsx
+++ b/packages/gitbook/src/components/PageBody/PageBody.tsx
@@ -3,7 +3,13 @@ import type { JSONDocument, RevisionPageDocument, SiteInsightsDisplayContext } f
 
 import { getSpaceLanguage } from '@/intl/server';
 import { t } from '@/intl/translate';
-import { hasFullWidthBlock, hasMoreThan, hasTopLevelBlock, isNodeEmpty } from '@/lib/document';
+import {
+    hasAPIBlock,
+    hasFullWidthBlock,
+    hasMoreThan,
+    hasTopLevelBlock,
+    isNodeEmpty,
+} from '@/lib/document';
 import { getLLMsTxtURL, getPageMarkdownURL } from '@/lib/llms-directive';
 import type { AncestorRevisionPage } from '@/lib/pages';
 import { tcls } from '@/lib/tailwind';
@@ -59,6 +65,10 @@ export async function PageBody(props: {
     // Determine if content should use wide layout (2-column or 1-column instead of 3-column)
     // This happens when: (1) document has full-width blocks, OR (2) page layout is explicitly set to 'wide'
     const wideContent = document ? hasFullWidthBlock(document) : false;
+    // Whether the page has OpenAPI/Swagger blocks — used to scope the sticky, extracted page-actions
+    // to API-reference pages only (matching the `page-api-block` styling), so other pages keep the
+    // header structure untouched.
+    const hasAPIBlocks = document ? hasAPIBlock(document) : false;
     const wideLayout = wideContent || page.layout.width === 'wide';
     const language = await getSpaceLanguage(context);
     const updatedAt = page.updatedAt ?? page.createdAt;
@@ -99,6 +109,7 @@ export async function PageBody(props: {
                     page={page}
                     ancestors={ancestors}
                     withRSSFeed={contentHasUpdates}
+                    hasAPIBlocks={hasAPIBlocks}
                 />
                 {document && !isNodeEmpty(document) ? (
                     <OptionalSuspense

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -138,11 +138,28 @@ export async function PageHeader(props: {
     }
 
     return (
-        <header className={tcls(CONTENT_STYLE, 'mb-6 space-y-3 after:clear-both after:block')}>
+        <>
+            {/* Page actions ("Ask", "On this page"…). Rendered as a sibling of the <header> — i.e. a
+                direct child of the scrolling <main> — rather than inside it, so their sticky
+                containing block is the full-height article instead of the short header. That lets
+                them stay pinned below the site header while scrolling, but only where it matters:
+                desktop API-reference pages (see the `page-api-block:lg:` classes), where the outline
+                collapses to a button and long operations would otherwise scroll it out of reach.
+                Everywhere else they keep flowing (and scrolling away) with the header as before. */}
             <div
                 className={tcls(
                     'float-right ml-4 flex gap-2',
-                    showBreadcrumbs ? '-mb-1 -mt-1.5' : '-mt-3 xs:mt-2'
+                    showBreadcrumbs ? '-mb-1 -mt-1.5' : '-mt-3 xs:mt-2',
+                    'page-api-block:lg:sticky',
+                    // Pin just below the site header; the offset tracks the header height (banner,
+                    // cover…) via the same --toc-top-offset the outline and code samples use.
+                    'page-api-block:lg:top-[calc(var(--toc-top-offset,4rem)+1rem)]',
+                    'page-api-block:lg:z-20',
+                    // When the outline opens as a drawer over this pinned bar (desktop API pages),
+                    // hide the bar so it doesn't overlap the sheet — the sheet has its own header
+                    // and close button. A single body-rooted selector, since `page-api-block`
+                    // (also body-rooted) can't be stacked with another `body…&` variant.
+                    'lg:[body.outline-open:has(.openapi-block)_&]:hidden'
                 )}
             >
                 {hasPageActions ? (
@@ -160,78 +177,86 @@ export async function PageHeader(props: {
                 ) : null}
                 <PageAsideToggleButton />
             </div>
-
-            {showBreadcrumbs && (
-                // Hide the breadcrumbs on wide pages that have no table of contents: there the
-                // content spans the full width with no navigation column, so the crumbs sit stranded.
-                <nav
-                    aria-label="Breadcrumb"
-                    className="layout-wide:page-no-toc:hidden text-tint text-xs leading-relaxed"
-                >
-                    <ol className="inline">
-                        {contextCrumbs.map((crumb, index) => (
-                            <li key={crumb.key} className="inline">
-                                <ContextCrumb crumb={crumb} />
-                                {(index !== contextCrumbs.length - 1 || hasAncestors) && (
-                                    <BreadcrumbSeparator />
-                                )}
-                            </li>
-                        ))}
-                        {ancestors.map((breadcrumb, index) => {
-                            const parentPages = ancestors[index - 1]?.pages ?? revision.pages;
-                            const href = linker.toPathForPage({
-                                pages: revision.pages,
-                                page: breadcrumb,
-                            });
-                            return (
-                                <li key={breadcrumb.id} className="inline">
-                                    <BreadcrumbItemDropdown
-                                        href={href}
-                                        label={breadcrumb.title}
-                                        emoji={breadcrumb.emoji}
-                                        icon={breadcrumb.icon}
-                                        linkClassName={BREADCRUMB_LINK_CLASSES}
-                                        siblings={getPageSiblings(
-                                            context,
-                                            parentPages,
-                                            breadcrumb.id
-                                        )}
-                                    />
-                                    {index !== ancestors.length - 1 && <BreadcrumbSeparator />}
+            <header className={tcls(CONTENT_STYLE, 'mb-6 space-y-3 after:clear-both after:block')}>
+                {showBreadcrumbs && (
+                    // Hide the breadcrumbs on wide pages that have no table of contents: there the
+                    // content spans the full width with no navigation column, so the crumbs sit stranded.
+                    <nav
+                        aria-label="Breadcrumb"
+                        className="layout-wide:page-no-toc:hidden text-tint text-xs leading-relaxed"
+                    >
+                        <ol className="inline">
+                            {contextCrumbs.map((crumb, index) => (
+                                <li key={crumb.key} className="inline">
+                                    <ContextCrumb crumb={crumb} />
+                                    {(index !== contextCrumbs.length - 1 || hasAncestors) && (
+                                        <BreadcrumbSeparator />
+                                    )}
                                 </li>
-                            );
-                        })}
-                    </ol>
-                </nav>
-            )}
-            <PageTags page={page} revision={revision} />
-            {page.layout.title ? (
-                <h1
-                    className={tcls(
-                        'text-2xl',
-                        '@xs:text-3xl',
-                        '@lg:text-4xl',
-                        'leading-tight',
-                        'font-bold',
-                        'flex',
-                        'items-center',
-                        'gap-[.5em]',
-                        'grow',
-                        'text-pretty',
-                        'clear-right',
-                        'xs:clear-none'
-                    )}
-                >
-                    <PageIcon page={page} style={['text-tint-subtle ', 'shrink-0']} />
-                    {page.title}
-                </h1>
-            ) : null}
-            {page.description && page.layout.description ? (
-                <p className={tcls(CONTENT_STYLE_REDUCED, 'text-lg', 'text-tint', 'clear-both')}>
-                    {page.description}
-                </p>
-            ) : null}
-        </header>
+                            ))}
+                            {ancestors.map((breadcrumb, index) => {
+                                const parentPages = ancestors[index - 1]?.pages ?? revision.pages;
+                                const href = linker.toPathForPage({
+                                    pages: revision.pages,
+                                    page: breadcrumb,
+                                });
+                                return (
+                                    <li key={breadcrumb.id} className="inline">
+                                        <BreadcrumbItemDropdown
+                                            href={href}
+                                            label={breadcrumb.title}
+                                            emoji={breadcrumb.emoji}
+                                            icon={breadcrumb.icon}
+                                            linkClassName={BREADCRUMB_LINK_CLASSES}
+                                            siblings={getPageSiblings(
+                                                context,
+                                                parentPages,
+                                                breadcrumb.id
+                                            )}
+                                        />
+                                        {index !== ancestors.length - 1 && <BreadcrumbSeparator />}
+                                    </li>
+                                );
+                            })}
+                        </ol>
+                    </nav>
+                )}
+                <PageTags page={page} revision={revision} />
+                {page.layout.title ? (
+                    <h1
+                        className={tcls(
+                            'text-2xl',
+                            '@xs:text-3xl',
+                            '@lg:text-4xl',
+                            'leading-tight',
+                            'font-bold',
+                            'flex',
+                            'items-center',
+                            'gap-[.5em]',
+                            'grow',
+                            'text-pretty',
+                            'clear-right',
+                            'xs:clear-none'
+                        )}
+                    >
+                        <PageIcon page={page} style={['text-tint-subtle ', 'shrink-0']} />
+                        {page.title}
+                    </h1>
+                ) : null}
+                {page.description && page.layout.description ? (
+                    <p
+                        className={tcls(
+                            CONTENT_STYLE_REDUCED,
+                            'text-lg',
+                            'text-tint',
+                            'clear-both'
+                        )}
+                    >
+                        {page.description}
+                    </p>
+                ) : null}
+            </header>
+        </>
     );
 }
 

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -32,8 +32,14 @@ export async function PageHeader(props: {
     page: RevisionPageDocument;
     ancestors: AncestorRevisionPage[];
     withRSSFeed: boolean;
+    /**
+     * Whether the page has OpenAPI/Swagger blocks. On desktop, such pages get the page-actions
+     * pinned below the site header (see the render below); everywhere else the header is left
+     * exactly as-is.
+     */
+    hasAPIBlocks: boolean;
 }) {
-    const { context, page, ancestors, withRSSFeed } = props;
+    const { context, page, ancestors, withRSSFeed, hasAPIBlocks } = props;
     const { revision, linker } = context;
 
     const hasAncestors = ancestors.length > 0;
@@ -137,129 +143,132 @@ export async function PageHeader(props: {
         return null;
     }
 
-    return (
-        <>
-            {/* Page actions ("Ask", "On this page"…). Rendered as a sibling of the <header> — i.e. a
-                direct child of the scrolling <main> — rather than inside it, so their sticky
-                containing block is the full-height article instead of the short header. That lets
-                them stay pinned below the site header while scrolling, but only where it matters:
-                desktop API-reference pages (see the `page-api-block:lg:` classes), where the outline
-                collapses to a button and long operations would otherwise scroll it out of reach.
-                Everywhere else they keep flowing (and scrolling away) with the header as before. */}
-            <div
-                className={tcls(
-                    'float-right ml-4 flex gap-2',
-                    showBreadcrumbs ? '-mb-1 -mt-1.5' : '-mt-3 xs:mt-2',
+    const pageActions = (
+        <div
+            className={tcls(
+                'float-right ml-4 flex gap-2',
+                showBreadcrumbs ? '-mb-1 -mt-1.5' : '-mt-3 xs:mt-2',
+                // On desktop API pages (where this <div> is rendered as a sibling of <header>, see
+                // below) keep the actions pinned below the site header while scrolling long
+                // operations. The offset tracks the header height (banner, cover…) via the same
+                // --toc-top-offset the outline and code samples use. Hidden while the outline drawer
+                // is open (drawer widths only) so it doesn't overlap the sheet.
+                hasAPIBlocks && [
                     'page-api-block:lg:sticky',
-                    // Pin just below the site header; the offset tracks the header height (banner,
-                    // cover…) via the same --toc-top-offset the outline and code samples use.
                     'page-api-block:lg:top-[calc(var(--toc-top-offset,4rem)+1rem)]',
                     'page-api-block:lg:z-20',
-                    // When the outline opens as a drawer over this pinned bar, hide the bar so it
-                    // doesn't overlap the sheet — the sheet has its own header and close button.
-                    // Bounded to the drawer widths only (lg up to <96rem): at ≥96rem the outline is
-                    // forced inline and its toggle/close controls are hidden, so `outline-open` can
-                    // linger after a resize — the actions must stay visible there. A single
-                    // body-rooted selector, since `page-api-block` (also body-rooted) can't be
-                    // stacked with another `body…&` variant.
-                    'lg:max-[96rem]:[body.outline-open:has(.openapi-block)_&]:hidden'
-                )}
-            >
-                {hasPageActions ? (
-                    <PageActionsDropdown
-                        siteTitle={context.site.title}
-                        urls={getPageActionsURLs({ context, page, withRSSFeed })}
-                        actions={context.customization.pageActions}
-                        page={{
-                            id: page.id,
-                            title: page.title,
-                            path: page.path,
-                            href: linker.toPathForPage({ pages: revision.pages, page }),
-                        }}
-                    />
-                ) : null}
-                <PageAsideToggleButton />
-            </div>
-            <header className={tcls(CONTENT_STYLE, 'mb-6 space-y-3 after:clear-both after:block')}>
-                {showBreadcrumbs && (
-                    // Hide the breadcrumbs on wide pages that have no table of contents: there the
-                    // content spans the full width with no navigation column, so the crumbs sit stranded.
-                    <nav
-                        aria-label="Breadcrumb"
-                        className="layout-wide:page-no-toc:hidden text-tint text-xs leading-relaxed"
-                    >
-                        <ol className="inline">
-                            {contextCrumbs.map((crumb, index) => (
-                                <li key={crumb.key} className="inline">
-                                    <ContextCrumb crumb={crumb} />
-                                    {(index !== contextCrumbs.length - 1 || hasAncestors) && (
-                                        <BreadcrumbSeparator />
-                                    )}
+                    'lg:max-[96rem]:[body.outline-open:has(.openapi-block)_&]:hidden',
+                ]
+            )}
+        >
+            {hasPageActions ? (
+                <PageActionsDropdown
+                    siteTitle={context.site.title}
+                    urls={getPageActionsURLs({ context, page, withRSSFeed })}
+                    actions={context.customization.pageActions}
+                    page={{
+                        id: page.id,
+                        title: page.title,
+                        path: page.path,
+                        href: linker.toPathForPage({ pages: revision.pages, page }),
+                    }}
+                />
+            ) : null}
+            <PageAsideToggleButton />
+        </div>
+    );
+
+    const headerContent = (
+        <>
+            {showBreadcrumbs && (
+                // Hide the breadcrumbs on wide pages that have no table of contents: there the
+                // content spans the full width with no navigation column, so the crumbs sit stranded.
+                <nav
+                    aria-label="Breadcrumb"
+                    className="layout-wide:page-no-toc:hidden text-tint text-xs leading-relaxed"
+                >
+                    <ol className="inline">
+                        {contextCrumbs.map((crumb, index) => (
+                            <li key={crumb.key} className="inline">
+                                <ContextCrumb crumb={crumb} />
+                                {(index !== contextCrumbs.length - 1 || hasAncestors) && (
+                                    <BreadcrumbSeparator />
+                                )}
+                            </li>
+                        ))}
+                        {ancestors.map((breadcrumb, index) => {
+                            const parentPages = ancestors[index - 1]?.pages ?? revision.pages;
+                            const href = linker.toPathForPage({
+                                pages: revision.pages,
+                                page: breadcrumb,
+                            });
+                            return (
+                                <li key={breadcrumb.id} className="inline">
+                                    <BreadcrumbItemDropdown
+                                        href={href}
+                                        label={breadcrumb.title}
+                                        emoji={breadcrumb.emoji}
+                                        icon={breadcrumb.icon}
+                                        linkClassName={BREADCRUMB_LINK_CLASSES}
+                                        siblings={getPageSiblings(
+                                            context,
+                                            parentPages,
+                                            breadcrumb.id
+                                        )}
+                                    />
+                                    {index !== ancestors.length - 1 && <BreadcrumbSeparator />}
                                 </li>
-                            ))}
-                            {ancestors.map((breadcrumb, index) => {
-                                const parentPages = ancestors[index - 1]?.pages ?? revision.pages;
-                                const href = linker.toPathForPage({
-                                    pages: revision.pages,
-                                    page: breadcrumb,
-                                });
-                                return (
-                                    <li key={breadcrumb.id} className="inline">
-                                        <BreadcrumbItemDropdown
-                                            href={href}
-                                            label={breadcrumb.title}
-                                            emoji={breadcrumb.emoji}
-                                            icon={breadcrumb.icon}
-                                            linkClassName={BREADCRUMB_LINK_CLASSES}
-                                            siblings={getPageSiblings(
-                                                context,
-                                                parentPages,
-                                                breadcrumb.id
-                                            )}
-                                        />
-                                        {index !== ancestors.length - 1 && <BreadcrumbSeparator />}
-                                    </li>
-                                );
-                            })}
-                        </ol>
-                    </nav>
-                )}
-                <PageTags page={page} revision={revision} />
-                {page.layout.title ? (
-                    <h1
-                        className={tcls(
-                            'text-2xl',
-                            '@xs:text-3xl',
-                            '@lg:text-4xl',
-                            'leading-tight',
-                            'font-bold',
-                            'flex',
-                            'items-center',
-                            'gap-[.5em]',
-                            'grow',
-                            'text-pretty',
-                            'clear-right',
-                            'xs:clear-none'
-                        )}
-                    >
-                        <PageIcon page={page} style={['text-tint-subtle ', 'shrink-0']} />
-                        {page.title}
-                    </h1>
-                ) : null}
-                {page.description && page.layout.description ? (
-                    <p
-                        className={tcls(
-                            CONTENT_STYLE_REDUCED,
-                            'text-lg',
-                            'text-tint',
-                            'clear-both'
-                        )}
-                    >
-                        {page.description}
-                    </p>
-                ) : null}
-            </header>
+                            );
+                        })}
+                    </ol>
+                </nav>
+            )}
+            <PageTags page={page} revision={revision} />
+            {page.layout.title ? (
+                <h1
+                    className={tcls(
+                        'text-2xl',
+                        '@xs:text-3xl',
+                        '@lg:text-4xl',
+                        'leading-tight',
+                        'font-bold',
+                        'flex',
+                        'items-center',
+                        'gap-[.5em]',
+                        'grow',
+                        'text-pretty',
+                        'clear-right',
+                        'xs:clear-none'
+                    )}
+                >
+                    <PageIcon page={page} style={['text-tint-subtle ', 'shrink-0']} />
+                    {page.title}
+                </h1>
+            ) : null}
+            {page.description && page.layout.description ? (
+                <p className={tcls(CONTENT_STYLE_REDUCED, 'text-lg', 'text-tint', 'clear-both')}>
+                    {page.description}
+                </p>
+            ) : null}
         </>
+    );
+
+    const headerClassName = tcls(CONTENT_STYLE, 'mb-6 space-y-3 after:clear-both after:block');
+
+    // On API pages the actions are pulled out of <header> so their sticky containing block is the
+    // full-height <main> rather than the short header (a sticky element can't outlive its containing
+    // block). Everywhere else they stay inside <header> exactly as before, so those pages render
+    // byte-for-byte identically.
+    return hasAPIBlocks ? (
+        <>
+            {pageActions}
+            <header className={headerClassName}>{headerContent}</header>
+        </>
+    ) : (
+        <header className={headerClassName}>
+            {pageActions}
+            {headerContent}
+        </header>
     );
 }
 

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -155,11 +155,14 @@ export async function PageHeader(props: {
                     // cover…) via the same --toc-top-offset the outline and code samples use.
                     'page-api-block:lg:top-[calc(var(--toc-top-offset,4rem)+1rem)]',
                     'page-api-block:lg:z-20',
-                    // When the outline opens as a drawer over this pinned bar (desktop API pages),
-                    // hide the bar so it doesn't overlap the sheet — the sheet has its own header
-                    // and close button. A single body-rooted selector, since `page-api-block`
-                    // (also body-rooted) can't be stacked with another `body…&` variant.
-                    'lg:[body.outline-open:has(.openapi-block)_&]:hidden'
+                    // When the outline opens as a drawer over this pinned bar, hide the bar so it
+                    // doesn't overlap the sheet — the sheet has its own header and close button.
+                    // Bounded to the drawer widths only (lg up to <96rem): at ≥96rem the outline is
+                    // forced inline and its toggle/close controls are hidden, so `outline-open` can
+                    // linger after a resize — the actions must stay visible there. A single
+                    // body-rooted selector, since `page-api-block` (also body-rooted) can't be
+                    // stacked with another `body…&` variant.
+                    'lg:max-[96rem]:[body.outline-open:has(.openapi-block)_&]:hidden'
                 )}
             >
                 {hasPageActions ? (

--- a/packages/gitbook/src/lib/document.tsx
+++ b/packages/gitbook/src/lib/document.tsx
@@ -37,6 +37,21 @@ export function hasFullWidthBlock(document: JSONDocument): boolean {
 }
 
 /**
+ * Check if the document contains an OpenAPI/Swagger block at the top level.
+ * Mirrors the `page-api-block` CSS variant (`body:has(.openapi-block)`) so server-rendered layout
+ * decisions can be scoped to API-reference pages the same way the styling is.
+ */
+export function hasAPIBlock(document: JSONDocument): boolean {
+    return hasTopLevelBlock(
+        document,
+        (block) =>
+            block.type === 'swagger' ||
+            block.type === 'openapi-operation' ||
+            block.type === 'openapi-webhook'
+    );
+}
+
+/**
  * Check if a top level block matches a predicate.
  */
 export function hasTopLevelBlock(


### PR DESCRIPTION
## Overview

- On desktop **API-reference pages**, the "On this page" outline collapses into a header button. That button — together with the page-actions **"Ask"** button — lived in the page `<header>` and scrolled out of view inside long operations, so readers lost both in-page navigation and the ability to ask partway down a page ([RND-11139](https://linear.app/gitbook/issue/RND-11139)).
- The page-actions row is now pulled out of the short `<header>` so it's a direct child of the scrolling `<main>`. That gives it a full-height sticky containing block, so **it pins just below the site header and stays reachable while scrolling**.
- Scoped to **desktop (`lg:`) API pages (`page-api-block:`) only** — everywhere else the buttons keep flowing (and scrolling away) with the header exactly as before.
- The pinned bar **hides while the outline drawer is open** so it doesn't overlap the sheet (the drawer has its own header + close button).
- The sticky OpenAPI **code-sample offsets are reworked** to clear the new bar: its `top` moves down (`--toc-top-offset + 4rem`) and its `max-height` shrinks to match, preserving the ~1.5rem bottom margin. All offsets key off the existing `--toc-top-offset`, matching the outline and code columns.

## Demo

Reproduced on the GitBook API "Site AI ask" reference page (`/docs/developers/gitbook-api/api-reference/docs-sites/site-ai-ask`).

**Before** — scrolling down into an operation, "On this page" and "Ask" scroll off the top with the page header and become inaccessible (the behavior in the Linear video).

**After** — scrolled deep into the operation:

- **Laptop (≈1280px, `<96rem`):** the "Ask | On this page" bar stays pinned ~16px below the site header; the sticky code sample sits ~19px below it with no overlap. Opening "On this page" now works *while scrolled* — the outline drawer slides in, and the pinned bar hides so it no longer overlaps the sheet.
- **Wide desktop (≈1600px, `≥96rem`):** the outline shows inline in the right aside; the "Ask" bar pins to the top-right of the content column with no overlap between them.
- **Non-API pages & mobile:** unchanged — the actions stay `position: static` and scroll with the header as before.

## Notes for reviewers

- The actions row becomes a `position: sticky` `float-right` child of `<main>`; the `<header>` content (breadcrumbs/title/description) still wraps to its left as before, and clears the float via its existing `after:clear-both`. The large line count in `PageHeader.tsx` is mostly re-indentation from wrapping the return in a fragment.
- The drawer-hide rule is a single body-rooted selector (`lg:[body.outline-open:has(.openapi-block)_&]:hidden`) because `page-api-block` is also body-rooted and can't be stacked with another `body…&` variant.
- Verified at 1280px and 1600px on an API page and on a non-API page; `bun run typecheck` passes with 0 errors and `bun run format` is clean.

*— Authored by Claude*
