### PR TITLE
Declare embed standalone bundle as a Turbo build output (RND-11876)

### DIFF
--- a/.changeset/rnd-11876-embed-standalone-turbo-output.md
+++ b/.changeset/rnd-11876-embed-standalone-turbo-output.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the docs embed widget shipping a stale script: declare the embed package's `standalone/` bundle as a Turbo build output. Because it wasn't declared, changes confined to the standalone widget (which compiles to `standalone/` but not `dist/`) didn't invalidate the downstream `generate` cache that copies it into the app, so the deployed widget could lag the source — e.g. the `clipboard-write` permission on the widget iframe never reached production, breaking the copy button in the Assistant embed.

--- a/packages/embed/turbo.json
+++ b/packages/embed/turbo.json
@@ -1,0 +1,8 @@
+{
+    "extends": ["//"],
+    "tasks": {
+        "build": {
+            "outputs": ["dist/**", "standalone/**"]
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Root-cause fix for [RND-11876](https://linear.app/gitbook-x/issue/RND-11876) — the copy button in the Assistant embed "not working" — which turned out to be a **build-cache staleness bug**, not an app bug. (Supersedes the earlier attempt in #4383, now closed: the widget code was already correct; it just wasn't reaching production.)

### Root cause

The embed widget script served at `~gitbook/static/embed/index.js` is a **copied build artifact**, not an import:

- `@gitbook/embed` builds a self-executing widget to `standalone/` via its `build-standalone` script.
- The gitbook app's `generate.sh` copies it in: `cp -r ../embed/standalone/ ./public/~gitbook/static/embed`.
- `packages/gitbook/turbo.json` already does the right thing on its side — it declares `public/~gitbook/static/embed/**` as a `generate` output **and** depends on `@gitbook/embed#build`.

The gap is upstream: **`@gitbook/embed`'s `build` task only declared `dist/` as an output — never `standalone/`.** Turbo folds a dependency's *declared outputs* into the dependent's cache key, and only restores declared outputs on a cache hit. So a change confined to the standalone widget — which compiles to `standalone/` but **not** `dist/` (the lib build is from `src/index.ts`, which doesn't import the standalone entry) — never changed embed#build's declared outputs, never invalidated the downstream `generate` cache, and never got restored on a cache hit.

Net effect: `src/standalone/index.ts` has set `widgetIframe.allow = 'clipboard-write'` since #4321 (June 17), a fresh local build contains it, but the **deployed** widget bundle lagged the source and shipped without it — so the embed iframe lacked the `clipboard-write` permission and the copy button failed.

### Fix

Add `packages/embed/turbo.json` declaring `standalone/**` (alongside `dist/**`) as outputs of the embed `build` task. This makes the standalone bundle part of the cache key/artifact, so changes to it correctly bust the downstream copy cache and the freshly built widget reaches production.

One file; build-config only; no runtime code change.

### Verifying / how to confirm in prod

Grep the live `…/~gitbook/static/embed/index.js` for `clipboard-write`. Pre-fix it's absent (stale); after this lands and a fresh deploy runs, it should be present, and the Assistant-embed copy button works via the widget's `allow="clipboard-write"` (confirmed working when the bundle is current).

Note: a customer's **hand-rolled** `<iframe>` (not our widget/script) still needs `allow="clipboard-write"` on their own element — that's separate from this pipeline fix.

## Changelog
- [Fix] Fixed the docs embed widget shipping a stale script, which (among other things) dropped the `clipboard-write` permission on the embed iframe and broke the copy button in the Assistant embed.

---
Drafted by the GitBook night shift for @zenoachtig to review — left as draft since it touches the Turbo build graph.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxDckjBnKCnQDGnuWufeKp)_