### PR TITLE
docs(agents): discourage multi-line block comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,7 @@ Save as `.changeset/<name>.md`, then commit it separately with message: `changes
 ## Formatting
 
 Uses Biome (not ESLint/Prettier). Always run `bun run format` before committing.
+
+## Comments
+
+Comment to explain *why*, not *what* — the code already shows what it does. Keep comments short, ideally a single line. Avoid multi-line block comments that narrate mechanics a reader can follow from the code; they add noise and go stale. Reserve longer comments for genuinely non-obvious rationale: a subtle invariant, or a workaround and the reason it exists.


### PR DESCRIPTION
## Proposed changes

Adds a short **Comments** guideline to `AGENTS.md` (which `CLAUDE.md` imports via `@AGENTS.md`): comment the *why* not the *what*, keep comments short/single-line, and avoid multi-line block comments that narrate mechanics the code already shows — reserving longer comments for genuinely non-obvious rationale.

Follows review feedback on #4377 that verbose block comments add noise and go stale. Split out as its own PR since it's a repo-wide convention change rather than part of the feature.

Docs-only; no code changes.

## Changelog

- [Chore] Add a comment-style guideline to AGENTS.md/CLAUDE.md (prefer terse "why" comments; avoid multi-line block comments).