### PR TITLE
Fix copy button in Assistant embed (RND-11876)

### DIFF
--- a/.changeset/rnd-11876-embed-copy-button.md
+++ b/.changeset/rnd-11876-embed-copy-button.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the code-block copy button not copying (and logging a console error) in the AI Assistant embed. The async Clipboard API can be unavailable or rejected in cross-origin iframe / non-secure embed contexts; we now fall back to a legacy `execCommand('copy')` write and only show the "copied" state when the copy actually succeeds.

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/CopyCodeButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/CopyCodeButton.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/primitives';
 import { t, useLanguage } from '@/intl/client';
 import { type ClassValue, tcls } from '@/lib/tailwind';
 
-import { getCodeTextFromId } from './utils';
+import { copyToClipboard, getCodeTextFromId } from './utils';
 
 /**
  * Client component to copy the code of a code block.
@@ -32,15 +32,17 @@ export function CopyCodeButton(props: { codeId: string; style: ClassValue }) {
         };
     }, [copied]);
 
-    const onClick = () => {
+    const onClick = async () => {
         const codeText = getCodeTextFromId(codeId);
         if (codeText === null) {
             return;
         }
 
-        navigator.clipboard.writeText(codeText);
-
-        setCopied(true);
+        // Only surface the "copied" state when the write actually succeeded, so a blocked
+        // clipboard in the embed no longer looks like a successful copy.
+        if (await copyToClipboard(codeText)) {
+            setCopied(true);
+        }
     };
 
     return (

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/utils.ts
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/utils.ts
@@ -76,6 +76,61 @@ export function getCodeTextFromId(codeId: string): string | null {
 }
 
 /**
+ * Copy text to the clipboard in a way that survives embed contexts.
+ *
+ * The async Clipboard API (`navigator.clipboard`) is unavailable or rejects in some embed
+ * setups — cross-origin iframes where the `clipboard-write` permission wasn't delegated, or
+ * non-secure contexts — which is why copying silently failed (and logged an error) in the
+ * Assistant embed. We fall back to a hidden `<textarea>` + `execCommand('copy')` so the button
+ * keeps working there. Returns whether the copy succeeded so callers only show a success state
+ * when the text actually reached the clipboard.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+            return true;
+        } catch {
+            // The async API can reject in restricted embed contexts; fall back below.
+        }
+    }
+
+    return copyWithExecCommand(text);
+}
+
+/**
+ * Legacy clipboard write used as a fallback when the async Clipboard API is unavailable.
+ *
+ * `execCommand('copy')` still works in cross-origin iframes where the async API is blocked,
+ * which is why we keep it as the safety net for the embed.
+ */
+function copyWithExecCommand(text: string): boolean {
+    if (typeof document === 'undefined') {
+        return false;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    // Keep it out of view and avoid scrolling/zooming to it when focused.
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+
+    try {
+        textarea.focus();
+        textarea.select();
+        return document.execCommand('copy');
+    } catch {
+        return false;
+    } finally {
+        textarea.remove();
+    }
+}
+
+/**
  * Compute the code text from the DOM,
  * ignoring the empty white space we use for empty lines (represented with a class "ew").
  */


### PR DESCRIPTION
## Proposed changes

The **Copy** button on code blocks inside the AI Assistant embed does nothing and logs a console error — a regression of [RND-10845](https://linear.app/gitbook-x/issue/RND-10845), which was fixed in #4251 ("Allow to copy in embed"). The reporter of [RND-11876](https://linear.app/gitbook-x/issue/RND-11876) confirms it is "the same error as before."

### Root cause

#4251 fixed the original report by delegating the `clipboard-write` permission to the embed iframe (`allow="clipboard-write"` on `GitBookFrame`, `createGitBookFrame`, and the standalone widget). Those attributes are all still in place.

However, the actual clipboard write in `CopyCodeButton` was never hardened. It called `navigator.clipboard.writeText(codeText)` directly:

- with no `await` and no `catch`, so when the async Clipboard API rejects (cross-origin iframe where the permission wasn't delegated by the host page, or a non-secure context) it produces the **unhandled rejection / console error** the reporter sees;
- and it called `setCopied(true)` unconditionally, so the UI showed a successful "Copied" state even though nothing reached the clipboard.

The async Clipboard API is fragile in embed contexts regardless of the `allow` attribute (it depends on the host page's permissions policy, secure context, and browser). So relying on it alone lets the original failure mode return.

### Fix

Add a resilient `copyToClipboard` helper (co-located in the code block `utils.ts`) that:

1. uses `navigator.clipboard.writeText` when available, guarded and wrapped in `try/catch`;
2. falls back to a hidden `<textarea>` + `document.execCommand('copy')`, which still works in cross-origin iframes where the async API is blocked;
3. returns whether the copy actually succeeded.

`CopyCodeButton` now `await`s it and only shows the "copied" state on success. This is the smallest change that restores copy in the embed; no existing behaviour changes in the normal (non-embed) path.

### Testing

- `bunx biome check` clean on the changed files; `tsc` reports no errors in the changed files (the pre-existing `tsc` errors in the package are unbuilt-workspace-dep / env-type issues unrelated to this change).
- **Test gap:** the only existing unit test surface for this area (`CodeBlock/utils.test.ts`) covers the pure `convertCodeStringToBlock` function and mocks no browser APIs. Per the repo's frontend testing guidance, I did not introduce browser-API mocking just to cover this. A Playwright test that drives copy inside the embed would be the right long-term guard but is out of scope for this draft — noted as a possible follow-up.
- Not manually verified in a live embed against the reporter's site (`docs.enterprise.10duke.com`); worth a quick smoke test there and in Safari (which is the browser most likely to exercise the `execCommand` fallback).

## Changelog
- [Fix] Fixed the code-block copy button not copying (and logging a console error) in the AI Assistant embed.

---
Drafted by the GitBook night shift for @zenoachtig to review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxDckjBnKCnQDGnuWufeKp)_