### PR TITLE
Separate prompt block actions

### DIFF
--- a/.changeset/rnd-11847-separate-prompt-block-actions.md
+++ b/.changeset/rnd-11847-separate-prompt-block-actions.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Separate the prompt block actions into a primary "Open in" dropdown and a secondary "Copy prompt" button, instead of a single combined button group.

--- a/.changeset/rnd-11847-separate-prompt-block-actions.md
+++ b/.changeset/rnd-11847-separate-prompt-block-actions.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Separate the prompt block actions into a primary "Open in" dropdown and a secondary "Copy prompt" button, instead of a single combined button group.
+Separate the prompt block actions into a primary "Open in" dropdown and a secondary "Copy prompt" button, instead of a single combined button group, and align the block's design with the expandable block (bordered frame, left disclosure chevron, and subtle elevation when expanded).

--- a/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/Prompt.tsx
@@ -1,4 +1,3 @@
-import { tcls } from '@/lib/tailwind';
 import {
     CustomizationPageActionType,
     type DocumentBlockPrompt,
@@ -15,21 +14,12 @@ export function Prompt(props: BlockProps<DocumentBlockPrompt>) {
         block.data.icon && validateIconName(block.data.icon) ? block.data.icon : null;
 
     return (
-        <div
-            className={tcls(
-                'relative flex w-full flex-col overflow-hidden',
-                'border border-tint-subtle bg-tint-subtle theme-bold-tint:bg-tint-base theme-muted:bg-tint-base text-tint-strong contrast-more:border-tint contrast-more:bg-tint-base',
-                'circular-corners:rounded-2xl rounded-corners:rounded-xl straight-corners:rounded-xs',
-                'depth-subtle:shadow-xs'
-            )}
-        >
-            <PromptClient
-                contentIcon={contentIcon}
-                description={block.data.description}
-                prompt={getPromptText(block)}
-                openInAIProviders={getOpenInAIProviders(props)}
-            />
-        </div>
+        <PromptClient
+            contentIcon={contentIcon}
+            description={block.data.description}
+            prompt={getPromptText(block)}
+            openInAIProviders={getOpenInAIProviders(props)}
+        />
     );
 }
 

--- a/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import {
-    Button,
-    ButtonGroup,
-    DropdownMenu,
-    DropdownMenuItem,
-    ToggleChevron,
-} from '@/components/primitives';
+import { Button, DropdownMenu, DropdownMenuItem, ToggleChevron } from '@/components/primitives';
 import { getURLForLLM } from '@/components/utils';
 import { tString, useLanguage } from '@/intl/client';
 import { tcls } from '@/lib/tailwind';
@@ -29,7 +23,7 @@ export function PromptClient(props: {
     const [headerHasFocus, setHeaderHasFocus] = React.useState(false);
     return (
         <>
-            <div className="group/prompt-header relative flex min-h-9 flex-row items-center justify-between gap-4 px-3 py-2">
+            <div className="group/prompt-header relative flex min-h-9 flex-row items-center justify-between gap-4 p-3">
                 <button
                     type="button"
                     aria-controls={promptId}
@@ -109,10 +103,10 @@ function PromptActions(props: { prompt: string; openInAIProviders: boolean }) {
     const { prompt, openInAIProviders } = props;
 
     return (
-        <ButtonGroup className="relative z-20 shrink-0 overflow-visible">
+        <div className="relative z-20 flex shrink-0 items-center gap-2">
             <CopyPromptButton prompt={prompt} />
             {openInAIProviders ? <OpenPromptDropdown prompt={prompt} /> : null}
-        </ButtonGroup>
+        </div>
     );
 }
 
@@ -142,9 +136,7 @@ function CopyPromptButton(props: { prompt: string }) {
         <Button
             variant="secondary"
             size="xsmall"
-            icon={copied ? 'check' : 'copy'}
             label={copied ? tString(language, 'code_copied') : tString(language, 'prompt_copy')}
-            className="bg-tint-base"
             disabled={!prompt}
             onClick={() => {
                 navigator.clipboard.writeText(prompt);
@@ -164,12 +156,10 @@ function OpenPromptDropdown(props: { prompt: string }) {
             className="!min-w-48 max-w-max"
             button={
                 <Button
-                    icon={<ToggleChevron className="size-text-sm" />}
-                    label={tString(language, 'open')}
-                    iconOnly
+                    label={tString(language, 'open_in_ai')}
+                    trailing={<ToggleChevron className="size-text-sm" />}
                     size="xsmall"
-                    variant="secondary"
-                    className="bg-tint-base"
+                    variant="primary"
                     disabled={!prompt}
                 />
             }

--- a/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
@@ -23,7 +23,7 @@ export function PromptClient(props: {
     return (
         <div
             className={tcls(
-                'relative flex w-full flex-col overflow-hidden rounded-lg text-tint-strong',
+                'relative flex w-full flex-col overflow-hidden circular-corners:rounded-2xl rounded-corners:rounded-xl straight-corners:rounded-xs text-tint-strong',
                 'border border-tint-subtle contrast-more:border-tint',
                 'transition',
                 open ? 'bg-tint depth-subtle:shadow-xs' : 'bg-tint-base'

--- a/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
@@ -132,6 +132,7 @@ function OpenPromptDropdown(props: { prompt: string }) {
                     trailing={<ToggleChevron className="size-text-sm" />}
                     size="xsmall"
                     variant="secondary"
+                    className="max-sm:hidden"
                     disabled={!prompt}
                 />
             }

--- a/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
@@ -20,10 +20,21 @@ export function PromptClient(props: {
     const language = useLanguage();
     const promptId = React.useId();
     const [open, setOpen] = React.useState(false);
-    const [headerHasFocus, setHeaderHasFocus] = React.useState(false);
     return (
-        <>
-            <div className="group/prompt-header relative flex min-h-9 flex-row items-center justify-between gap-4 p-3">
+        <div
+            className={tcls(
+                'relative flex w-full flex-col overflow-hidden rounded-lg text-tint-strong',
+                'border border-tint-subtle contrast-more:border-tint',
+                'transition',
+                open ? 'bg-tint depth-subtle:shadow-xs' : 'bg-tint-base'
+            )}
+        >
+            <div
+                className={tcls(
+                    'group/prompt-header relative flex min-h-9 flex-row items-center justify-between gap-4 p-3 transition-colors',
+                    open ? 'hover:bg-tint-hover' : 'hover:bg-tint-subtle'
+                )}
+            >
                 <button
                     type="button"
                     aria-controls={promptId}
@@ -34,16 +45,15 @@ export function PromptClient(props: {
                         'focus-visible:ring-2 focus-visible:ring-primary-hover'
                     )}
                     disabled={!prompt}
-                    onBlur={() => setHeaderHasFocus(false)}
                     onClick={() => setOpen((prev) => !prev)}
-                    onFocus={() => setHeaderHasFocus(true)}
                 />
                 <div className="pointer-events-none relative z-0 flex min-w-0 flex-row items-center gap-2 text-tint-strong">
-                    <PromptDisclosureIcon
-                        contentIcon={contentIcon}
-                        headerHasFocus={headerHasFocus}
+                    <ToggleChevron
                         open={open}
+                        orientation="right-to-down"
+                        className="size-3 shrink-0 text-tint-subtle transition-colors group-hover/prompt-header:text-tint-strong"
                     />
+                    {contentIcon ? <Icon icon={contentIcon} className="size-4 shrink-0" /> : null}
                     <span className="min-w-0 truncate">{description}</span>
                 </div>
                 <PromptActions prompt={prompt} openInAIProviders={openInAIProviders} />
@@ -57,45 +67,7 @@ export function PromptClient(props: {
                     </pre>
                 </div>
             ) : null}
-        </>
-    );
-}
-
-function PromptDisclosureIcon(props: {
-    contentIcon: IconName | null;
-    headerHasFocus: boolean;
-    open: boolean;
-}) {
-    const { contentIcon, headerHasFocus, open } = props;
-    return (
-        <span className="relative flex size-4 shrink-0 items-center justify-center">
-            {contentIcon ? (
-                <>
-                    <span
-                        className={tcls(
-                            'flex items-center transition-opacity duration-150 group-hover/prompt-header:opacity-0',
-                            headerHasFocus && 'opacity-0'
-                        )}
-                    >
-                        <Icon icon={contentIcon} className="size-4 shrink-0" />
-                    </span>
-                    <span
-                        className={tcls(
-                            'absolute inset-0 flex items-center justify-center text-tint-subtle opacity-0 transition-opacity duration-150 group-hover/prompt-header:opacity-100',
-                            headerHasFocus && 'opacity-100'
-                        )}
-                    >
-                        <ToggleChevron open={open} orientation="right-to-down" className="size-3" />
-                    </span>
-                </>
-            ) : (
-                <ToggleChevron
-                    open={open}
-                    orientation="right-to-down"
-                    className="size-3 text-tint-subtle"
-                />
-            )}
-        </span>
+        </div>
     );
 }
 

--- a/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
+++ b/packages/gitbook/src/components/DocumentView/Prompt/PromptClient.tsx
@@ -106,7 +106,7 @@ function CopyPromptButton(props: { prompt: string }) {
 
     return (
         <Button
-            variant="secondary"
+            variant="primary"
             size="xsmall"
             label={copied ? tString(language, 'code_copied') : tString(language, 'prompt_copy')}
             disabled={!prompt}
@@ -131,7 +131,7 @@ function OpenPromptDropdown(props: { prompt: string }) {
                     label={tString(language, 'open_in_ai')}
                     trailing={<ToggleChevron className="size-text-sm" />}
                     size="xsmall"
-                    variant="primary"
+                    variant="secondary"
                     disabled={!prompt}
                 />
             }

--- a/packages/gitbook/src/intl/translations/ar.ts
+++ b/packages/gitbook/src/intl/translations/ar.ts
@@ -156,6 +156,7 @@ export const ar: TranslationLanguage = {
     view_page_markdown: 'عرض كـ Markdown',
     view_page_plaintext: 'عرض هذه الصفحة كنص عادي',
     open_in: 'فتح في ${1}',
+    open_in_ai: 'فتح في',
     open_in_llms_pre_prompt: 'اقرأ ${1} وأجب عن الأسئلة المتعلقة بالمحتوى.',
     connect_mcp_to: 'الاتصال بـ ${1}',
     install_mcp_on: 'استخدام MCP هذا في ${1}',

--- a/packages/gitbook/src/intl/translations/bg.ts
+++ b/packages/gitbook/src/intl/translations/bg.ts
@@ -160,6 +160,7 @@ export const bg: TranslationLanguage = {
     view_page_markdown: 'Преглед като Markdown',
     view_page_plaintext: 'Преглед на тази страница като обикновен текст',
     open_in: 'Отваряне в ${1}',
+    open_in_ai: 'Отвори в',
     open_in_llms_pre_prompt: 'Прочетете ${1} и отговорете на въпроси за съдържанието.',
     connect_mcp_to: 'Свързване към ${1}',
     install_mcp_on: 'Използване на този MCP в ${1}',

--- a/packages/gitbook/src/intl/translations/cs.ts
+++ b/packages/gitbook/src/intl/translations/cs.ts
@@ -158,6 +158,7 @@ export const cs: TranslationLanguage = {
     view_page_markdown: 'Zobrazit jako Markdown',
     view_page_plaintext: 'Zobrazit tuto stránku jako prostý text',
     open_in: 'Otevřít v ${1}',
+    open_in_ai: 'Otevřít v',
     open_in_llms_pre_prompt: 'Přečtěte si ${1} a odpovězte na otázky o obsahu.',
     connect_mcp_to: 'Připojit k ${1}',
     install_mcp_on: 'Použít tento MCP v ${1}',

--- a/packages/gitbook/src/intl/translations/da.ts
+++ b/packages/gitbook/src/intl/translations/da.ts
@@ -157,6 +157,7 @@ export const da: TranslationLanguage = {
     view_page_markdown: 'Vis som Markdown',
     view_page_plaintext: 'Vis denne side som almindelig tekst',
     open_in: 'Åbn i ${1}',
+    open_in_ai: 'Åbn i',
     open_in_llms_pre_prompt: 'Læs ${1}, og besvar spørgsmål om indholdet.',
     connect_mcp_to: 'Opret forbindelse til ${1}',
     install_mcp_on: 'Brug denne MCP i ${1}',

--- a/packages/gitbook/src/intl/translations/de.ts
+++ b/packages/gitbook/src/intl/translations/de.ts
@@ -163,6 +163,7 @@ export const de: TranslationLanguage = {
     view_page_markdown: 'Als Markdown anzeigen',
     view_page_plaintext: 'Diese Seite als Klartext anzeigen',
     open_in: 'Öffnen in ${1}',
+    open_in_ai: 'Öffnen in',
     open_in_llms_pre_prompt: 'Lies ${1} und beantworte Fragen zum Inhalt.',
     connect_mcp_to: 'Mit ${1} verbinden',
     install_mcp_on: 'Dieses MCP in ${1} verwenden',

--- a/packages/gitbook/src/intl/translations/el.ts
+++ b/packages/gitbook/src/intl/translations/el.ts
@@ -162,6 +162,7 @@ export const el: TranslationLanguage = {
     view_page_markdown: 'Προβολή ως Markdown',
     view_page_plaintext: 'Προβολή αυτής της σελίδας ως απλού κειμένου',
     open_in: 'Άνοιγμα στο ${1}',
+    open_in_ai: 'Άνοιγμα σε',
     open_in_llms_pre_prompt: 'Διαβάστε το ${1} και απαντήστε σε ερωτήσεις για το περιεχόμενο.',
     connect_mcp_to: 'Σύνδεση με ${1}',
     install_mcp_on: 'Χρήση αυτού του MCP στο ${1}',

--- a/packages/gitbook/src/intl/translations/en.ts
+++ b/packages/gitbook/src/intl/translations/en.ts
@@ -155,6 +155,7 @@ export const en = {
     view_page_markdown: 'View as Markdown',
     view_page_plaintext: 'View this page as plain text',
     open_in: 'Open in ${1}',
+    open_in_ai: 'Open in',
     open_in_llms_pre_prompt: 'Read ${1} and answer questions about the content.',
     connect_mcp_to: 'Connect to ${1}',
     install_mcp_on: 'Use this MCP in ${1}',

--- a/packages/gitbook/src/intl/translations/es.ts
+++ b/packages/gitbook/src/intl/translations/es.ts
@@ -161,6 +161,7 @@ export const es: TranslationLanguage = {
     view_page_markdown: 'Ver como Markdown',
     view_page_plaintext: 'Ver esta página como texto plano',
     open_in: 'Abrir en ${1}',
+    open_in_ai: 'Abrir en',
     open_in_llms_pre_prompt: 'Lee ${1} y responde preguntas sobre el contenido.',
     connect_mcp_to: 'Conectar a ${1}',
     install_mcp_on: 'Usar este MCP en ${1}',

--- a/packages/gitbook/src/intl/translations/et.ts
+++ b/packages/gitbook/src/intl/translations/et.ts
@@ -157,6 +157,7 @@ export const et: TranslationLanguage = {
     view_page_markdown: 'Kuva Markdownina',
     view_page_plaintext: 'Kuva see leht lihttekstina',
     open_in: 'Ava rakenduses ${1}',
+    open_in_ai: 'Ava rakenduses',
     open_in_llms_pre_prompt: 'Lugege ${1} ja vastake sisu puudutavatele küsimustele.',
     connect_mcp_to: 'Ühenda teenusega ${1}',
     install_mcp_on: 'Kasuta seda MCP-d rakenduses ${1}',

--- a/packages/gitbook/src/intl/translations/fi.ts
+++ b/packages/gitbook/src/intl/translations/fi.ts
@@ -159,6 +159,7 @@ export const fi: TranslationLanguage = {
     view_page_markdown: 'Näytä Markdownina',
     view_page_plaintext: 'Näytä tämä sivu pelkkänä tekstinä',
     open_in: 'Avaa sovelluksessa ${1}',
+    open_in_ai: 'Avaa sovelluksessa',
     open_in_llms_pre_prompt: 'Lue ${1} ja vastaa sisältöä koskeviin kysymyksiin.',
     connect_mcp_to: 'Yhdistä kohteeseen ${1}',
     install_mcp_on: 'Käytä tätä MCP:tä sovelluksessa ${1}',

--- a/packages/gitbook/src/intl/translations/fr.ts
+++ b/packages/gitbook/src/intl/translations/fr.ts
@@ -157,6 +157,7 @@ export const fr: TranslationLanguage = {
     view_page_markdown: 'Voir en Markdown',
     view_page_plaintext: 'Voir en texte brut',
     open_in: 'Ouvrir dans ${1}',
+    open_in_ai: 'Ouvrir dans',
     open_in_llms_pre_prompt: 'Lire ${1} et répondre aux questions sur le contenu.',
     connect_mcp_to: 'Se connecter à ${1}',
     install_mcp_on: 'Utiliser ce MCP dans ${1}',

--- a/packages/gitbook/src/intl/translations/he.ts
+++ b/packages/gitbook/src/intl/translations/he.ts
@@ -155,6 +155,7 @@ export const he: TranslationLanguage = {
     view_page_markdown: 'הצגה כ-Markdown',
     view_page_plaintext: 'הצגת דף זה כטקסט פשוט',
     open_in: 'פתיחה ב-${1}',
+    open_in_ai: 'פתיחה באמצעות',
     open_in_llms_pre_prompt: 'קרא את ${1} וענה על שאלות לגבי התוכן.',
     connect_mcp_to: 'התחברות אל ${1}',
     install_mcp_on: 'שימוש ב-MCP הזה ב-${1}',

--- a/packages/gitbook/src/intl/translations/hi.ts
+++ b/packages/gitbook/src/intl/translations/hi.ts
@@ -156,6 +156,7 @@ export const hi: TranslationLanguage = {
     view_page_markdown: 'Markdown के रूप में देखें',
     view_page_plaintext: 'इस पृष्ठ को सादे पाठ के रूप में देखें',
     open_in: '${1} में खोलें',
+    open_in_ai: 'इसमें खोलें',
     open_in_llms_pre_prompt: '${1} पढ़ें और सामग्री के बारे में प्रश्नों का उत्तर दें।',
     connect_mcp_to: '${1} से कनेक्ट करें',
     install_mcp_on: 'इस MCP को ${1} में उपयोग करें',

--- a/packages/gitbook/src/intl/translations/hr.ts
+++ b/packages/gitbook/src/intl/translations/hr.ts
@@ -158,6 +158,7 @@ export const hr: TranslationLanguage = {
     view_page_markdown: 'Prikaži kao Markdown',
     view_page_plaintext: 'Prikaži ovu stranicu kao običan tekst',
     open_in: 'Otvori u ${1}',
+    open_in_ai: 'Otvori u',
     open_in_llms_pre_prompt: 'Pročitajte ${1} i odgovorite na pitanja o sadržaju.',
     connect_mcp_to: 'Poveži s ${1}',
     install_mcp_on: 'Upotrijebi ovaj MCP u ${1}',

--- a/packages/gitbook/src/intl/translations/hu.ts
+++ b/packages/gitbook/src/intl/translations/hu.ts
@@ -159,6 +159,7 @@ export const hu: TranslationLanguage = {
     view_page_markdown: 'Megtekintés Markdownként',
     view_page_plaintext: 'Az oldal megtekintése egyszerű szövegként',
     open_in: 'Megnyitás itt: ${1}',
+    open_in_ai: 'Megnyitás ebben:',
     open_in_llms_pre_prompt:
         'Olvassa el ezt: ${1}, és válaszoljon a tartalommal kapcsolatos kérdésekre.',
     connect_mcp_to: 'Csatlakozás ehhez: ${1}',

--- a/packages/gitbook/src/intl/translations/id.ts
+++ b/packages/gitbook/src/intl/translations/id.ts
@@ -157,6 +157,7 @@ export const id: TranslationLanguage = {
     view_page_markdown: 'Lihat sebagai Markdown',
     view_page_plaintext: 'Lihat halaman ini sebagai teks biasa',
     open_in: 'Buka di ${1}',
+    open_in_ai: 'Buka di',
     open_in_llms_pre_prompt: 'Baca ${1} dan jawab pertanyaan tentang kontennya.',
     connect_mcp_to: 'Hubungkan ke ${1}',
     install_mcp_on: 'Gunakan MCP ini di ${1}',

--- a/packages/gitbook/src/intl/translations/it.ts
+++ b/packages/gitbook/src/intl/translations/it.ts
@@ -160,6 +160,7 @@ export const it: TranslationLanguage = {
     view_page_markdown: 'Visualizza come Markdown',
     view_page_plaintext: 'Visualizza questa pagina come testo semplice',
     open_in: 'Apri in ${1}',
+    open_in_ai: 'Apri in',
     open_in_llms_pre_prompt: 'Leggi ${1} e rispondi alle domande sul contenuto.',
     connect_mcp_to: 'Connetti a ${1}',
     install_mcp_on: 'Usa questo MCP in ${1}',

--- a/packages/gitbook/src/intl/translations/ja.ts
+++ b/packages/gitbook/src/intl/translations/ja.ts
@@ -157,6 +157,7 @@ export const ja: TranslationLanguage = {
     view_page_markdown: 'Markdown として表示',
     view_page_plaintext: 'このページをプレーンテキストで表示',
     open_in: '${1} で開く',
+    open_in_ai: '以下で開く',
     open_in_llms_pre_prompt: '${1} を読んで内容に関する質問に答えてください。',
     connect_mcp_to: '${1} に接続',
     install_mcp_on: '${1} でこのMCPを使用',

--- a/packages/gitbook/src/intl/translations/ko.ts
+++ b/packages/gitbook/src/intl/translations/ko.ts
@@ -156,6 +156,7 @@ export const ko: TranslationLanguage = {
     view_page_markdown: 'Markdown으로 보기',
     view_page_plaintext: '이 페이지를 일반 텍스트로 보기',
     open_in: '${1}에서 열기',
+    open_in_ai: '다음에서 열기',
     open_in_llms_pre_prompt: '${1}을(를) 읽고 콘텐츠에 대한 질문에 답하세요.',
     connect_mcp_to: '${1}에 연결',
     install_mcp_on: '${1}에서 이 MCP 사용',

--- a/packages/gitbook/src/intl/translations/lt.ts
+++ b/packages/gitbook/src/intl/translations/lt.ts
@@ -158,6 +158,7 @@ export const lt: TranslationLanguage = {
     view_page_markdown: 'Peržiūrėti kaip Markdown',
     view_page_plaintext: 'Peržiūrėti šį puslapį kaip paprastą tekstą',
     open_in: 'Atidaryti ${1}',
+    open_in_ai: 'Atidaryti su',
     open_in_llms_pre_prompt: 'Perskaitykite ${1} ir atsakykite į klausimus apie turinį.',
     connect_mcp_to: 'Prisijungti prie ${1}',
     install_mcp_on: 'Naudoti šį MCP ${1}',

--- a/packages/gitbook/src/intl/translations/lv.ts
+++ b/packages/gitbook/src/intl/translations/lv.ts
@@ -156,6 +156,7 @@ export const lv: TranslationLanguage = {
     view_page_markdown: 'Skatīt kā Markdown',
     view_page_plaintext: 'Skatīt šo lapu kā vienkāršu tekstu',
     open_in: 'Atvērt ${1}',
+    open_in_ai: 'Atvērt ar',
     open_in_llms_pre_prompt: 'Izlasiet ${1} un atbildiet uz jautājumiem par saturu.',
     connect_mcp_to: 'Savienot ar ${1}',
     install_mcp_on: 'Izmantot šo MCP ${1}',

--- a/packages/gitbook/src/intl/translations/ms.ts
+++ b/packages/gitbook/src/intl/translations/ms.ts
@@ -157,6 +157,7 @@ export const ms: TranslationLanguage = {
     view_page_markdown: 'Lihat sebagai Markdown',
     view_page_plaintext: 'Lihat halaman ini sebagai teks biasa',
     open_in: 'Buka dalam ${1}',
+    open_in_ai: 'Buka dalam',
     open_in_llms_pre_prompt: 'Baca ${1} dan jawab soalan tentang kandungan.',
     connect_mcp_to: 'Sambung ke ${1}',
     install_mcp_on: 'Gunakan MCP ini dalam ${1}',

--- a/packages/gitbook/src/intl/translations/nl.ts
+++ b/packages/gitbook/src/intl/translations/nl.ts
@@ -159,6 +159,7 @@ export const nl: TranslationLanguage = {
     view_page_markdown: 'Bekijk als Markdown',
     view_page_plaintext: 'Bekijk deze pagina als platte tekst',
     open_in: 'Open in ${1}',
+    open_in_ai: 'Openen in',
     open_in_llms_pre_prompt: 'Lees ${1} en beantwoord vragen over de inhoud.',
     connect_mcp_to: 'Verbind met ${1}',
     install_mcp_on: 'Gebruik deze MCP in ${1}',

--- a/packages/gitbook/src/intl/translations/no.ts
+++ b/packages/gitbook/src/intl/translations/no.ts
@@ -158,6 +158,7 @@ export const no: TranslationLanguage = {
     view_page_markdown: 'Vis som Markdown',
     view_page_plaintext: 'Vis denne siden som ren tekst',
     open_in: 'Åpne i ${1}',
+    open_in_ai: 'Åpne i',
     open_in_llms_pre_prompt: 'Les ${1} og besvar spørsmål om innholdet.',
     connect_mcp_to: 'Koble til ${1}',
     install_mcp_on: 'Bruk denne MCP i ${1}',

--- a/packages/gitbook/src/intl/translations/pl.ts
+++ b/packages/gitbook/src/intl/translations/pl.ts
@@ -158,6 +158,7 @@ export const pl: TranslationLanguage = {
     view_page_markdown: 'Wyświetl jako Markdown',
     view_page_plaintext: 'Wyświetl tę stronę jako zwykły tekst',
     open_in: 'Otwórz w ${1}',
+    open_in_ai: 'Otwórz w',
     open_in_llms_pre_prompt: 'Przeczytaj ${1} i odpowiedz na pytania dotyczące treści.',
     connect_mcp_to: 'Połącz z ${1}',
     install_mcp_on: 'Użyj tego MCP w ${1}',

--- a/packages/gitbook/src/intl/translations/pt-br.ts
+++ b/packages/gitbook/src/intl/translations/pt-br.ts
@@ -161,6 +161,7 @@ export const pt_br: TranslationLanguage = {
     view_page_markdown: 'Ver como Markdown',
     view_page_plaintext: 'Ver esta página em texto simples',
     open_in: 'Abrir no ${1}',
+    open_in_ai: 'Abrir em',
     open_in_llms_pre_prompt: 'Leia ${1} e responda perguntas sobre o conteúdo.',
     connect_mcp_to: 'Conectar a ${1}',
     install_mcp_on: 'Usar este MCP no ${1}',

--- a/packages/gitbook/src/intl/translations/pt.ts
+++ b/packages/gitbook/src/intl/translations/pt.ts
@@ -159,6 +159,7 @@ export const pt: TranslationLanguage = {
     view_page_markdown: 'Ver como Markdown',
     view_page_plaintext: 'Ver esta página como texto simples',
     open_in: 'Abrir em ${1}',
+    open_in_ai: 'Abrir em',
     open_in_llms_pre_prompt: 'Leia ${1} e responda a perguntas sobre o conteúdo.',
     connect_mcp_to: 'Ligar a ${1}',
     install_mcp_on: 'Usar este MCP em ${1}',

--- a/packages/gitbook/src/intl/translations/ro.ts
+++ b/packages/gitbook/src/intl/translations/ro.ts
@@ -161,6 +161,7 @@ export const ro: TranslationLanguage = {
     view_page_markdown: 'Vizualizează ca Markdown',
     view_page_plaintext: 'Vizualizează această pagină ca text simplu',
     open_in: 'Deschide în ${1}',
+    open_in_ai: 'Deschide în',
     open_in_llms_pre_prompt: 'Citește ${1} și răspunde la întrebări despre conținut.',
     connect_mcp_to: 'Conectează la ${1}',
     install_mcp_on: 'Folosește acest MCP în ${1}',

--- a/packages/gitbook/src/intl/translations/ru.ts
+++ b/packages/gitbook/src/intl/translations/ru.ts
@@ -160,6 +160,7 @@ export const ru: TranslationLanguage = {
     view_page_markdown: 'Посмотреть как Markdown',
     view_page_plaintext: 'Посмотреть как текст без форматирования',
     open_in: 'Открыть в ${1}',
+    open_in_ai: 'Открыть в',
     open_in_llms_pre_prompt: 'Прочитай ${1} и ответь на вопросы о содержимом.',
     connect_mcp_to: 'Подключиться к ${1}',
     install_mcp_on: 'Использовать этот MCP в ${1}',

--- a/packages/gitbook/src/intl/translations/sk.ts
+++ b/packages/gitbook/src/intl/translations/sk.ts
@@ -160,6 +160,7 @@ export const sk: TranslationLanguage = {
     view_page_markdown: 'Zobraziť ako Markdown',
     view_page_plaintext: 'Zobraziť túto stránku ako obyčajný text',
     open_in: 'Otvoriť v ${1}',
+    open_in_ai: 'Otvoriť v',
     open_in_llms_pre_prompt: 'Prečítajte si ${1} a odpovedzte na otázky o obsahu.',
     connect_mcp_to: 'Pripojiť k ${1}',
     install_mcp_on: 'Použiť tento MCP v ${1}',

--- a/packages/gitbook/src/intl/translations/sl.ts
+++ b/packages/gitbook/src/intl/translations/sl.ts
@@ -158,6 +158,7 @@ export const sl: TranslationLanguage = {
     view_page_markdown: 'Prikaži kot Markdown',
     view_page_plaintext: 'Prikaži to stran kot navadno besedilo',
     open_in: 'Odpri v ${1}',
+    open_in_ai: 'Odpri v',
     open_in_llms_pre_prompt: 'Preberite ${1} in odgovorite na vprašanja o vsebini.',
     connect_mcp_to: 'Poveži z ${1}',
     install_mcp_on: 'Uporabi ta MCP v ${1}',

--- a/packages/gitbook/src/intl/translations/sv.ts
+++ b/packages/gitbook/src/intl/translations/sv.ts
@@ -158,6 +158,7 @@ export const sv: TranslationLanguage = {
     view_page_markdown: 'Visa som Markdown',
     view_page_plaintext: 'Visa den här sidan som vanlig text',
     open_in: 'Öppna i ${1}',
+    open_in_ai: 'Öppna i',
     open_in_llms_pre_prompt: 'Läs ${1} och svara på frågor om innehållet.',
     connect_mcp_to: 'Anslut till ${1}',
     install_mcp_on: 'Använd denna MCP i ${1}',

--- a/packages/gitbook/src/intl/translations/th.ts
+++ b/packages/gitbook/src/intl/translations/th.ts
@@ -154,6 +154,7 @@ export const th: TranslationLanguage = {
     view_page_markdown: 'ดูเป็น Markdown',
     view_page_plaintext: 'ดูหน้านี้เป็นข้อความธรรมดา',
     open_in: 'เปิดใน ${1}',
+    open_in_ai: 'เปิดใน',
     open_in_llms_pre_prompt: 'อ่าน ${1} แล้วตอบคำถามเกี่ยวกับเนื้อหา',
     connect_mcp_to: 'เชื่อมต่อกับ ${1}',
     install_mcp_on: 'ใช้ MCP นี้ใน ${1}',

--- a/packages/gitbook/src/intl/translations/tr.ts
+++ b/packages/gitbook/src/intl/translations/tr.ts
@@ -156,6 +156,7 @@ export const tr: TranslationLanguage = {
     view_page_markdown: 'Markdown olarak görüntüle',
     view_page_plaintext: 'Bu sayfayı düz metin olarak görüntüle',
     open_in: '${1} içinde aç',
+    open_in_ai: 'Şununla aç',
     open_in_llms_pre_prompt: '${1} içeriğini okuyun ve içerikle ilgili soruları yanıtlayın.',
     connect_mcp_to: '${1} ile bağlan',
     install_mcp_on: 'Bu MCPyi ${1} içinde kullan',

--- a/packages/gitbook/src/intl/translations/uk.ts
+++ b/packages/gitbook/src/intl/translations/uk.ts
@@ -156,6 +156,7 @@ export const uk: TranslationLanguage = {
     view_page_markdown: 'Переглянути як Markdown',
     view_page_plaintext: 'Переглянути цю сторінку як звичайний текст',
     open_in: 'Відкрити в ${1}',
+    open_in_ai: 'Відкрити в',
     open_in_llms_pre_prompt: 'Прочитайте ${1} і дайте відповіді на запитання про вміст.',
     connect_mcp_to: 'Підключитися до ${1}',
     install_mcp_on: 'Використати цей MCP у ${1}',

--- a/packages/gitbook/src/intl/translations/vi.ts
+++ b/packages/gitbook/src/intl/translations/vi.ts
@@ -156,6 +156,7 @@ export const vi: TranslationLanguage = {
     view_page_markdown: 'Xem dưới dạng Markdown',
     view_page_plaintext: 'Xem trang này dưới dạng văn bản thuần',
     open_in: 'Mở trong ${1}',
+    open_in_ai: 'Mở trong',
     open_in_llms_pre_prompt: 'Đọc ${1} và trả lời câu hỏi về nội dung.',
     connect_mcp_to: 'Kết nối với ${1}',
     install_mcp_on: 'Dùng MCP này trong ${1}',

--- a/packages/gitbook/src/intl/translations/yue.ts
+++ b/packages/gitbook/src/intl/translations/yue.ts
@@ -153,6 +153,7 @@ export const yue: TranslationLanguage = {
     view_page_markdown: '以 Markdown 檢視',
     view_page_plaintext: '以純文字檢視此頁面',
     open_in: '喺 ${1} 開啟',
+    open_in_ai: '開啟方式',
     open_in_llms_pre_prompt: '閱讀 ${1}，並回答關於內容嘅問題。',
     connect_mcp_to: '連接到 ${1}',
     install_mcp_on: '喺 ${1} 使用此 MCP',

--- a/packages/gitbook/src/intl/translations/zh-tw.ts
+++ b/packages/gitbook/src/intl/translations/zh-tw.ts
@@ -153,6 +153,7 @@ export const zh_tw: TranslationLanguage = {
     view_page_markdown: '以 Markdown 檢視',
     view_page_plaintext: '以純文字檢視此頁面',
     open_in: '在 ${1} 中開啟',
+    open_in_ai: '開啟方式',
     open_in_llms_pre_prompt: '閱讀 ${1}，並回答關於內容的問題。',
     connect_mcp_to: '連線至 ${1}',
     install_mcp_on: '在 ${1} 使用此 MCP',

--- a/packages/gitbook/src/intl/translations/zh.ts
+++ b/packages/gitbook/src/intl/translations/zh.ts
@@ -153,6 +153,7 @@ export const zh: TranslationLanguage = {
     view_page_markdown: '以 Markdown 查看',
     view_page_plaintext: '以纯文本查看此页面',
     open_in: '在 ${1} 中打开',
+    open_in_ai: '打开方式',
     open_in_llms_pre_prompt: '阅读 ${1} 并回答内容相关的问题。',
     connect_mcp_to: '连接到 ${1}',
     install_mcp_on: '在 ${1} 中使用此 MCP',


### PR DESCRIPTION
Splits the prompt block header actions into two distinct buttons instead of a single combined button group:

- **Primary "Open in" dropdown** — opens the prompt in Claude, ChatGPT, or Cursor.
- **Secondary "Copy prompt" button**.

Also adds a standalone `open_in_ai` ("Open in") translation key across all locales (the existing `open_in` key requires a provider argument, so it can't be reused for the generic dropdown label).

Resolves RND-11847.

Demo:
<img width="1540" height="418" alt="CleanShot 2026-07-08 at 12 17 24@2x" src="https://github.com/user-attachments/assets/1eb8635a-dcae-44aa-8c02-a76568fcb7b9" />

------------------------------------------------------------------------------------

<img width="1530" height="502" alt="CleanShot 2026-07-08 at 12 17 30@2x" src="https://github.com/user-attachments/assets/c23a9c84-6119-4b79-97bb-3e57942a6746" />
