### PR TITLE
Fix "Domain not found" for subdirectory-proxy sites forwarding their own host

### DIFF
--- a/.changeset/fix-proxy-forwarded-host-mixing.md
+++ b/.changeset/fix-proxy-forwarded-host-mixing.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix a "Domain not found" error that could occur for sites published on a subdirectory proxy (e.g. `company.com/docs`) when the request was served through a proxy that forwards its own host. Such requests are now resolved by their proxy site path instead of the forwarded host.

--- a/packages/gitbook/src/lib/proxy.test.ts
+++ b/packages/gitbook/src/lib/proxy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import { getProxyRequestIdentifier, isProxyRequest, isProxyRootRequest } from './proxy';
+import {
+    getProxyRequestIdentifier,
+    isProxyRequest,
+    isProxyRootRequest,
+    resolveForwardedHost,
+} from './proxy';
 
 describe('isProxyRequest', () => {
     it('should return true for proxy requests', () => {
@@ -46,5 +51,34 @@ describe('isProxyRootRequest', () => {
             'https://proxy.gitbook.site/sites/site_foo/hello/world'
         );
         expect(isProxyRootRequest(nonRootProxyRequestURL)).toBe(false);
+    });
+});
+
+describe('resolveForwardedHost', () => {
+    it('keeps the proxy host when a proxied request forwards a customer x-forwarded-host', () => {
+        // A customer's Vercel rewrite to proxy.gitbook.site/sites/<id> forwards its own
+        // x-forwarded-host; using it would glue the customer host onto the /sites/<id> path
+        // and resolve to a "Domain not found".
+        expect(
+            resolveForwardedHost({ host: 'proxy.gitbook.site', forwardedHost: 'argos-ci.com' })
+        ).toBe('proxy.gitbook.site');
+        expect(
+            resolveForwardedHost({
+                host: 'proxy.gitbook-staging.site',
+                forwardedHost: 'argos-ci.com',
+            })
+        ).toBe('proxy.gitbook-staging.site');
+    });
+
+    it('uses the forwarded host for regular custom-hostname requests', () => {
+        expect(
+            resolveForwardedHost({ host: 'docs.company.com', forwardedHost: 'docs.company.com' })
+        ).toBe('docs.company.com');
+    });
+
+    it('falls back to the forwarded host when the request host is missing', () => {
+        expect(resolveForwardedHost({ host: null, forwardedHost: 'argos-ci.com' })).toBe(
+            'argos-ci.com'
+        );
     });
 });

--- a/packages/gitbook/src/lib/proxy.ts
+++ b/packages/gitbook/src/lib/proxy.ts
@@ -1,10 +1,32 @@
 /**
+ * Check if a host is one of the GitBook proxy domains.
+ */
+export function isProxyHost(host: string): boolean {
+    return host === 'proxy.gitbook.site' || host === 'proxy.gitbook-staging.site';
+}
+
+/**
  * Check if the request to the site was through a proxy.
  */
 export function isProxyRequest(requestURL: URL): boolean {
-    return (
-        requestURL.host === 'proxy.gitbook.site' || requestURL.host === 'proxy.gitbook-staging.site'
-    );
+    return isProxyHost(requestURL.host);
+}
+
+/**
+ * Resolve the host to build the site URL from when a request carries an `x-forwarded-host`.
+ *
+ * A request that physically reaches GitBook on the proxy domain identifies its site by the
+ * `/sites/<id>` path, not by its host. Some upstream proxies (e.g. a customer's Vercel rewrite
+ * to the proxy domain) forward their own `x-forwarded-host`; trusting it would glue the customer
+ * host onto the internal `/sites/<id>` path and resolve to a "Domain not found". When the request
+ * actually arrived on the proxy domain, keep that host so the site resolves by its path instead.
+ */
+export function resolveForwardedHost(args: { host: string | null; forwardedHost: string }): string {
+    const { host, forwardedHost } = args;
+    if (host && isProxyHost(host)) {
+        return host;
+    }
+    return forwardedHost;
 }
 
 export function getProxyRequestIdentifier(requestURL: URL): string {

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -31,6 +31,7 @@ import {
     isOAuthProtectedResourceRequest,
 } from '@/lib/oauth-protected';
 import { removeLeadingSlash, removeTrailingSlash } from '@/lib/paths';
+import { resolveForwardedHost } from '@/lib/proxy';
 import {
     getPreviewCookieResponse,
     getPreviewRequestIdentifier,
@@ -645,6 +646,8 @@ async function serveWithQueryAPIToken(input: {
  *      URL is taken from the header.
  * - The request has a `X-Forwarded-Host` header:
  *      Host is taken from the header, pathname is taken from the request URL.
+ *      Except when the request actually reached us on the proxy domain, in which
+ *      case the proxy host is kept (see `resolveForwardedHost`).
  * - The request URL is matching `/url/:url`:
  *      URL is taken from the pathname.
  */
@@ -681,9 +684,16 @@ function getSiteURLFromRequest(request: NextRequest): URLWithMode | null {
     // The x-forwarded-host is set by Vercel for all requests
     // so we ignore it if the hostname is the same as the instance one.
     if (xForwardedHost) {
+        // A request proxied to us on the proxy domain (e.g. a customer's Vercel rewrite
+        // to proxy.gitbook.site/sites/<id>) can forward its own x-forwarded-host. Keep the
+        // proxy host in that case so the site resolves by its `/sites/<id>` path.
+        const host = resolveForwardedHost({
+            host: request.headers.get('host'),
+            forwardedHost: xForwardedHost,
+        });
         return {
             url: appendQueryParams(
-                new URL(`https://${xForwardedHost}${request.nextUrl.pathname}`),
+                new URL(`https://${host}${request.nextUrl.pathname}`),
                 request.nextUrl.searchParams
             ),
             mode: 'url-host',


### PR DESCRIPTION
## What & why

A user hit **`Domain not found`** on `https://argos-ci.com/docs` (a site published on a **subdirectory proxy**, `argos-ci.com/docs` → rewrite to `proxy.gitbook.site/sites/site_S9wzD`). It worked for most visitors but failed for some (a specific Vercel edge region, on a cache miss).

### Root cause

There are two proxy resolution mechanisms:
- **Host-based** — `x-forwarded-host` = the customer domain, path = the customer's original `/docs/...`.
- **ID-based** — `host` = `proxy.gitbook.site`, path = the internal `/sites/<id>/...`.

argos's setup rewrites to the **ID-based** path, but its Vercel edge also forwards `x-forwarded-host: argos-ci.com`. `getSiteURLFromRequest` trusted `x-forwarded-host` unconditionally and glued the **customer host** onto the **internal path**, resolving `https://argos-ci.com/sites/site_S9wzD`. That matches argos's custom-proxy host but expects the path to start with `/docs`, not `/sites/...` → `Domain not found`.

Confirmed with:
```bash
curl -sSL -H 'x-gitbook-url: https://argos-ci.com/sites/site_S9wzD' \
  https://proxy.gitbook.site/sites/site_S9wzD/     # → "Domain not found"
```

### Fix

When a request physically reaches us on the proxy domain, its site identity comes from the `/sites/<id>` path, not the host — so keep the proxy host and ignore a forwarded customer host. Extracted the decision into `resolveForwardedHost()` in `lib/proxy.ts`.

| request | before | after |
|---|---|---|
| `host: proxy.gitbook.site`, `x-forwarded-host: argos-ci.com`, `/sites/<id>` | resolves `argos-ci.com` + `/sites/…` → **Domain not found** | resolves `proxy.gitbook.site` + `/sites/…` → by site ID ✅ |
| direct `proxy.gitbook.site` | ✅ | ✅ (unchanged) |
| custom hostname `docs.company.com` | ✅ | ✅ (unchanged — host isn't a proxy domain) |

### Testing

- New unit tests for `resolveForwardedHost` in `lib/proxy.test.ts` (`bun test src/lib/proxy.test.ts` → 11 pass).
- `bun run typecheck` → clean.

### Note

The bad 404 was negatively cached per-region — a cache purge/invalidation may be needed after deploy so affected regions recover immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)