### PR TITLE
Fix embed ignoring explicit ?theme override on single-theme sites (RND-11571)

### DIFF
--- a/.changeset/rnd-11571-embed-force-theme.md
+++ b/.changeset/rnd-11571-embed-force-theme.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Embed: an explicit `?theme=light` / `?theme=dark` (the SDK `colorScheme` option) now reliably forces the embed's color scheme, even on sites where the theme toggle is disabled. Previously single-theme sites ignored the requested scheme.

--- a/packages/gitbook/src/lib/embeddable.test.ts
+++ b/packages/gitbook/src/lib/embeddable.test.ts
@@ -146,14 +146,31 @@ describe('resolveEmbeddableTheme', () => {
         });
     });
 
-    it('keeps the site theme for single-theme sites', () => {
+    it('keeps the site theme for single-theme sites without an override', () => {
         expect(
             resolveEmbeddableTheme(
                 createCustomization({
                     toggeable: false,
                     default: CustomizationDefaultThemeMode.Light,
+                })
+            )
+        ).toEqual({
+            htmlTheme: CustomizationDefaultThemeMode.Light,
+            defaultTheme: CustomizationDefaultThemeMode.Light,
+            forcedTheme: CustomizationDefaultThemeMode.Light,
+        });
+    });
+
+    it('honors an explicit override on single-theme sites (RND-11571)', () => {
+        // A `?theme=light` embed on a site with the theme toggle disabled must still
+        // force the requested scheme, since a webview can only pass it via the URL.
+        expect(
+            resolveEmbeddableTheme(
+                createCustomization({
+                    toggeable: false,
+                    default: CustomizationDefaultThemeMode.Dark,
                 }),
-                CustomizationDefaultThemeMode.Dark
+                CustomizationDefaultThemeMode.Light
             )
         ).toEqual({
             htmlTheme: CustomizationDefaultThemeMode.Light,

--- a/packages/gitbook/src/lib/embeddable.ts
+++ b/packages/gitbook/src/lib/embeddable.ts
@@ -46,6 +46,18 @@ export function resolveEmbeddableTheme(
     customization: Pick<SiteCustomizationSettings, 'themes'>,
     forcedTheme?: CustomizationDefaultThemeMode | null
 ) {
+    // An explicit override (the embed's `?theme=` / `colorScheme` option) always wins, even for
+    // single-theme sites: the embedder is deliberately matching the color scheme of their own page,
+    // and a webview can only pass it via the URL. This must be checked before the toggeable branch,
+    // otherwise a site with the theme toggle disabled silently ignores the requested scheme. RND-11571
+    if (forcedTheme) {
+        return {
+            htmlTheme: forcedTheme,
+            defaultTheme: forcedTheme,
+            forcedTheme,
+        };
+    }
+
     if (!customization.themes.toggeable) {
         const mode = customization.themes.default;
         return {
@@ -53,14 +65,6 @@ export function resolveEmbeddableTheme(
             defaultTheme: mode,
             // Only force concrete light/dark; System stays unforced so next-themes resolves prefers-color-scheme pre-paint (avoids the flash). A theme saved while the toggle was previously on still wins — see the PR's "Known limitation". RND-11643
             forcedTheme: mode === CustomizationDefaultThemeMode.System ? undefined : mode,
-        };
-    }
-
-    if (forcedTheme) {
-        return {
-            htmlTheme: forcedTheme,
-            defaultTheme: forcedTheme,
-            forcedTheme,
         };
     }
 


### PR DESCRIPTION
## Proposed changes

Fixes [RND-11571](https://linear.app/gitbook/issue/RND-11571) — "Iframe light theme does not apply correctly". Two customer Intercom reports; the affected setup is a mobile app that renders the GitBook embed inside a webview, so only the URL/query param and iframe CSS are available (no JS/React).

### Root cause

Loading the embed with `?theme=light` (what the embed SDK's `colorScheme` option produces, via `createGitBook().getFrameURL({ colorScheme })`) does reach the server: the middleware turns any `?theme=light|dark` request into a **dynamic** route and forwards it as the `x-gitbook-theme` header, and the dynamic embed layout reads it with `getThemeFromMiddleware()` and passes it as `forcedTheme` into `resolveEmbeddableTheme()`.

The bug is in `resolveEmbeddableTheme()` (`packages/gitbook/src/lib/embeddable.ts`): it checked the `!customization.themes.toggeable` branch **before** the explicit `forcedTheme`. So for any site with the theme toggle disabled — the common case — the function returned early with the site's own default theme and silently dropped the requested scheme. `?theme=light` only worked on multi-theme (toggeable) sites.

### The fix

Reorder the checks so an explicit `forcedTheme` (from `?theme=` / the SDK `colorScheme`) is honored first, regardless of the site's toggle setting. The embedder is deliberately matching the color scheme of their own page, and in a webview the query param is the only lever they have. All other behavior (single-theme default, the `System` no-flash handling from RND-11643, multi-theme default following the frame) is unchanged.

Files changed:
- `packages/gitbook/src/lib/embeddable.ts` — reorder so the explicit override wins.
- `packages/gitbook/src/lib/embeddable.test.ts` — the existing "single-theme sites" test encoded the buggy behavior (override ignored); split it into an unchanged no-override case and a new case asserting the override now wins.
- `.changeset/rnd-11571-embed-force-theme.md` — patch changeset.

## Testing

What I verified:
- `bun test src/lib/embeddable.test.ts` — 11/11 pass, including the new "honors an explicit override on single-theme sites" case. Confirmed the new test **fails before** the reorder and **passes after**.
- Traced the full request path (middleware `?theme` → dynamic route → `getThemeFromMiddleware` → `resolveEmbeddableTheme`) by reading the code to confirm the fix sits at the actual decision point and that `?theme` reaches it for published (non-preview) sites.

What I did NOT verify:
- No end-to-end / browser run against a real embedded site or a real mobile webview. The customer repro (webview + `?theme=light`) was not reproduced live.
- The **second** symptom in the issue — setting the iframe CSS `color-scheme: light` rendering incorrectly — is **not** addressed here. When no `?theme` is given the embed follows `System` (prefers-color-scheme), which tracks the OS, not the iframe's CSS `color-scheme` property; that mismatch is a browser limitation that a query-param fix can't change. The reliable lever for a webview is `?theme=`, which this PR fixes. Flagging so a reviewer can decide whether the CSS path needs separate work.
- No typecheck of the full `gitbook` app was run (the change is a pure branch reorder with identical return shapes).

Drafted by the GitBook night shift for @zenoachtig to review.

## Changelog
- [Fix] Embed: `?theme=light` / `?theme=dark` now reliably forces the embed's color scheme, even on sites with the theme toggle disabled.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MN7HAu1vHzuFeND4UCRCBo)_