### PR TITLE
Only show "Back to [space]" for table-of-contents cross-space links

### DIFF
--- a/.changeset/stricter-back-to-space.md
+++ b/.changeset/stricter-back-to-space.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Only show the "Back to [space]" shortcut for cross-space links in the table of contents, not for in-content text links or other ways of reaching another space.

--- a/packages/gitbook/src/components/Header/SpacesDropdownMenuItem.tsx
+++ b/packages/gitbook/src/components/Header/SpacesDropdownMenuItem.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import { joinPath } from '@/lib/paths';
-import {
-    markSpaceNavigationFromPickerOnClick,
-    useCurrentPageMetadata,
-    useCurrentPagePath,
-} from '../hooks';
+import { useCurrentPageMetadata, useCurrentPagePath } from '../hooks';
 import { DropdownMenuItem } from '../primitives/DropdownMenu';
 
 export interface VariantSpace {
@@ -64,18 +60,7 @@ export function SpacesDropdownMenuItem(props: {
     const variantHref = useVariantSpaceHref(variantSpace, currentSpacePath, active);
 
     return (
-        <DropdownMenuItem
-            key={variantSpace.id}
-            href={variantHref}
-            active={active}
-            onClick={(event) => {
-                // Switching variant/translation through the picker shouldn't offer to
-                // navigate "back" to the space we're leaving.
-                if (!active) {
-                    markSpaceNavigationFromPickerOnClick(event);
-                }
-            }}
-        >
+        <DropdownMenuItem key={variantSpace.id} href={variantHref} active={active}>
             {variantSpace.title}
         </DropdownMenuItem>
     );

--- a/packages/gitbook/src/components/SiteSections/SiteSectionList.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionList.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { type ClassValue, tcls } from '@/lib/tailwind';
 import { findSectionInGroup } from '@/lib/utils';
-import { markSpaceNavigationFromPickerOnClick, useToggleAnimation } from '../hooks';
+import { useToggleAnimation } from '../hooks';
 import { Link, ToggleChevron } from '../primitives';
 import { ScrollContainer } from '../primitives/ScrollContainer';
 import { SectionIcon } from './SectionIcon';
@@ -31,7 +31,6 @@ export function SiteSectionList(props: { sections: ClientSiteSections; className
         sectionsAndGroups.length > 0 && (
             <nav
                 aria-label="Sections"
-                onClickCapture={markSpaceNavigationFromPickerOnClick}
                 className={tcls(
                     '-mx-5 before:contents[] relative border-tint-subtle border-b from-transparent sidebar-filled:to-tint-subtle theme-muted:to-tint-subtle to-tint-base text-sm text-tint before:pointer-events-none before:absolute before:right-2 before:bottom-0 before:left-0 before:h-12 before:bg-linear-to-b [html.sidebar-filled.theme-bold.tint_&]:to-tint-base [html.sidebar-filled.theme-bold.tint_&]:to-tint-subtle [html.sidebar-filled.theme-muted_&]:to-tint-base',
                     className

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -7,7 +7,6 @@ import React from 'react';
 import { Button, Link, ToggleChevron } from '@/components/primitives';
 import { tcls } from '@/lib/tailwind';
 import { findSectionInGroup } from '@/lib/utils';
-import { markSpaceNavigationFromPickerOnClick } from '../hooks';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { CONTAINER_STYLE } from '../layout';
 import { ScrollContainer } from '../primitives/ScrollContainer';
@@ -65,7 +64,6 @@ export function SiteSectionTabs(props: {
                 className
             )}
             ref={containerRef}
-            onClickCapture={markSpaceNavigationFromPickerOnClick}
             style={
                 {
                     '--site-section-column-width': COLUMN_WIDTH,

--- a/packages/gitbook/src/components/TableOfContents/BackToSpaceButton.tsx
+++ b/packages/gitbook/src/components/TableOfContents/BackToSpaceButton.tsx
@@ -25,7 +25,9 @@ export function BackToSpaceButton(props: { spaceId: string; spaceTitle: string }
     }
 
     return (
-        <div className="mb-2 px-2">
+        // Top margin so the shortcut, as the first element in the sidebar, isn't flush
+        // against the (rounded) filled-sidebar edge.
+        <div className="mt-2 mb-2 px-2">
             <Link
                 href={backToSpace.url}
                 className={tcls(

--- a/packages/gitbook/src/components/TableOfContents/PagesList.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PagesList.tsx
@@ -5,6 +5,7 @@ import type { ClientTOCPage } from './encodeClientTableOfContents';
 import { type ClassValue, tcls } from '@/lib/tailwind';
 
 import assertNever from 'assert-never';
+import { markSpaceNavigationFromTOCLinkOnClick } from '../hooks';
 import { PageDocumentItem } from './PageDocumentItem';
 import { PageGroupItem } from './PageGroupItem';
 import { PageLinkItem } from './PageLinkItem';
@@ -17,7 +18,13 @@ export function PagesList(props: {
     const { pages, style, isRoot = false } = props;
 
     return (
-        <ul className={tcls('flex flex-col gap-y-0.5', style)}>
+        <ul
+            className={tcls('flex flex-col gap-y-0.5', style)}
+            // Flag navigations that start from a ToC link so the destination can offer a
+            // "Back to space" shortcut for cross-space links. Only needed on the root
+            // list: capture catches clicks on nested items too.
+            onClickCapture={isRoot ? markSpaceNavigationFromTOCLinkOnClick : undefined}
+        >
             {pages.map((page, idx) => {
                 switch (page.type) {
                     case 'document':

--- a/packages/gitbook/src/components/hooks/useBackToSpace.test.ts
+++ b/packages/gitbook/src/components/hooks/useBackToSpace.test.ts
@@ -25,20 +25,33 @@ describe('resolveBackToSpace', () => {
                 current: gettingStarted,
                 lastLocation: null,
                 storedBack: null,
-                fromPicker: false,
+                fromTocLink: false,
             })
         ).toBeNull();
     });
 
-    it('offers to go back after following a link into a different space', () => {
+    it('offers to go back after following a ToC link into a different space', () => {
         expect(
             resolveBackToSpace({
                 current: programmersGuide,
                 lastLocation: gettingStarted,
                 storedBack: null,
-                fromPicker: false,
+                fromTocLink: true,
             })
         ).toEqual(gettingStarted);
+    });
+
+    it('does not offer to go back when reaching a different space without a ToC link', () => {
+        // e.g. an in-content text link, the section/variant picker, a direct URL or the
+        // browser history — none of which should surface the shortcut.
+        expect(
+            resolveBackToSpace({
+                current: programmersGuide,
+                lastLocation: gettingStarted,
+                storedBack: null,
+                fromTocLink: false,
+            })
+        ).toBeNull();
     });
 
     it('keeps the back target while browsing within the destination space', () => {
@@ -51,20 +64,9 @@ describe('resolveBackToSpace', () => {
                 current: deeperInGuide,
                 lastLocation: programmersGuide,
                 storedBack: gettingStarted,
-                fromPicker: false,
+                fromTocLink: false,
             })
         ).toEqual(gettingStarted);
-    });
-
-    it('does not offer to go back when the space was changed through the picker', () => {
-        expect(
-            resolveBackToSpace({
-                current: programmersGuide,
-                lastLocation: gettingStarted,
-                storedBack: null,
-                fromPicker: true,
-            })
-        ).toBeNull();
     });
 
     it('clears the back target once the reader returns to the space they came from', () => {
@@ -73,31 +75,31 @@ describe('resolveBackToSpace', () => {
                 current: gettingStarted,
                 lastLocation: programmersGuide,
                 storedBack: gettingStarted,
-                fromPicker: false,
+                fromTocLink: false,
             })
         ).toBeNull();
     });
 
-    it('points back to the most recent space when chaining cross-space links', () => {
-        // Was in Getting Started (stored back), followed a link from the Programmer's
+    it('points back to the most recent space when chaining cross-space ToC links', () => {
+        // Was in Getting Started (stored back), followed a ToC link from the Programmer's
         // Guide into the API Reference: back should now point to the Programmer's Guide.
         expect(
             resolveBackToSpace({
                 current: apiReference,
                 lastLocation: programmersGuide,
                 storedBack: gettingStarted,
-                fromPicker: false,
+                fromTocLink: true,
             })
         ).toEqual(programmersGuide);
     });
 
-    it('resets the back target when switching space through the picker even if one was set', () => {
+    it('clears an existing back target when reaching a new space without a ToC link', () => {
         expect(
             resolveBackToSpace({
                 current: apiReference,
                 lastLocation: programmersGuide,
                 storedBack: gettingStarted,
-                fromPicker: true,
+                fromTocLink: false,
             })
         ).toBeNull();
     });

--- a/packages/gitbook/src/components/hooks/useBackToSpace.tsx
+++ b/packages/gitbook/src/components/hooks/useBackToSpace.tsx
@@ -24,23 +24,25 @@ export type SpaceLocation = {
 // Keys used to persist the navigation state for the current tab session.
 const LAST_LOCATION_KEY = 'gitbook-space-navigation:last';
 const BACK_TO_SPACE_KEY = 'gitbook-space-navigation:back';
-const FROM_PICKER_KEY = 'gitbook-space-navigation:from-picker';
+const FROM_TOC_LINK_KEY = 'gitbook-space-navigation:from-toc-link';
 
 /**
- * Mark that the navigation about to happen was initiated from the section/variant
- * picker (spaces dropdown, translations dropdown or section switcher).
+ * Mark that the navigation about to happen was initiated from a link in the table of
+ * contents.
  *
- * Such navigations are deliberate moves within the site's own structure and should
- * not surface a "Back to space" shortcut. Set synchronously when a picker link is
- * activated, so the flag is in place before the destination page reads it.
+ * Only deliberate, author-defined links in the ToC — including cross-space links — may
+ * surface a "Back to space" shortcut on the destination page. Reaching another space any
+ * other way (an in-content link, the section/variant picker, a direct URL or the browser
+ * history) must not. Set synchronously when a ToC link is activated, so the flag is in
+ * place before the destination page reads it.
  */
-function markSpaceNavigationFromPicker() {
-    setSessionStorageItem(FROM_PICKER_KEY, true);
+function markSpaceNavigationFromTOCLink() {
+    setSessionStorageItem(FROM_TOC_LINK_KEY, true);
 }
 
 /**
  * Whether a click opens its link in a new tab or window instead of navigating the
- * current tab (a modifier key or a non-primary button). These must not mark a picker
+ * current tab (a modifier key or a non-primary button). These must not mark a ToC
  * navigation: the current tab stays put, so the flag would otherwise linger and be
  * mis-attributed to a later, unrelated navigation.
  */
@@ -49,16 +51,16 @@ function opensInNewTab(event: React.MouseEvent): boolean {
 }
 
 /**
- * Click handler for the section/variant/translation pickers that marks the upcoming
- * navigation as picker-initiated, so arriving in the target space doesn't surface a
- * "Back to space" shortcut.
+ * Click handler for the table of contents that marks the upcoming navigation as
+ * ToC-initiated, so arriving in a different space can surface the "Back to space"
+ * shortcut.
  *
- * Attach it with `onClickCapture` on a picker container (section list/tabs) or as the
- * `onClick` of a picker menu item (spaces dropdown). It intentionally does nothing for
- * clicks that leave the current tab unchanged: re-selecting the already-active item,
- * or opening the link in a new tab/window.
+ * Attach it with `onClickCapture` on the root of the page list. It intentionally does
+ * nothing for clicks that leave the current tab unchanged — not on a link, re-selecting
+ * the already-active page, or opening the link in a new tab/window — since the flag
+ * would otherwise linger and be mis-attributed to a later, unrelated navigation.
  */
-export function markSpaceNavigationFromPickerOnClick(event: React.MouseEvent<HTMLElement>) {
+export function markSpaceNavigationFromTOCLinkOnClick(event: React.MouseEvent<HTMLElement>) {
     if (opensInNewTab(event)) {
         return;
     }
@@ -73,17 +75,13 @@ export function markSpaceNavigationFromPickerOnClick(event: React.MouseEvent<HTM
         return;
     }
 
-    // Skip the currently active item: re-selecting it doesn't navigate. The sidebar
-    // section list marks the active link with `aria-current`, while the header section
-    // tabs (rendered via the Button primitive) use `aria-pressed`.
-    if (
-        link.getAttribute('aria-current') === 'page' ||
-        link.getAttribute('aria-pressed') === 'true'
-    ) {
+    // Skip the currently active page: re-selecting it doesn't navigate, so the flag
+    // would linger. Active ToC links are marked with `aria-current="page"`.
+    if (link.getAttribute('aria-current') === 'page') {
         return;
     }
 
-    markSpaceNavigationFromPicker();
+    markSpaceNavigationFromTOCLink();
 }
 
 /**
@@ -97,9 +95,9 @@ export function resolveBackToSpace(input: {
     current: SpaceLocation;
     lastLocation: SpaceLocation | null;
     storedBack: SpaceLocation | null;
-    fromPicker: boolean;
+    fromTocLink: boolean;
 }): SpaceLocation | null {
-    const { current, lastLocation, storedBack, fromPicker } = input;
+    const { current, lastLocation, storedBack, fromTocLink } = input;
 
     // No previous navigation this session, or we're still browsing the same space:
     // keep whatever "back" target we already had (it persists while browsing).
@@ -109,18 +107,20 @@ export function resolveBackToSpace(input: {
 
     // The reader moved to a different space since the last navigation.
 
-    // Switching space through the picker is a deliberate navigation within the
-    // site structure: reset the context instead of offering to go back.
-    if (fromPicker) {
-        return null;
-    }
-
-    // The reader returned to the space they originally came from.
+    // The reader returned to the space they originally came from: clear the shortcut.
     if (storedBack && storedBack.spaceId === current.spaceId) {
         return null;
     }
 
-    // The reader followed a link into a different space: offer to go back to the
+    // Only a deliberate cross-space link in the table of contents may surface the
+    // shortcut — that was the intent of the feature. Reaching a different space any
+    // other way (an in-content link, the section/variant picker, a direct URL or the
+    // browser history) must not introduce it, and clears any shortcut we were showing.
+    if (!fromTocLink) {
+        return null;
+    }
+
+    // The reader followed a ToC link into a different space: offer to go back to the
     // page they were on.
     return lastLocation;
 }
@@ -128,11 +128,10 @@ export function resolveBackToSpace(input: {
 /**
  * Track navigation between spaces and return the space to offer navigating back to.
  *
- * When a reader follows a link (in the ToC or in the content) into a space different
- * from the one they were browsing, we remember where they came from so a "Back to
- * [space]" shortcut can be surfaced. The shortcut persists while they browse the
- * destination space and is cleared once they return or switch space through the
- * section/variant picker.
+ * When a reader follows a cross-space link in the ToC into a space different from the
+ * one they were browsing, we remember where they came from so a "Back to [space]"
+ * shortcut can be surfaced. The shortcut persists while they browse the destination
+ * space and is cleared once they return or reach another space some other way.
  *
  * The state is kept in `sessionStorage` so it survives both client-side and full-page
  * navigations within the tab, without leaking across tabs or sessions.
@@ -154,14 +153,14 @@ export function useBackToSpace(current: {
             url: `${pathname}${window.location.search}`,
         };
 
-        const fromPicker = getSessionStorageItem<boolean>(FROM_PICKER_KEY, false);
-        removeSessionStorageItem(FROM_PICKER_KEY);
+        const fromTocLink = getSessionStorageItem<boolean>(FROM_TOC_LINK_KEY, false);
+        removeSessionStorageItem(FROM_TOC_LINK_KEY);
 
         const back = resolveBackToSpace({
             current: currentLocation,
             lastLocation: getSessionStorageItem<SpaceLocation | null>(LAST_LOCATION_KEY, null),
             storedBack: getSessionStorageItem<SpaceLocation | null>(BACK_TO_SPACE_KEY, null),
-            fromPicker,
+            fromTocLink,
         });
 
         if (back) {

--- a/packages/gitbook/src/components/hooks/useBackToSpace.tsx
+++ b/packages/gitbook/src/components/hooks/useBackToSpace.tsx
@@ -55,10 +55,13 @@ function opensInNewTab(event: React.MouseEvent): boolean {
  * ToC-initiated, so arriving in a different space can surface the "Back to space"
  * shortcut.
  *
- * Attach it with `onClickCapture` on the root of the page list. It intentionally does
- * nothing for clicks that leave the current tab unchanged — not on a link, re-selecting
- * the already-active page, or opening the link in a new tab/window — since the flag
- * would otherwise linger and be mis-attributed to a later, unrelated navigation.
+ * Attach it with `onClickCapture` on the root of the page list. It only flags clicks
+ * that will actually navigate to a different page, since the destination effect is what
+ * consumes the flag: a click that doesn't change the pathname would leave the flag
+ * lingering, to be mis-attributed to a later, unrelated navigation. So it does nothing
+ * for clicks that open a new tab/window, land on a nested control (e.g. the
+ * expand/collapse chevron, which toggles the tree rather than navigating), or target the
+ * current page (the active item or an in-page anchor).
  */
 export function markSpaceNavigationFromTOCLinkOnClick(event: React.MouseEvent<HTMLElement>) {
     if (opensInNewTab(event)) {
@@ -70,14 +73,21 @@ export function markSpaceNavigationFromTOCLinkOnClick(event: React.MouseEvent<HT
         return;
     }
 
-    const link = target.closest('a[href]');
-    if (!link) {
+    // The expand/collapse chevron is a <button> nested inside the link; clicking it only
+    // toggles the tree (it calls preventDefault/stopPropagation), so it must not flag a
+    // navigation — and this runs in the capture phase, before that handler.
+    if (target.closest('button')) {
         return;
     }
 
-    // Skip the currently active page: re-selecting it doesn't navigate, so the flag
-    // would linger. Active ToC links are marked with `aria-current="page"`.
-    if (link.getAttribute('aria-current') === 'page') {
+    const link = target.closest('a[href]');
+    if (!(link instanceof HTMLAnchorElement)) {
+        return;
+    }
+
+    // Skip same-page links (the active item, or an in-page anchor): they don't change the
+    // pathname, so the effect never re-runs to consume the flag.
+    if (link.pathname === window.location.pathname) {
         return;
     }
 


### PR DESCRIPTION
## Overview

Makes the "Back to [space]" sidebar shortcut strict, so it only appears for the case it was designed for in RND-11590: following a **cross-space link in the table of contents**.

- Previously the shortcut showed for *any* navigation that ended up in a different space (unless it went through a section/variant picker). Following an in-content text link into another space wrongly triggered it — e.g. clicking a card link on a home page and landing on a "Back to …" shortcut.
- Detection is now **opt-in** instead of opt-out: a navigation only qualifies when it was initiated from a link in the table of contents (flagged with `onClickCapture` on the root page list). Reaching another space any other way — an in-content link, the section/variant picker, a direct URL or the browser history — no longer introduces the shortcut and clears any shortcut currently shown.
- Removed the now-redundant picker-suppression markers from the section list, section tabs and spaces dropdown.
- Gave the shortcut a small top margin so it isn't flush against the rounded edge of a `sidebar-filled` sidebar.

## Demo

**Behavior**

- _Before:_ on a site's home page, following an in-content link into another space surfaced a "Back to [space]" shortcut.
- _After:_ the shortcut appears only when the cross-space navigation came from a ToC link — intentional, author-defined cross-space links still work as before.

**Sidebar spacing (`sidebar-filled`)** — the shortcut previously sat flush against the rounded top corner (0px); it now has an 8px top margin.

| Sidebar mode | Top gap (before → after) |
| --- | --- |
| `sidebar-default` | 0px → 8px |
| `sidebar-filled` | 0px → 8px |

## Testing

- Updated the `resolveBackToSpace` unit tests to the opt-in model and added a regression test asserting the shortcut does **not** appear when a different space is reached without a ToC link.
- `bun run typecheck` and `bun run format` pass.
- Verified in the local dev preview by forcing the shortcut to render, confirming it appears with the correct top margin in both `sidebar-default` and `sidebar-filled`.

Closes RND-11856

*— Authored by Claude*
