### PR TITLE
Let visitors type a follow-up while the Assistant is answering (RND-11789)

### DIFF
--- a/.changeset/assistant-type-while-answering.md
+++ b/.changeset/assistant-type-while-answering.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Assistant: you can now send a follow-up question while an answer is still being written. It's queued with a "will be sent after … finishes" note (and an × to cancel), then sent automatically as soon as the current answer completes.
+Assistant: you can now send follow-up questions while an answer is still being written. Each one appears as your own message with a "Queued" badge (hover for when it will send, × to cancel), and they're sent automatically one at a time as each answer completes.

--- a/.changeset/assistant-type-while-answering.md
+++ b/.changeset/assistant-type-while-answering.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Assistant: you can now start typing a follow-up question while an answer is still being written. The input stays editable during streaming and sends as soon as the answer completes.
+Assistant: you can now send a follow-up question while an answer is still being written. It's queued with a "will be sent after … finishes" note (and an × to cancel), then sent automatically as soon as the current answer completes.

--- a/.changeset/assistant-type-while-answering.md
+++ b/.changeset/assistant-type-while-answering.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Assistant: you can now start typing a follow-up question while an answer is still being written. The input stays editable during streaming and sends as soon as the answer completes.

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -125,11 +125,12 @@ export type AIChatState = {
     draft: string;
 
     /**
-     * A follow-up the visitor submitted while a previous turn was still streaming. It is held
-     * here and sent automatically once the current answer finishes (see the flush in
-     * `streamResponse`), so submitting mid-stream isn't lost. `null` when nothing is queued.
+     * Follow-ups the visitor submitted while a previous turn was still streaming. They are held
+     * here and sent automatically, one at a time in submission order, as each answer finishes
+     * (see the flush in `streamResponse`), so submitting mid-stream isn't lost. Empty when
+     * nothing is queued.
      */
-    queuedMessage: string | null;
+    queuedMessages: string[];
 };
 
 export type AIChatEvent =
@@ -165,8 +166,8 @@ export type AIChatController = {
     focus: () => void;
     /** Pre-fill the chat input with draft text, without sending it. */
     setDraft: (draft: string) => void;
-    /** Remove the follow-up queued to send after the current answer finishes. */
-    cancelQueuedMessage: () => void;
+    /** Remove a follow-up queued to send after the current answer finishes, by its queue index. */
+    cancelQueuedMessage: (index: number) => void;
     /** Register an event listener */
     on: <T extends AIChatEvent['type']>(
         event: T,
@@ -191,7 +192,7 @@ const globalState = zustand.create<AIChatState>(() => {
         initialQuery: null,
         references: [],
         draft: '',
-        queuedMessage: null,
+        queuedMessages: [],
     };
 });
 
@@ -528,14 +529,17 @@ export function AIChatProvider(props: {
                         error: false,
                     }));
 
-                    // The turn is fully settled: send any follow-up the visitor queued while it was
-                    // streaming. Skipped when a control is awaiting input (posting would throw and
-                    // the input is disabled anyway) — it stays queued and flushes after the control
-                    // continuation ends.
-                    const { queuedMessage, control: activeControl } = globalState.getState();
-                    if (queuedMessage !== null && !activeControl) {
-                        globalState.setState((state) => ({ ...state, queuedMessage: null }));
-                        postMessageRef.current?.({ message: queuedMessage });
+                    // The turn is fully settled: send the next follow-up the visitor queued while
+                    // it was streaming (oldest first). Skipped when a control is awaiting input
+                    // (posting would throw and the input is disabled anyway) — they stay queued and
+                    // flush after the control continuation ends. Sending one message starts a new
+                    // turn whose own completion flushes the following one, draining the queue in
+                    // order.
+                    const { queuedMessages, control: activeControl } = globalState.getState();
+                    const [next, ...rest] = queuedMessages;
+                    if (next !== undefined && !activeControl) {
+                        globalState.setState((state) => ({ ...state, queuedMessages: rest }));
+                        postMessageRef.current?.({ message: next });
                     }
                 }
             } catch (error) {
@@ -570,11 +574,14 @@ export function AIChatProvider(props: {
                 throw new Error("We can't post a message when a control is active");
             }
 
-            // A turn is still streaming: queue this follow-up instead of dropping it. It is sent
-            // automatically once the current answer finishes (flushed in `streamResponse`). The
-            // latest submission wins if one is already queued.
+            // A turn is still streaming: queue this follow-up instead of dropping it. Queued
+            // messages are sent automatically, one at a time in submission order, as each answer
+            // finishes (flushed in `streamResponse`).
             if (responding) {
-                globalState.setState((state) => ({ ...state, queuedMessage: input.message }));
+                globalState.setState((state) => ({
+                    ...state,
+                    queuedMessages: [...state.queuedMessages, input.message],
+                }));
                 return;
             }
 
@@ -639,9 +646,14 @@ export function AIChatProvider(props: {
     postMessageRef.current = onPostMessage;
 
     // Remove a follow-up queued while the assistant is still answering (the × on the affordance).
-    const onCancelQueuedMessage = React.useCallback(() => {
+    const onCancelQueuedMessage = React.useCallback((index: number) => {
         globalState.setState((state) =>
-            state.queuedMessage === null ? state : { ...state, queuedMessage: null }
+            index < 0 || index >= state.queuedMessages.length
+                ? state
+                : {
+                      ...state,
+                      queuedMessages: state.queuedMessages.filter((_, i) => i !== index),
+                  }
         );
     }, []);
 
@@ -659,7 +671,7 @@ export function AIChatProvider(props: {
             error: false,
             initialQuery: null,
             references: [],
-            queuedMessage: null,
+            queuedMessages: [],
         }));
 
         // Reset ask parameter to empty string (keeps chat open but clears content)

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -268,9 +268,7 @@ export function AIChatProvider(props: {
         notify(eventsRef.current.get('close'), {});
     }, [setSearchState]);
 
-    // Holds the latest `onPostMessage` so `streamResponse` can flush a queued follow-up once a
-    // turn finishes. A ref avoids a declaration cycle (streamResponse is defined before
-    // onPostMessage) and keeps the callback stable across renders.
+    // Lets `streamResponse` flush a queued follow-up via `onPostMessage`, which is defined later.
     const postMessageRef = React.useRef<((input: { message: string }) => void) | null>(null);
 
     // Stream a message with the AI backend
@@ -529,12 +527,8 @@ export function AIChatProvider(props: {
                         error: false,
                     }));
 
-                    // The turn is fully settled: send the next follow-up the visitor queued while
-                    // it was streaming (oldest first). Skipped when a control is awaiting input
-                    // (posting would throw and the input is disabled anyway) — they stay queued and
-                    // flush after the control continuation ends. Sending one message starts a new
-                    // turn whose own completion flushes the following one, draining the queue in
-                    // order.
+                    // Turn settled: send the next queued follow-up (oldest first). Held back while a
+                    // control is pending, since posting would throw; it flushes after that resolves.
                     const { queuedMessages, control: activeControl } = globalState.getState();
                     const [next, ...rest] = queuedMessages;
                     if (next !== undefined && !activeControl) {
@@ -574,9 +568,7 @@ export function AIChatProvider(props: {
                 throw new Error("We can't post a message when a control is active");
             }
 
-            // A turn is still streaming: queue this follow-up instead of dropping it. Queued
-            // messages are sent automatically, one at a time in submission order, as each answer
-            // finishes (flushed in `streamResponse`).
+            // Still streaming: queue this follow-up instead of dropping it (flushed in order in `streamResponse`).
             if (responding) {
                 globalState.setState((state) => ({
                     ...state,

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -123,6 +123,13 @@ export type AIChatState = {
      * this value (seeding its editable content) and then clears it back to an empty string.
      */
     draft: string;
+
+    /**
+     * A follow-up the visitor submitted while a previous turn was still streaming. It is held
+     * here and sent automatically once the current answer finishes (see the flush in
+     * `streamResponse`), so submitting mid-stream isn't lost. `null` when nothing is queued.
+     */
+    queuedMessage: string | null;
 };
 
 export type AIChatEvent =
@@ -158,6 +165,8 @@ export type AIChatController = {
     focus: () => void;
     /** Pre-fill the chat input with draft text, without sending it. */
     setDraft: (draft: string) => void;
+    /** Remove the follow-up queued to send after the current answer finishes. */
+    cancelQueuedMessage: () => void;
     /** Register an event listener */
     on: <T extends AIChatEvent['type']>(
         event: T,
@@ -182,6 +191,7 @@ const globalState = zustand.create<AIChatState>(() => {
         initialQuery: null,
         references: [],
         draft: '',
+        queuedMessage: null,
     };
 });
 
@@ -256,6 +266,11 @@ export function AIChatProvider(props: {
 
         notify(eventsRef.current.get('close'), {});
     }, [setSearchState]);
+
+    // Holds the latest `onPostMessage` so `streamResponse` can flush a queued follow-up once a
+    // turn finishes. A ref avoids a declaration cycle (streamResponse is defined before
+    // onPostMessage) and keeps the callback stable across renders.
+    const postMessageRef = React.useRef<((input: { message: string }) => void) | null>(null);
 
     // Stream a message with the AI backend
     const streamResponse = React.useCallback(
@@ -512,6 +527,16 @@ export function AIChatProvider(props: {
                         loading: false,
                         error: false,
                     }));
+
+                    // The turn is fully settled: send any follow-up the visitor queued while it was
+                    // streaming. Skipped when a control is awaiting input (posting would throw and
+                    // the input is disabled anyway) — it stays queued and flushes after the control
+                    // continuation ends.
+                    const { queuedMessage, control: activeControl } = globalState.getState();
+                    if (queuedMessage !== null && !activeControl) {
+                        globalState.setState((state) => ({ ...state, queuedMessage: null }));
+                        postMessageRef.current?.({ message: queuedMessage });
+                    }
                 }
             } catch (error) {
                 console.error('Error streaming AI response', error);
@@ -545,8 +570,11 @@ export function AIChatProvider(props: {
                 throw new Error("We can't post a message when a control is active");
             }
 
-            // Ignore duplicates while a previous turn is still streaming
+            // A turn is still streaming: queue this follow-up instead of dropping it. It is sent
+            // automatically once the current answer finishes (flushed in `streamResponse`). The
+            // latest submission wins if one is already queued.
             if (responding) {
+                globalState.setState((state) => ({ ...state, queuedMessage: input.message }));
                 return;
             }
 
@@ -607,6 +635,16 @@ export function AIChatProvider(props: {
         [setSearchState, siteSpaceId, trackEvent, streamResponse]
     );
 
+    // Keep the ref current so `streamResponse` can flush a queued follow-up via the latest callback.
+    postMessageRef.current = onPostMessage;
+
+    // Remove a follow-up queued while the assistant is still answering (the × on the affordance).
+    const onCancelQueuedMessage = React.useCallback(() => {
+        globalState.setState((state) =>
+            state.queuedMessage === null ? state : { ...state, queuedMessage: null }
+        );
+    }, []);
+
     // Clear the conversation and reset ask parameter
     const onClear = React.useCallback(() => {
         globalState.setState((state) => ({
@@ -621,6 +659,7 @@ export function AIChatProvider(props: {
             error: false,
             initialQuery: null,
             references: [],
+            queuedMessage: null,
         }));
 
         // Reset ask parameter to empty string (keeps chat open but clears content)
@@ -704,6 +743,7 @@ export function AIChatProvider(props: {
             clearReferences: onClearReferences,
             focus: onFocus,
             setDraft: onSetDraft,
+            cancelQueuedMessage: onCancelQueuedMessage,
             on: onEvent,
         };
     }, [
@@ -716,6 +756,7 @@ export function AIChatProvider(props: {
         onClearReferences,
         onFocus,
         onSetDraft,
+        onCancelQueuedMessage,
         onEvent,
     ]);
 

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -286,7 +286,7 @@ export function AIChatBody(props: {
                 {chat.control ? <AIChatControl control={chat.control} /> : null}
                 <AIChatInput
                     responding={chat.responding}
-                    disabled={chat.responding || chat.error}
+                    disabled={chat.error}
                     onSubmit={(value) => {
                         chatController.postMessage({ message: value });
                     }}

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -35,6 +35,7 @@ import { AIChatExpandButton } from './AIChatExpandButton';
 import { AIChatIcon } from './AIChatIcon';
 import { AIChatInput } from './AIChatInput';
 import { AIChatMessages } from './AIChatMessages';
+import { AIChatQueuedMessage } from './AIChatQueuedMessage';
 import { AIChatResizeHandle } from './AIChatResizeHandle';
 import AIChatSuggestedQuestions from './AIChatSuggestedQuestions';
 
@@ -284,6 +285,15 @@ export function AIChatBody(props: {
                 {chat.error ? <AIChatError chatController={chatController} /> : null}
 
                 {chat.control ? <AIChatControl control={chat.control} /> : null}
+                {chat.queuedMessage ? (
+                    <AIChatQueuedMessage
+                        message={chat.queuedMessage}
+                        assistantName={
+                            config.assistantName ?? getAIChatName(language, config.trademark)
+                        }
+                        onRemove={chatController.cancelQueuedMessage}
+                    />
+                ) : null}
                 <AIChatInput
                     responding={chat.responding}
                     disabled={chat.error}

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -120,6 +120,7 @@ export function AIChat() {
                             chat={chat}
                             suggestions={config.suggestions}
                             trademark={config.trademark}
+                            assistantName={config.assistantName}
                         />
                     </EmbeddableFrameBody>
                 </EmbeddableFrameMain>
@@ -208,14 +209,17 @@ export function AIChatBody(props: {
     welcomeMessage?: string;
     suggestions?: string[];
     trademark?: boolean;
+    /** Custom assistant name override; falls back to the branded/unbranded default name. */
+    assistantName?: string;
     greeting?: {
         title: string;
         subtitle: string;
     };
 }) {
-    const { chatController, chat, suggestions, greeting, trademark } = props;
+    const { chatController, chat, suggestions, greeting, trademark, assistantName } = props;
 
     const language = useLanguage();
+    const resolvedAssistantName = assistantName ?? getAIChatName(language, trademark ?? true);
     const now = useNow(60 * 60 * 1000); // Refresh every hour for greeting
 
     const isEmpty = !chat.messages.length;
@@ -288,9 +292,7 @@ export function AIChatBody(props: {
                 {chat.queuedMessage ? (
                     <AIChatQueuedMessage
                         message={chat.queuedMessage}
-                        assistantName={
-                            config.assistantName ?? getAIChatName(language, config.trademark)
-                        }
+                        assistantName={resolvedAssistantName}
                         onRemove={chatController.cancelQueuedMessage}
                     />
                 ) : null}

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -285,17 +285,21 @@ export function AIChatBody(props: {
             </ScrollContainer>
 
             <div className="flex max-h-3/4 min-h-0 flex-col gap-2 not-embed:px-4 pb-4">
+                {!chat.error &&
+                    chat.queuedMessages.map((message, index) => (
+                        <AIChatQueuedMessage
+                            // Queue order is stable and items carry no local state, so the index is a
+                            // safe key here.
+                            key={index}
+                            message={message}
+                            assistantName={resolvedAssistantName}
+                            onRemove={() => chatController.cancelQueuedMessage(index)}
+                        />
+                    ))}
                 {/* Display an error banner when something went wrong. */}
                 {chat.error ? <AIChatError chatController={chatController} /> : null}
 
                 {chat.control ? <AIChatControl control={chat.control} /> : null}
-                {chat.queuedMessage ? (
-                    <AIChatQueuedMessage
-                        message={chat.queuedMessage}
-                        assistantName={resolvedAssistantName}
-                        onRemove={chatController.cancelQueuedMessage}
-                    />
-                ) : null}
                 <AIChatInput
                     responding={chat.responding}
                     disabled={chat.error}

--- a/packages/gitbook/src/components/AIChat/AIChatInput.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatInput.tsx
@@ -11,7 +11,8 @@ import { AIChatReferenceChips } from './AIChatReferenceChips';
 export function AIChatInput(props: {
     disabled?: boolean;
     /**
-     * When true, the input is disabled
+     * When true, the assistant is streaming an answer. The field stays editable so a follow-up
+     * can be composed, but submitting is blocked until the answer completes.
      */
     responding: boolean;
     onSubmit: (value: string) => void;
@@ -110,7 +111,8 @@ export function AIChatInput(props: {
                       }
                     : undefined
             }
-            disabled={disabled || responding || chat.control !== null}
+            disabled={disabled || chat.control !== null}
+            submitDisabled={responding}
             aria-busy={responding}
             ref={inputRef}
             header={

--- a/packages/gitbook/src/components/AIChat/AIChatInput.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatInput.tsx
@@ -11,8 +11,8 @@ import { AIChatReferenceChips } from './AIChatReferenceChips';
 export function AIChatInput(props: {
     disabled?: boolean;
     /**
-     * When true, the assistant is streaming an answer. The field stays editable so a follow-up
-     * can be composed, but submitting is blocked until the answer completes.
+     * When true, the assistant is streaming an answer. The field stays editable and submitting a
+     * follow-up queues it (sent automatically once the answer finishes) rather than being blocked.
      */
     responding: boolean;
     onSubmit: (value: string) => void;
@@ -112,7 +112,6 @@ export function AIChatInput(props: {
                     : undefined
             }
             disabled={disabled || chat.control !== null}
-            submitDisabled={responding}
             aria-busy={responding}
             ref={inputRef}
             header={

--- a/packages/gitbook/src/components/AIChat/AIChatQueuedMessage.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatQueuedMessage.tsx
@@ -1,0 +1,41 @@
+import { t, useLanguage } from '@/intl/client';
+import { tcls } from '@/lib/tailwind';
+import { Button } from '../primitives';
+
+/**
+ * Shows the follow-up a visitor submitted while the assistant was still answering, with a note
+ * that it will be sent once the current answer finishes and an × to drop it from the queue.
+ */
+export function AIChatQueuedMessage(props: {
+    message: string;
+    assistantName: string;
+    onRemove: () => void;
+}) {
+    const { message, assistantName, onRemove } = props;
+    const language = useLanguage();
+
+    return (
+        <div
+            className={tcls(
+                'flex items-start gap-2 circular-corners:rounded-2xl rounded-corners:rounded-lg',
+                'border border-tint-subtle bg-tint-base/9 p-2 pl-3 text-sm backdrop-blur-lg'
+            )}
+        >
+            <div className="flex min-w-0 grow flex-col gap-0.5">
+                <span className="truncate text-tint-strong">{message}</span>
+                <span className="text-tint text-xs">
+                    {t(language, 'ai_chat_queued_message', assistantName)}
+                </span>
+            </div>
+            <Button
+                variant="blank"
+                size="small"
+                iconOnly
+                icon="xmark"
+                label={t(language, 'clear')}
+                onClick={onRemove}
+                className="-my-1 -mr-1 shrink-0 text-tint"
+            />
+        </div>
+    );
+}

--- a/packages/gitbook/src/components/AIChat/AIChatQueuedMessage.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatQueuedMessage.tsx
@@ -1,10 +1,13 @@
 import { t, useLanguage } from '@/intl/client';
 import { tcls } from '@/lib/tailwind';
-import { Button } from '../primitives';
+import { Icon } from '@gitbook/icons';
+import { Button, Tooltip } from '../primitives';
 
 /**
- * Shows the follow-up a visitor submitted while the assistant was still answering, with a note
- * that it will be sent once the current answer finishes and an × to drop it from the queue.
+ * Shows a follow-up the visitor submitted while the assistant was still answering. It mirrors a
+ * sent user message — a right-aligned, tinted bubble — so it reads as "theirs", with a clock icon
+ * marking it as pending and a tooltip (on the whole bubble) explaining it will be sent once the
+ * current answer finishes. The × beside the bubble drops it from the queue.
  */
 export function AIChatQueuedMessage(props: {
     message: string;
@@ -15,18 +18,18 @@ export function AIChatQueuedMessage(props: {
     const language = useLanguage();
 
     return (
-        <div
-            className={tcls(
-                'flex items-start gap-2 circular-corners:rounded-2xl rounded-corners:rounded-lg',
-                'border border-tint-subtle bg-tint-base/9 p-2 pl-3 text-sm backdrop-blur-lg'
-            )}
-        >
-            <div className="flex min-w-0 grow flex-col gap-0.5">
-                <span className="truncate text-tint-strong">{message}</span>
-                <span className="text-tint text-xs">
-                    {t(language, 'ai_chat_queued_message', assistantName)}
-                </span>
-            </div>
+        <div className="flex max-w-[80%] origin-top-right animate-scale-in items-center gap-1 self-end">
+            <Tooltip label={t(language, 'ai_chat_queued_message', assistantName)}>
+                <div
+                    className={tcls(
+                        'flex min-w-0 items-center gap-2 circular-corners:rounded-2xl rounded-corners:rounded-md',
+                        'bg-primary-solid/1 px-4 py-2 text-tint'
+                    )}
+                >
+                    <Icon icon="clock" className="size-3.5 shrink-0 text-tint" />
+                    <span className="min-w-0 break-words">{message}</span>
+                </div>
+            </Tooltip>
             <Button
                 variant="blank"
                 size="small"
@@ -34,7 +37,7 @@ export function AIChatQueuedMessage(props: {
                 icon="xmark"
                 label={t(language, 'clear')}
                 onClick={onRemove}
-                className="-my-1 -mr-1 shrink-0 text-tint"
+                className="shrink-0 text-tint"
             />
         </div>
     );

--- a/packages/gitbook/src/components/Embeddable/EmbeddableAIChat.tsx
+++ b/packages/gitbook/src/components/Embeddable/EmbeddableAIChat.tsx
@@ -102,6 +102,7 @@ export function EmbeddableAIChat(props: EmbeddableAIChatProps) {
                             suggestions={siteConfig.suggestions}
                             greeting={siteConfig.greeting}
                             trademark={trademark}
+                            assistantName={siteConfig.assistantName}
                         />
                     </LinkContext>
                 </EmbeddableFrameBody>

--- a/packages/gitbook/src/components/primitives/Input.tsx
+++ b/packages/gitbook/src/components/primitives/Input.tsx
@@ -23,13 +23,6 @@ type CustomInputProps = {
      */
     submitButton?: boolean | ButtonProps;
     /**
-     * When true, the field stays editable but submitting is blocked: pressing Enter or the
-     * submit button does nothing and the typed value is preserved. Distinct from `disabled`,
-     * which also makes the field read-only. Lets callers keep the field usable while a submit
-     * would be premature (e.g. composing an Assistant follow-up while an answer streams).
-     */
-    submitDisabled?: boolean;
-    /**
      * A message to be shown to the right of the input when the value has been submitted.
      */
     submitMessage?: string | ReactNode;
@@ -91,7 +84,6 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
         className,
         clearButton,
         submitButton,
-        submitDisabled,
         submitMessage,
         label,
         keyboardShortcut,
@@ -176,11 +168,6 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
     };
 
     const handleSubmit = () => {
-        // Keep the typed value when submitting is blocked, so the caller can let the field stay
-        // editable (e.g. composing a follow-up) without losing what was typed.
-        if (submitDisabled) {
-            return;
-        }
         if (hasValue && onSubmit) {
             onSubmit(value);
             setSubmitted(true);
@@ -380,7 +367,7 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
                             label={tString(language, 'submit')}
                             onClick={handleSubmit}
                             icon={multiline ? undefined : 'arrow-right'}
-                            disabled={disabled || submitDisabled || !hasValidValue}
+                            disabled={disabled || !hasValidValue}
                             iconOnly={!multiline}
                             className={tcls(
                                 'ml-auto',

--- a/packages/gitbook/src/components/primitives/Input.tsx
+++ b/packages/gitbook/src/components/primitives/Input.tsx
@@ -195,9 +195,7 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
     };
 
     const inputClassName = tcls(
-        // Note: `aria-busy` intentionally does NOT change the cursor here — a busy field can still
-        // be editable (e.g. composing a follow-up while the Assistant streams), and a progress
-        // cursor made it look disabled. Read-only state is conveyed by `disabled` instead.
+        // `aria-busy` must not change the cursor: a busy field can still be editable.
         'peer -m-2 max-h-64 grow shrink resize-none leading-normal text-left outline-none placeholder:text-tint/8 placeholder-shown:text-ellipsis',
         sizes[sizing].input
     );

--- a/packages/gitbook/src/components/primitives/Input.tsx
+++ b/packages/gitbook/src/components/primitives/Input.tsx
@@ -208,7 +208,10 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
     };
 
     const inputClassName = tcls(
-        'peer -m-2 max-h-64 grow shrink resize-none leading-normal text-left outline-none placeholder:text-tint/8 placeholder-shown:text-ellipsis aria-busy:cursor-progress',
+        // Note: `aria-busy` intentionally does NOT change the cursor here — a busy field can still
+        // be editable (e.g. composing a follow-up while the Assistant streams), and a progress
+        // cursor made it look disabled. Read-only state is conveyed by `disabled` instead.
+        'peer -m-2 max-h-64 grow shrink resize-none leading-normal text-left outline-none placeholder:text-tint/8 placeholder-shown:text-ellipsis',
         sizes[sizing].input
     );
 
@@ -241,7 +244,6 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
                           'focus-within:border-primary-hover focus-within:depth-subtle:shadow-lg focus-within:shadow-primary-subtle focus-within:ring-2 hover:not-has-[button:hover]:cursor-text hover:not-has-[button:hover]:border-tint-hover hover:not-has-[button:hover]:not-focus-within:bg-tint-subtle depth-subtle:hover:not-has-[button:hover]:not-focus-within:shadow-md focus-within:hover:not-has-[button:hover]:border-primary-hover',
                       ],
                 multiline ? 'flex-col' : 'flex-row',
-                ariaBusy ? 'cursor-progress' : '',
                 sizes[sizing].container,
                 className
             )}

--- a/packages/gitbook/src/components/primitives/Input.tsx
+++ b/packages/gitbook/src/components/primitives/Input.tsx
@@ -23,6 +23,13 @@ type CustomInputProps = {
      */
     submitButton?: boolean | ButtonProps;
     /**
+     * When true, the field stays editable but submitting is blocked: pressing Enter or the
+     * submit button does nothing and the typed value is preserved. Distinct from `disabled`,
+     * which also makes the field read-only. Lets callers keep the field usable while a submit
+     * would be premature (e.g. composing an Assistant follow-up while an answer streams).
+     */
+    submitDisabled?: boolean;
+    /**
      * A message to be shown to the right of the input when the value has been submitted.
      */
     submitMessage?: string | ReactNode;
@@ -84,6 +91,7 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
         className,
         clearButton,
         submitButton,
+        submitDisabled,
         submitMessage,
         label,
         keyboardShortcut,
@@ -168,6 +176,11 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
     };
 
     const handleSubmit = () => {
+        // Keep the typed value when submitting is blocked, so the caller can let the field stay
+        // editable (e.g. composing a follow-up) without losing what was typed.
+        if (submitDisabled) {
+            return;
+        }
         if (hasValue && onSubmit) {
             onSubmit(value);
             setSubmitted(true);
@@ -365,7 +378,7 @@ export const Input = React.forwardRef<InputElement, InputProps>((props, passedRe
                             label={tString(language, 'submit')}
                             onClick={handleSubmit}
                             icon={multiline ? undefined : 'arrow-right'}
-                            disabled={disabled || !hasValidValue}
+                            disabled={disabled || submitDisabled || !hasValidValue}
                             iconOnly={!multiline}
                             className={tcls(
                                 'ml-auto',

--- a/packages/gitbook/src/intl/translations/ar.ts
+++ b/packages/gitbook/src/intl/translations/ar.ts
@@ -133,7 +133,7 @@ export const ar: TranslationLanguage = {
     ai_chat_context_previous_messages: 'الرسائل في محادثتك',
     ai_chat_context_disclaimer: 'قد تحتوي إجابات الذكاء الاصطناعي على أخطاء.',
     ai_chat_input_placeholder: 'اسأل أو ابحث أو اشرح...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'سيتم إرسال هذه الرسالة بعد أن ينتهي ${1}',
     send: 'إرسال',
     actions: 'إجراءات',
     ai_chat_suggested_questions_title: 'أسئلة مقترحة',

--- a/packages/gitbook/src/intl/translations/ar.ts
+++ b/packages/gitbook/src/intl/translations/ar.ts
@@ -133,6 +133,7 @@ export const ar: TranslationLanguage = {
     ai_chat_context_previous_messages: 'الرسائل في محادثتك',
     ai_chat_context_disclaimer: 'قد تحتوي إجابات الذكاء الاصطناعي على أخطاء.',
     ai_chat_input_placeholder: 'اسأل أو ابحث أو اشرح...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'إرسال',
     actions: 'إجراءات',
     ai_chat_suggested_questions_title: 'أسئلة مقترحة',

--- a/packages/gitbook/src/intl/translations/bg.ts
+++ b/packages/gitbook/src/intl/translations/bg.ts
@@ -137,7 +137,7 @@ export const bg: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Съобщения във вашия разговор',
     ai_chat_context_disclaimer: 'AI отговорите може да съдържат грешки.',
     ai_chat_input_placeholder: 'Попитайте, потърсете или обяснете...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Това съобщение ще бъде изпратено, след като ${1} приключи',
     send: 'Изпращане',
     actions: 'Действия',
     ai_chat_suggested_questions_title: 'Предложени въпроси',

--- a/packages/gitbook/src/intl/translations/bg.ts
+++ b/packages/gitbook/src/intl/translations/bg.ts
@@ -137,6 +137,7 @@ export const bg: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Съобщения във вашия разговор',
     ai_chat_context_disclaimer: 'AI отговорите може да съдържат грешки.',
     ai_chat_input_placeholder: 'Попитайте, потърсете или обяснете...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Изпращане',
     actions: 'Действия',
     ai_chat_suggested_questions_title: 'Предложени въпроси',

--- a/packages/gitbook/src/intl/translations/cs.ts
+++ b/packages/gitbook/src/intl/translations/cs.ts
@@ -135,6 +135,7 @@ export const cs: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Zprávy ve vaší konverzaci',
     ai_chat_context_disclaimer: 'Odpovědi AI mohou obsahovat chyby.',
     ai_chat_input_placeholder: 'Zeptejte se, hledejte nebo vysvětlete...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Odeslat',
     actions: 'Akce',
     ai_chat_suggested_questions_title: 'Navrhované otázky',

--- a/packages/gitbook/src/intl/translations/cs.ts
+++ b/packages/gitbook/src/intl/translations/cs.ts
@@ -135,7 +135,7 @@ export const cs: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Zprávy ve vaší konverzaci',
     ai_chat_context_disclaimer: 'Odpovědi AI mohou obsahovat chyby.',
     ai_chat_input_placeholder: 'Zeptejte se, hledejte nebo vysvětlete...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Tato zpráva se odešle, až ${1} dokončí odpověď',
     send: 'Odeslat',
     actions: 'Akce',
     ai_chat_suggested_questions_title: 'Navrhované otázky',

--- a/packages/gitbook/src/intl/translations/da.ts
+++ b/packages/gitbook/src/intl/translations/da.ts
@@ -134,7 +134,7 @@ export const da: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Beskeder i din samtale',
     ai_chat_context_disclaimer: 'AI-svar kan indeholde fejl.',
     ai_chat_input_placeholder: 'Spørg, søg eller forklar...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Denne besked sendes, når ${1} er færdig',
     send: 'Send',
     actions: 'Handlinger',
     ai_chat_suggested_questions_title: 'Foreslåede spørgsmål',

--- a/packages/gitbook/src/intl/translations/da.ts
+++ b/packages/gitbook/src/intl/translations/da.ts
@@ -134,6 +134,7 @@ export const da: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Beskeder i din samtale',
     ai_chat_context_disclaimer: 'AI-svar kan indeholde fejl.',
     ai_chat_input_placeholder: 'Spørg, søg eller forklar...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Send',
     actions: 'Handlinger',
     ai_chat_suggested_questions_title: 'Foreslåede spørgsmål',

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -141,7 +141,7 @@ export const de: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Nachrichten in Ihrem Gespräch',
     ai_chat_context_disclaimer: 'KI-Antworten können Fehler enthalten.',
     ai_chat_input_placeholder: 'Fragen, suchen oder erklären...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Diese Nachricht wird gesendet, sobald ${1} fertig ist',
     send: 'Senden',
     actions: 'Aktionen',
     ai_chat_suggested_questions_title: 'Vorgeschlagene Fragen',

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -141,6 +141,7 @@ export const de: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Nachrichten in Ihrem Gespräch',
     ai_chat_context_disclaimer: 'KI-Antworten können Fehler enthalten.',
     ai_chat_input_placeholder: 'Fragen, suchen oder erklären...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Senden',
     actions: 'Aktionen',
     ai_chat_suggested_questions_title: 'Vorgeschlagene Fragen',

--- a/packages/gitbook/src/intl/translations/el.ts
+++ b/packages/gitbook/src/intl/translations/el.ts
@@ -139,7 +139,7 @@ export const el: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Μηνύματα στη συνομιλία σας',
     ai_chat_context_disclaimer: 'Οι απαντήσεις AI μπορεί να περιέχουν λάθη.',
     ai_chat_input_placeholder: 'Ρωτήστε, αναζητήστε ή εξηγήστε...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Αυτό το μήνυμα θα σταλεί μόλις ολοκληρώσει ${1}',
     send: 'Αποστολή',
     actions: 'Ενέργειες',
     ai_chat_suggested_questions_title: 'Προτεινόμενες ερωτήσεις',

--- a/packages/gitbook/src/intl/translations/el.ts
+++ b/packages/gitbook/src/intl/translations/el.ts
@@ -139,6 +139,7 @@ export const el: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Μηνύματα στη συνομιλία σας',
     ai_chat_context_disclaimer: 'Οι απαντήσεις AI μπορεί να περιέχουν λάθη.',
     ai_chat_input_placeholder: 'Ρωτήστε, αναζητήστε ή εξηγήστε...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Αποστολή',
     actions: 'Ενέργειες',
     ai_chat_suggested_questions_title: 'Προτεινόμενες ερωτήσεις',

--- a/packages/gitbook/src/intl/translations/en.ts
+++ b/packages/gitbook/src/intl/translations/en.ts
@@ -132,6 +132,7 @@ export const en = {
     ai_chat_context_previous_messages: 'Messages in your conversation',
     ai_chat_context_disclaimer: 'AI responses may contain mistakes.',
     ai_chat_input_placeholder: 'Ask, search, or explain...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Send',
     actions: 'Actions',
     ai_chat_suggested_questions_title: 'Suggested questions',

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -139,7 +139,7 @@ export const es: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mensajes de tu conversación',
     ai_chat_context_disclaimer: 'Las respuestas de IA pueden contener errores.',
     ai_chat_input_placeholder: 'Pregunta, busca o explica...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Este mensaje se enviará cuando ${1} termine',
     send: 'Enviar',
     actions: 'Acciones',
     ai_chat_suggested_questions_title: 'Preguntas sugeridas',

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -139,6 +139,7 @@ export const es: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mensajes de tu conversación',
     ai_chat_context_disclaimer: 'Las respuestas de IA pueden contener errores.',
     ai_chat_input_placeholder: 'Pregunta, busca o explica...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Enviar',
     actions: 'Acciones',
     ai_chat_suggested_questions_title: 'Preguntas sugeridas',

--- a/packages/gitbook/src/intl/translations/et.ts
+++ b/packages/gitbook/src/intl/translations/et.ts
@@ -134,6 +134,7 @@ export const et: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Teie vestluse sõnumid',
     ai_chat_context_disclaimer: 'AI vastused võivad sisaldada vigu.',
     ai_chat_input_placeholder: 'Küsige, otsige või selgitage...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Saada',
     actions: 'Toimingud',
     ai_chat_suggested_questions_title: 'Soovitatud küsimused',

--- a/packages/gitbook/src/intl/translations/et.ts
+++ b/packages/gitbook/src/intl/translations/et.ts
@@ -134,7 +134,7 @@ export const et: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Teie vestluse sõnumid',
     ai_chat_context_disclaimer: 'AI vastused võivad sisaldada vigu.',
     ai_chat_input_placeholder: 'Küsige, otsige või selgitage...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'See sõnum saadetakse, kui ${1} on lõpetanud',
     send: 'Saada',
     actions: 'Toimingud',
     ai_chat_suggested_questions_title: 'Soovitatud küsimused',

--- a/packages/gitbook/src/intl/translations/fi.ts
+++ b/packages/gitbook/src/intl/translations/fi.ts
@@ -136,7 +136,7 @@ export const fi: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Viestit keskustelussasi',
     ai_chat_context_disclaimer: 'AI-vastaukset voivat sisältää virheitä.',
     ai_chat_input_placeholder: 'Kysy, hae tai selitä...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Tämä viesti lähetetään, kun ${1} on valmis',
     send: 'Lähetä',
     actions: 'Toiminnot',
     ai_chat_suggested_questions_title: 'Ehdotetut kysymykset',

--- a/packages/gitbook/src/intl/translations/fi.ts
+++ b/packages/gitbook/src/intl/translations/fi.ts
@@ -136,6 +136,7 @@ export const fi: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Viestit keskustelussasi',
     ai_chat_context_disclaimer: 'AI-vastaukset voivat sisältää virheitä.',
     ai_chat_input_placeholder: 'Kysy, hae tai selitä...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Lähetä',
     actions: 'Toiminnot',
     ai_chat_suggested_questions_title: 'Ehdotetut kysymykset',

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -135,6 +135,7 @@ export const fr: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Messages de votre conversation',
     ai_chat_context_disclaimer: 'Les réponses générées peuvent contenir des erreurs.',
     ai_chat_input_placeholder: 'Demander, rechercher ou expliquer...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Envoyer',
     actions: 'Actions',
     ai_chat_suggested_questions_title: 'Suggestions de questions',

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -135,7 +135,7 @@ export const fr: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Messages de votre conversation',
     ai_chat_context_disclaimer: 'Les réponses générées peuvent contenir des erreurs.',
     ai_chat_input_placeholder: 'Demander, rechercher ou expliquer...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Ce message sera envoyé une fois que ${1} aura terminé',
     send: 'Envoyer',
     actions: 'Actions',
     ai_chat_suggested_questions_title: 'Suggestions de questions',

--- a/packages/gitbook/src/intl/translations/he.ts
+++ b/packages/gitbook/src/intl/translations/he.ts
@@ -132,6 +132,7 @@ export const he: TranslationLanguage = {
     ai_chat_context_previous_messages: 'הודעות בשיחה שלך',
     ai_chat_context_disclaimer: 'תשובות AI עשויות להכיל טעויות.',
     ai_chat_input_placeholder: 'שאל, חפש או הסבר...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'שליחה',
     actions: 'פעולות',
     ai_chat_suggested_questions_title: 'שאלות מוצעות',

--- a/packages/gitbook/src/intl/translations/he.ts
+++ b/packages/gitbook/src/intl/translations/he.ts
@@ -132,7 +132,7 @@ export const he: TranslationLanguage = {
     ai_chat_context_previous_messages: 'הודעות בשיחה שלך',
     ai_chat_context_disclaimer: 'תשובות AI עשויות להכיל טעויות.',
     ai_chat_input_placeholder: 'שאל, חפש או הסבר...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'הודעה זו תישלח לאחר ש-${1} יסיים',
     send: 'שליחה',
     actions: 'פעולות',
     ai_chat_suggested_questions_title: 'שאלות מוצעות',

--- a/packages/gitbook/src/intl/translations/hi.ts
+++ b/packages/gitbook/src/intl/translations/hi.ts
@@ -133,6 +133,7 @@ export const hi: TranslationLanguage = {
     ai_chat_context_previous_messages: 'आपकी बातचीत के संदेश',
     ai_chat_context_disclaimer: 'AI उत्तरों में गलतियां हो सकती हैं।',
     ai_chat_input_placeholder: 'पूछें, खोजें या समझाएं...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'भेजें',
     actions: 'कार्रवाइयां',
     ai_chat_suggested_questions_title: 'सुझाए गए प्रश्न',

--- a/packages/gitbook/src/intl/translations/hi.ts
+++ b/packages/gitbook/src/intl/translations/hi.ts
@@ -133,7 +133,7 @@ export const hi: TranslationLanguage = {
     ai_chat_context_previous_messages: 'आपकी बातचीत के संदेश',
     ai_chat_context_disclaimer: 'AI उत्तरों में गलतियां हो सकती हैं।',
     ai_chat_input_placeholder: 'पूछें, खोजें या समझाएं...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'यह संदेश ${1} के समाप्त होने के बाद भेजा जाएगा',
     send: 'भेजें',
     actions: 'कार्रवाइयां',
     ai_chat_suggested_questions_title: 'सुझाए गए प्रश्न',

--- a/packages/gitbook/src/intl/translations/hr.ts
+++ b/packages/gitbook/src/intl/translations/hr.ts
@@ -135,6 +135,7 @@ export const hr: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Poruke u vašem razgovoru',
     ai_chat_context_disclaimer: 'AI odgovori mogu sadržavati pogreške.',
     ai_chat_input_placeholder: 'Pitajte, pretražite ili objasnite...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Pošalji',
     actions: 'Radnje',
     ai_chat_suggested_questions_title: 'Predložena pitanja',

--- a/packages/gitbook/src/intl/translations/hr.ts
+++ b/packages/gitbook/src/intl/translations/hr.ts
@@ -135,7 +135,7 @@ export const hr: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Poruke u vašem razgovoru',
     ai_chat_context_disclaimer: 'AI odgovori mogu sadržavati pogreške.',
     ai_chat_input_placeholder: 'Pitajte, pretražite ili objasnite...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Ova poruka bit će poslana kada ${1} završi',
     send: 'Pošalji',
     actions: 'Radnje',
     ai_chat_suggested_questions_title: 'Predložena pitanja',

--- a/packages/gitbook/src/intl/translations/hu.ts
+++ b/packages/gitbook/src/intl/translations/hu.ts
@@ -136,6 +136,7 @@ export const hu: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Üzenetek a beszélgetésében',
     ai_chat_context_disclaimer: 'Az AI-válaszok hibákat tartalmazhatnak.',
     ai_chat_input_placeholder: 'Kérdezzen, keressen vagy magyarázzon...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Küldés',
     actions: 'Műveletek',
     ai_chat_suggested_questions_title: 'Javasolt kérdések',

--- a/packages/gitbook/src/intl/translations/hu.ts
+++ b/packages/gitbook/src/intl/translations/hu.ts
@@ -136,7 +136,7 @@ export const hu: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Üzenetek a beszélgetésében',
     ai_chat_context_disclaimer: 'Az AI-válaszok hibákat tartalmazhatnak.',
     ai_chat_input_placeholder: 'Kérdezzen, keressen vagy magyarázzon...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Ez az üzenet akkor lesz elküldve, amikor ${1} befejezi',
     send: 'Küldés',
     actions: 'Műveletek',
     ai_chat_suggested_questions_title: 'Javasolt kérdések',

--- a/packages/gitbook/src/intl/translations/id.ts
+++ b/packages/gitbook/src/intl/translations/id.ts
@@ -134,7 +134,7 @@ export const id: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Pesan dalam percakapan Anda',
     ai_chat_context_disclaimer: 'Jawaban AI dapat berisi kesalahan.',
     ai_chat_input_placeholder: 'Tanya, cari, atau jelaskan...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Pesan ini akan dikirim setelah ${1} selesai',
     send: 'Kirim',
     actions: 'Tindakan',
     ai_chat_suggested_questions_title: 'Pertanyaan yang disarankan',

--- a/packages/gitbook/src/intl/translations/id.ts
+++ b/packages/gitbook/src/intl/translations/id.ts
@@ -134,6 +134,7 @@ export const id: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Pesan dalam percakapan Anda',
     ai_chat_context_disclaimer: 'Jawaban AI dapat berisi kesalahan.',
     ai_chat_input_placeholder: 'Tanya, cari, atau jelaskan...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Kirim',
     actions: 'Tindakan',
     ai_chat_suggested_questions_title: 'Pertanyaan yang disarankan',

--- a/packages/gitbook/src/intl/translations/it.ts
+++ b/packages/gitbook/src/intl/translations/it.ts
@@ -138,6 +138,7 @@ export const it: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Messaggi nella tua conversazione',
     ai_chat_context_disclaimer: "Le risposte dell'IA possono contenere errori.",
     ai_chat_input_placeholder: 'Chiedi, cerca o spiega...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Invia',
     actions: 'Azioni',
     ai_chat_suggested_questions_title: 'Domande suggerite',

--- a/packages/gitbook/src/intl/translations/it.ts
+++ b/packages/gitbook/src/intl/translations/it.ts
@@ -138,7 +138,7 @@ export const it: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Messaggi nella tua conversazione',
     ai_chat_context_disclaimer: "Le risposte dell'IA possono contenere errori.",
     ai_chat_input_placeholder: 'Chiedi, cerca o spiega...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Questo messaggio verrà inviato quando ${1} avrà finito',
     send: 'Invia',
     actions: 'Azioni',
     ai_chat_suggested_questions_title: 'Domande suggerite',

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -135,7 +135,7 @@ export const ja: TranslationLanguage = {
     ai_chat_context_previous_messages: '会話内のメッセージ',
     ai_chat_context_disclaimer: 'AIの回答には誤りが含まれる場合があります。',
     ai_chat_input_placeholder: '質問、検索、または説明...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: '${1}の応答が完了したら、このメッセージが送信されます',
     send: '送信',
     actions: 'アクション',
     ai_chat_suggested_questions_title: 'おすすめの質問',

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -135,6 +135,7 @@ export const ja: TranslationLanguage = {
     ai_chat_context_previous_messages: '会話内のメッセージ',
     ai_chat_context_disclaimer: 'AIの回答には誤りが含まれる場合があります。',
     ai_chat_input_placeholder: '質問、検索、または説明...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: '送信',
     actions: 'アクション',
     ai_chat_suggested_questions_title: 'おすすめの質問',

--- a/packages/gitbook/src/intl/translations/ko.ts
+++ b/packages/gitbook/src/intl/translations/ko.ts
@@ -134,6 +134,7 @@ export const ko: TranslationLanguage = {
     ai_chat_context_previous_messages: '대화의 메시지',
     ai_chat_context_disclaimer: 'AI 응답에는 오류가 있을 수 있습니다.',
     ai_chat_input_placeholder: '질문, 검색 또는 설명...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: '전송',
     actions: '작업',
     ai_chat_suggested_questions_title: '추천 질문',

--- a/packages/gitbook/src/intl/translations/ko.ts
+++ b/packages/gitbook/src/intl/translations/ko.ts
@@ -134,7 +134,7 @@ export const ko: TranslationLanguage = {
     ai_chat_context_previous_messages: '대화의 메시지',
     ai_chat_context_disclaimer: 'AI 응답에는 오류가 있을 수 있습니다.',
     ai_chat_input_placeholder: '질문, 검색 또는 설명...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: '${1}의 응답이 끝나면 이 메시지가 전송됩니다',
     send: '전송',
     actions: '작업',
     ai_chat_suggested_questions_title: '추천 질문',

--- a/packages/gitbook/src/intl/translations/lt.ts
+++ b/packages/gitbook/src/intl/translations/lt.ts
@@ -135,7 +135,7 @@ export const lt: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Pranešimai jūsų pokalbyje',
     ai_chat_context_disclaimer: 'AI atsakymuose gali būti klaidų.',
     ai_chat_input_placeholder: 'Klauskite, ieškokite arba paaiškinkite...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Ši žinutė bus išsiųsta, kai ${1} baigs',
     send: 'Siųsti',
     actions: 'Veiksmai',
     ai_chat_suggested_questions_title: 'Siūlomi klausimai',

--- a/packages/gitbook/src/intl/translations/lt.ts
+++ b/packages/gitbook/src/intl/translations/lt.ts
@@ -135,6 +135,7 @@ export const lt: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Pranešimai jūsų pokalbyje',
     ai_chat_context_disclaimer: 'AI atsakymuose gali būti klaidų.',
     ai_chat_input_placeholder: 'Klauskite, ieškokite arba paaiškinkite...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Siųsti',
     actions: 'Veiksmai',
     ai_chat_suggested_questions_title: 'Siūlomi klausimai',

--- a/packages/gitbook/src/intl/translations/lv.ts
+++ b/packages/gitbook/src/intl/translations/lv.ts
@@ -133,7 +133,7 @@ export const lv: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Ziņojumi jūsų sarunā',
     ai_chat_context_disclaimer: 'AI atbildēs var būt kļūdas.',
     ai_chat_input_placeholder: 'Jautājiet, meklējiet vai skaidrojiet...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Šī ziņa tiks nosūtīta, kad ${1} būs pabeidzis',
     send: 'Sūtīt',
     actions: 'Darbības',
     ai_chat_suggested_questions_title: 'Ieteiktie jautājumi',

--- a/packages/gitbook/src/intl/translations/lv.ts
+++ b/packages/gitbook/src/intl/translations/lv.ts
@@ -133,6 +133,7 @@ export const lv: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Ziņojumi jūsų sarunā',
     ai_chat_context_disclaimer: 'AI atbildēs var būt kļūdas.',
     ai_chat_input_placeholder: 'Jautājiet, meklējiet vai skaidrojiet...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Sūtīt',
     actions: 'Darbības',
     ai_chat_suggested_questions_title: 'Ieteiktie jautājumi',

--- a/packages/gitbook/src/intl/translations/ms.ts
+++ b/packages/gitbook/src/intl/translations/ms.ts
@@ -134,6 +134,7 @@ export const ms: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mesej dalam perbualan anda',
     ai_chat_context_disclaimer: 'Jawapan AI mungkin mengandungi kesilapan.',
     ai_chat_input_placeholder: 'Tanya, cari atau jelaskan...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Hantar',
     actions: 'Tindakan',
     ai_chat_suggested_questions_title: 'Soalan yang dicadangkan',

--- a/packages/gitbook/src/intl/translations/ms.ts
+++ b/packages/gitbook/src/intl/translations/ms.ts
@@ -134,7 +134,7 @@ export const ms: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mesej dalam perbualan anda',
     ai_chat_context_disclaimer: 'Jawapan AI mungkin mengandungi kesilapan.',
     ai_chat_input_placeholder: 'Tanya, cari atau jelaskan...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Mesej ini akan dihantar setelah ${1} selesai',
     send: 'Hantar',
     actions: 'Tindakan',
     ai_chat_suggested_questions_title: 'Soalan yang dicadangkan',

--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -137,6 +137,7 @@ export const nl: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Berichten in je gesprek',
     ai_chat_context_disclaimer: 'AI-antwoorden kunnen fouten bevatten.',
     ai_chat_input_placeholder: 'Vraag, zoek of leg uit...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Versturen',
     actions: 'Acties',
     ai_chat_suggested_questions_title: 'Voorgestelde vragen',

--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -137,7 +137,7 @@ export const nl: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Berichten in je gesprek',
     ai_chat_context_disclaimer: 'AI-antwoorden kunnen fouten bevatten.',
     ai_chat_input_placeholder: 'Vraag, zoek of leg uit...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Dit bericht wordt verzonden zodra ${1} klaar is',
     send: 'Versturen',
     actions: 'Acties',
     ai_chat_suggested_questions_title: 'Voorgestelde vragen',

--- a/packages/gitbook/src/intl/translations/no.ts
+++ b/packages/gitbook/src/intl/translations/no.ts
@@ -136,7 +136,7 @@ export const no: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Meldinger i samtalen din',
     ai_chat_context_disclaimer: 'AI-svar kan inneholde feil.',
     ai_chat_input_placeholder: 'Spør, søk eller forklar...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Denne meldingen sendes når ${1} er ferdig',
     send: 'Send',
     actions: 'Handlinger',
     ai_chat_suggested_questions_title: 'Foreslåtte spørsmål',

--- a/packages/gitbook/src/intl/translations/no.ts
+++ b/packages/gitbook/src/intl/translations/no.ts
@@ -136,6 +136,7 @@ export const no: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Meldinger i samtalen din',
     ai_chat_context_disclaimer: 'AI-svar kan inneholde feil.',
     ai_chat_input_placeholder: 'Spør, søk eller forklar...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Send',
     actions: 'Handlinger',
     ai_chat_suggested_questions_title: 'Foreslåtte spørsmål',

--- a/packages/gitbook/src/intl/translations/pl.ts
+++ b/packages/gitbook/src/intl/translations/pl.ts
@@ -135,7 +135,7 @@ export const pl: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Wiadomości w Twojej rozmowie',
     ai_chat_context_disclaimer: 'Odpowiedzi AI mogą zawierać błędy.',
     ai_chat_input_placeholder: 'Zapytaj, wyszukaj lub wyjaśnij...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Ta wiadomość zostanie wysłana, gdy ${1} zakończy',
     send: 'Wyślij',
     actions: 'Działania',
     ai_chat_suggested_questions_title: 'Sugerowane pytania',

--- a/packages/gitbook/src/intl/translations/pl.ts
+++ b/packages/gitbook/src/intl/translations/pl.ts
@@ -135,6 +135,7 @@ export const pl: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Wiadomości w Twojej rozmowie',
     ai_chat_context_disclaimer: 'Odpowiedzi AI mogą zawierać błędy.',
     ai_chat_input_placeholder: 'Zapytaj, wyszukaj lub wyjaśnij...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Wyślij',
     actions: 'Działania',
     ai_chat_suggested_questions_title: 'Sugerowane pytania',

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -139,7 +139,7 @@ export const pt_br: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mensagens na sua conversa',
     ai_chat_context_disclaimer: 'Respostas de IA podem conter erros.',
     ai_chat_input_placeholder: 'Pergunte, pesquise ou explique...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Esta mensagem será enviada quando ${1} terminar',
     send: 'Enviar',
     actions: 'Ações',
     ai_chat_suggested_questions_title: 'Perguntas sugeridas',

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -139,6 +139,7 @@ export const pt_br: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mensagens na sua conversa',
     ai_chat_context_disclaimer: 'Respostas de IA podem conter erros.',
     ai_chat_input_placeholder: 'Pergunte, pesquise ou explique...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Enviar',
     actions: 'Ações',
     ai_chat_suggested_questions_title: 'Perguntas sugeridas',

--- a/packages/gitbook/src/intl/translations/pt.ts
+++ b/packages/gitbook/src/intl/translations/pt.ts
@@ -136,6 +136,7 @@ export const pt: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mensagens na sua conversa',
     ai_chat_context_disclaimer: 'As respostas de IA podem conter erros.',
     ai_chat_input_placeholder: 'Pergunte, pesquise ou explique...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Enviar',
     actions: 'Ações',
     ai_chat_suggested_questions_title: 'Perguntas sugeridas',

--- a/packages/gitbook/src/intl/translations/pt.ts
+++ b/packages/gitbook/src/intl/translations/pt.ts
@@ -136,7 +136,7 @@ export const pt: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mensagens na sua conversa',
     ai_chat_context_disclaimer: 'As respostas de IA podem conter erros.',
     ai_chat_input_placeholder: 'Pergunte, pesquise ou explique...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Esta mensagem será enviada quando ${1} terminar',
     send: 'Enviar',
     actions: 'Ações',
     ai_chat_suggested_questions_title: 'Perguntas sugeridas',

--- a/packages/gitbook/src/intl/translations/ro.ts
+++ b/packages/gitbook/src/intl/translations/ro.ts
@@ -138,7 +138,7 @@ export const ro: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mesaje din conversația ta',
     ai_chat_context_disclaimer: 'Răspunsurile AI pot conține greșeli.',
     ai_chat_input_placeholder: 'Întreabă, caută sau explică...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Acest mesaj va fi trimis după ce ${1} termină',
     send: 'Trimite',
     actions: 'Acțiuni',
     ai_chat_suggested_questions_title: 'Întrebări sugerate',

--- a/packages/gitbook/src/intl/translations/ro.ts
+++ b/packages/gitbook/src/intl/translations/ro.ts
@@ -138,6 +138,7 @@ export const ro: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Mesaje din conversația ta',
     ai_chat_context_disclaimer: 'Răspunsurile AI pot conține greșeli.',
     ai_chat_input_placeholder: 'Întreabă, caută sau explică...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Trimite',
     actions: 'Acțiuni',
     ai_chat_suggested_questions_title: 'Întrebări sugerate',

--- a/packages/gitbook/src/intl/translations/ru.ts
+++ b/packages/gitbook/src/intl/translations/ru.ts
@@ -138,7 +138,7 @@ export const ru: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Сообщения в вашем разговоре',
     ai_chat_context_disclaimer: 'Ответы ИИ могут содержать ошибки.',
     ai_chat_input_placeholder: 'Спросите, найдите или объясните...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Это сообщение будет отправлено, когда ${1} закончит',
     send: 'Отправить',
     actions: 'Действия',
     ai_chat_suggested_questions_title: 'Предложенные вопросы',

--- a/packages/gitbook/src/intl/translations/ru.ts
+++ b/packages/gitbook/src/intl/translations/ru.ts
@@ -138,6 +138,7 @@ export const ru: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Сообщения в вашем разговоре',
     ai_chat_context_disclaimer: 'Ответы ИИ могут содержать ошибки.',
     ai_chat_input_placeholder: 'Спросите, найдите или объясните...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Отправить',
     actions: 'Действия',
     ai_chat_suggested_questions_title: 'Предложенные вопросы',

--- a/packages/gitbook/src/intl/translations/sk.ts
+++ b/packages/gitbook/src/intl/translations/sk.ts
@@ -137,7 +137,7 @@ export const sk: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Správy vo vašej konverzácii',
     ai_chat_context_disclaimer: 'Odpovede AI môžu obsahovať chyby.',
     ai_chat_input_placeholder: 'Pýtajte sa, hľadajte alebo vysvetľujte...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Táto správa sa odošle, keď ${1} skončí',
     send: 'Odoslať',
     actions: 'Akcie',
     ai_chat_suggested_questions_title: 'Navrhované otázky',

--- a/packages/gitbook/src/intl/translations/sk.ts
+++ b/packages/gitbook/src/intl/translations/sk.ts
@@ -137,6 +137,7 @@ export const sk: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Správy vo vašej konverzácii',
     ai_chat_context_disclaimer: 'Odpovede AI môžu obsahovať chyby.',
     ai_chat_input_placeholder: 'Pýtajte sa, hľadajte alebo vysvetľujte...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Odoslať',
     actions: 'Akcie',
     ai_chat_suggested_questions_title: 'Navrhované otázky',

--- a/packages/gitbook/src/intl/translations/sl.ts
+++ b/packages/gitbook/src/intl/translations/sl.ts
@@ -135,7 +135,7 @@ export const sl: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Sporočila v vašem pogovoru',
     ai_chat_context_disclaimer: 'Odgovori AI lahko vsebujejo napake.',
     ai_chat_input_placeholder: 'Vprašajte, iščite ali razložite...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'To sporočilo bo poslano, ko ${1} zaključi',
     send: 'Pošlji',
     actions: 'Dejanja',
     ai_chat_suggested_questions_title: 'Predlagana vprašanja',

--- a/packages/gitbook/src/intl/translations/sl.ts
+++ b/packages/gitbook/src/intl/translations/sl.ts
@@ -135,6 +135,7 @@ export const sl: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Sporočila v vašem pogovoru',
     ai_chat_context_disclaimer: 'Odgovori AI lahko vsebujejo napake.',
     ai_chat_input_placeholder: 'Vprašajte, iščite ali razložite...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Pošlji',
     actions: 'Dejanja',
     ai_chat_suggested_questions_title: 'Predlagana vprašanja',

--- a/packages/gitbook/src/intl/translations/sv.ts
+++ b/packages/gitbook/src/intl/translations/sv.ts
@@ -135,7 +135,7 @@ export const sv: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Meddelanden i din konversation',
     ai_chat_context_disclaimer: 'AI-svar kan innehålla fel.',
     ai_chat_input_placeholder: 'Fråga, sök eller förklara...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Det här meddelandet skickas när ${1} är klar',
     send: 'Skicka',
     actions: 'Åtgärder',
     ai_chat_suggested_questions_title: 'Föreslagna frågor',

--- a/packages/gitbook/src/intl/translations/sv.ts
+++ b/packages/gitbook/src/intl/translations/sv.ts
@@ -135,6 +135,7 @@ export const sv: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Meddelanden i din konversation',
     ai_chat_context_disclaimer: 'AI-svar kan innehålla fel.',
     ai_chat_input_placeholder: 'Fråga, sök eller förklara...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Skicka',
     actions: 'Åtgärder',
     ai_chat_suggested_questions_title: 'Föreslagna frågor',

--- a/packages/gitbook/src/intl/translations/th.ts
+++ b/packages/gitbook/src/intl/translations/th.ts
@@ -131,6 +131,7 @@ export const th: TranslationLanguage = {
     ai_chat_context_previous_messages: 'ข้อความในการสนทนาของคุณ',
     ai_chat_context_disclaimer: 'คำตอบจาก AI อาจมีข้อผิดพลาด',
     ai_chat_input_placeholder: 'ถาม ค้นหา หรืออธิบาย...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'ส่ง',
     actions: 'การดำเนินการ',
     ai_chat_suggested_questions_title: 'คำถามที่แนะนำ',

--- a/packages/gitbook/src/intl/translations/th.ts
+++ b/packages/gitbook/src/intl/translations/th.ts
@@ -131,7 +131,7 @@ export const th: TranslationLanguage = {
     ai_chat_context_previous_messages: 'ข้อความในการสนทนาของคุณ',
     ai_chat_context_disclaimer: 'คำตอบจาก AI อาจมีข้อผิดพลาด',
     ai_chat_input_placeholder: 'ถาม ค้นหา หรืออธิบาย...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'ข้อความนี้จะถูกส่งหลังจากที่ ${1} เสร็จสิ้น',
     send: 'ส่ง',
     actions: 'การดำเนินการ',
     ai_chat_suggested_questions_title: 'คำถามที่แนะนำ',

--- a/packages/gitbook/src/intl/translations/tr.ts
+++ b/packages/gitbook/src/intl/translations/tr.ts
@@ -133,6 +133,7 @@ export const tr: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Konuşmanızdaki mesajlar',
     ai_chat_context_disclaimer: 'AI yanıtları hata içerebilir.',
     ai_chat_input_placeholder: 'Sor, ara veya açıkla...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Gönder',
     actions: 'Eylemler',
     ai_chat_suggested_questions_title: 'Önerilen sorular',

--- a/packages/gitbook/src/intl/translations/tr.ts
+++ b/packages/gitbook/src/intl/translations/tr.ts
@@ -133,7 +133,7 @@ export const tr: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Konuşmanızdaki mesajlar',
     ai_chat_context_disclaimer: 'AI yanıtları hata içerebilir.',
     ai_chat_input_placeholder: 'Sor, ara veya açıkla...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Bu mesaj, ${1} yanıtını tamamladıktan sonra gönderilecek',
     send: 'Gönder',
     actions: 'Eylemler',
     ai_chat_suggested_questions_title: 'Önerilen sorular',

--- a/packages/gitbook/src/intl/translations/uk.ts
+++ b/packages/gitbook/src/intl/translations/uk.ts
@@ -133,7 +133,7 @@ export const uk: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Повідомлення у вашій розмові',
     ai_chat_context_disclaimer: 'Відповіді AI можуть містити помилки.',
     ai_chat_input_placeholder: 'Запитайте, знайдіть або поясніть...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Це повідомлення буде надіслано, коли ${1} завершить',
     send: 'Надіслати',
     actions: 'Дії',
     ai_chat_suggested_questions_title: 'Запропоновані запитання',

--- a/packages/gitbook/src/intl/translations/uk.ts
+++ b/packages/gitbook/src/intl/translations/uk.ts
@@ -133,6 +133,7 @@ export const uk: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Повідомлення у вашій розмові',
     ai_chat_context_disclaimer: 'Відповіді AI можуть містити помилки.',
     ai_chat_input_placeholder: 'Запитайте, знайдіть або поясніть...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Надіслати',
     actions: 'Дії',
     ai_chat_suggested_questions_title: 'Запропоновані запитання',

--- a/packages/gitbook/src/intl/translations/vi.ts
+++ b/packages/gitbook/src/intl/translations/vi.ts
@@ -133,6 +133,7 @@ export const vi: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Tin nhắn trong cuộc trò chuyện của bạn',
     ai_chat_context_disclaimer: 'Câu trả lời AI có thể chứa lỗi.',
     ai_chat_input_placeholder: 'Hỏi, tìm kiếm hoặc giải thích...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: 'Gửi',
     actions: 'Hành động',
     ai_chat_suggested_questions_title: 'Câu hỏi gợi ý',

--- a/packages/gitbook/src/intl/translations/vi.ts
+++ b/packages/gitbook/src/intl/translations/vi.ts
@@ -133,7 +133,7 @@ export const vi: TranslationLanguage = {
     ai_chat_context_previous_messages: 'Tin nhắn trong cuộc trò chuyện của bạn',
     ai_chat_context_disclaimer: 'Câu trả lời AI có thể chứa lỗi.',
     ai_chat_input_placeholder: 'Hỏi, tìm kiếm hoặc giải thích...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: 'Tin nhắn này sẽ được gửi sau khi ${1} hoàn tất',
     send: 'Gửi',
     actions: 'Hành động',
     ai_chat_suggested_questions_title: 'Câu hỏi gợi ý',

--- a/packages/gitbook/src/intl/translations/yue.ts
+++ b/packages/gitbook/src/intl/translations/yue.ts
@@ -130,7 +130,7 @@ export const yue: TranslationLanguage = {
     ai_chat_context_previous_messages: '你對話入面嘅訊息',
     ai_chat_context_disclaimer: 'AI 回答可能有錯。',
     ai_chat_input_placeholder: '發問、搜尋或說明...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: '呢個訊息會喺 ${1} 完成後發送',
     send: '傳送',
     actions: '動作',
     ai_chat_suggested_questions_title: '建議問題',

--- a/packages/gitbook/src/intl/translations/yue.ts
+++ b/packages/gitbook/src/intl/translations/yue.ts
@@ -130,6 +130,7 @@ export const yue: TranslationLanguage = {
     ai_chat_context_previous_messages: '你對話入面嘅訊息',
     ai_chat_context_disclaimer: 'AI 回答可能有錯。',
     ai_chat_input_placeholder: '發問、搜尋或說明...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: '傳送',
     actions: '動作',
     ai_chat_suggested_questions_title: '建議問題',

--- a/packages/gitbook/src/intl/translations/zh-tw.ts
+++ b/packages/gitbook/src/intl/translations/zh-tw.ts
@@ -130,6 +130,7 @@ export const zh_tw: TranslationLanguage = {
     ai_chat_context_previous_messages: '您對話中的訊息',
     ai_chat_context_disclaimer: 'AI 回答可能包含錯誤。',
     ai_chat_input_placeholder: '提問、搜尋或說明...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: '傳送',
     actions: '動作',
     ai_chat_suggested_questions_title: '建議問題',

--- a/packages/gitbook/src/intl/translations/zh-tw.ts
+++ b/packages/gitbook/src/intl/translations/zh-tw.ts
@@ -130,7 +130,7 @@ export const zh_tw: TranslationLanguage = {
     ai_chat_context_previous_messages: '您對話中的訊息',
     ai_chat_context_disclaimer: 'AI 回答可能包含錯誤。',
     ai_chat_input_placeholder: '提問、搜尋或說明...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: '這則訊息將在 ${1} 完成後傳送',
     send: '傳送',
     actions: '動作',
     ai_chat_suggested_questions_title: '建議問題',

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -131,7 +131,7 @@ export const zh: TranslationLanguage = {
     ai_chat_context_previous_messages: '您对话中的消息',
     ai_chat_context_disclaimer: '人工智能的回答可能包含错误。',
     ai_chat_input_placeholder: '询问、搜索或解释...',
-    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
+    ai_chat_queued_message: '此消息将在 ${1} 完成后发送',
     send: '发送',
     actions: '操作',
     ai_chat_suggested_questions_title: '建议的问题',

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -131,6 +131,7 @@ export const zh: TranslationLanguage = {
     ai_chat_context_previous_messages: '您对话中的消息',
     ai_chat_context_disclaimer: '人工智能的回答可能包含错误。',
     ai_chat_input_placeholder: '询问、搜索或解释...',
+    ai_chat_queued_message: 'This message will be sent after ${1} finishes',
     send: '发送',
     actions: '操作',
     ai_chat_suggested_questions_title: '建议的问题',


### PR DESCRIPTION
## Proposed changes

RND-11789: while the Assistant streamed an answer, the whole chat input was disabled, so you couldn't begin composing a follow-up until it finished. Worse, a submit attempted mid-stream was silently dropped by the controller (`onPostMessage` returns early when `responding`) — but only *after* the `Input` primitive had already cleared the typed text, so the follow-up you started was lost.

This makes the field stay editable during streaming while still blocking a premature send:

- **`Input` primitive** — new `submitDisabled` prop. When set, the field remains editable but Enter and the submit button are inert and the typed value is **preserved** (`handleSubmit` returns early before clearing). This is deliberately distinct from `disabled`, which also makes the field read-only.
- **`AIChatInput`** — now only fully disables on `disabled` (error) or an active control; it passes `submitDisabled={responding}` and keeps `aria-busy` for assistive tech. So you can type during a stream and send the moment it completes.
- **`AIChat`** — the call site no longer folds `responding` into `disabled` (submit-blocking now flows through the `responding`/`submitDisabled` path).

No change to concurrent-turn safety: `onPostMessage` already ignores a submit while `responding`; this just stops the UI from disabling the field and discarding text in that window.

## Test gap

Behavioural UI tweak validated by reading the flow; I did not add a Playwright test in this draft (no emulator run in this session). Happy to add one covering "type + send during/after a stream" if you'd like before it leaves draft.

## Changelog

- [Fix] Assistant: you can now start typing a follow-up question while an answer is still being written, instead of waiting for it to finish.

*— Drafted by the night shift for @zenoachtig to review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDRwrYgp4VpL3NVth3RzDj)_