### PR TITLE
Take a near-neutral extreme tint as the exact site background

### DIFF
--- a/.changeset/exact-light-tint-background.md
+++ b/.changeset/exact-light-tint-background.md
@@ -1,0 +1,6 @@
+---
+"@gitbook/colors": patch
+"gitbook": patch
+---
+
+A near-white tint color (e.g. a warm `#F5F3EF`) is now taken as the exact page background, mirroring the existing behavior for near-black tints. The tint's exact lightness, hue and chroma are preserved, and the color is anchored to whichever scale step the active theme renders as the background — so it matches exactly on `muted` (which uses the second step) as well as the other themes. This only applies to near-neutral tints; saturated colors keep their normal accent scale.

--- a/.changeset/exact-light-tint-background.md
+++ b/.changeset/exact-light-tint-background.md
@@ -3,4 +3,4 @@
 "gitbook": patch
 ---
 
-A near-white tint color (e.g. a warm `#F5F3EF`) is now taken as the exact page background, mirroring the existing behavior for near-black tints. The tint's exact lightness, hue and chroma are preserved, and the color is anchored to whichever scale step the active theme renders as the background — so it matches exactly on `muted` (which uses the second step) as well as the other themes. This only applies to near-neutral tints; saturated colors keep their normal accent scale.
+A near-white tint color (e.g. a warm `#F5F3EF`) is now taken as the exact page background, mirroring the existing behavior for near-black tints. The tint's exact lightness, hue and chroma are preserved, and the color is anchored to whichever scale step the active theme renders as the background — so it matches exactly on `muted` (which uses the second step) as well as `clean`. This applies only to near-neutral tints that are light enough to read as a background; saturated or merely light-ish colors keep their normal accent scale. The `bold` theme is unaffected: it already uses the tint for the header and stays intentionally two-tone.

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -17,6 +17,7 @@
     "scripts": {
         "build": "tsdown",
         "typecheck": "tsc --noEmit",
+        "unit": "bun test",
         "dev": "bun run build -- --watch ./src",
         "publish-to-npm": "../../scripts/publish-if-new.sh"
     },

--- a/packages/colors/src/transformations.test.ts
+++ b/packages/colors/src/transformations.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+
+import { colorScale } from './transformations';
+
+describe('colorScale exact base', () => {
+    it('takes a very light tint as the exact background on step 1 (clean/bold)', () => {
+        const scale = colorScale('#F5F3EF', { baseStep: 1 });
+        expect(scale[0]).toBe('#F5F3EF');
+    });
+
+    it('anchors a very light tint to step 2 when the theme uses the subtle step (muted)', () => {
+        const scale = colorScale('#F5F3EF', { baseStep: 2 });
+        expect(scale[1]).toBe('#F5F3EF');
+        // Step 1 sits just above the exact base, toward white.
+        expect(scale[0]).not.toBe('#F5F3EF');
+        expect(scale[0]).not.toBe('#ffffff');
+    });
+
+    it('takes a darker-than-dark tint as the exact background, preserving hue and chroma', () => {
+        const scale = colorScale('#0B0F19', { darkMode: true, baseStep: 1 });
+        expect(scale[0]).toBe('#0B0F19');
+    });
+
+    it('does not trigger for a normal mid-lightness tint', () => {
+        const scale = colorScale('#787878', { baseStep: 2 });
+        // The default white background is kept; the tint only colors the scale.
+        expect(scale[0]).toBe('#ffffff');
+        expect(scale[1]).not.toBe('#787878');
+    });
+
+    it('does not trigger for a saturated light color, keeping the normal accent ramp', () => {
+        // Light enough (L≈0.93) to pass the lightness bound, but too chromatic to read as a
+        // background — emitting it verbatim would leave a vivid step 1 above a near-gray scale.
+        const scale = colorScale('#FFEB3B', {});
+        expect(scale[0]).toBe('#ffffff');
+        expect(scale[0]).not.toBe('#FFEB3B');
+    });
+});

--- a/packages/colors/src/transformations.test.ts
+++ b/packages/colors/src/transformations.test.ts
@@ -31,7 +31,7 @@ describe('colorScale exact base', () => {
     it('does not trigger for a saturated light color, keeping the normal accent ramp', () => {
         // Light enough (L≈0.93) to pass the lightness bound, but too chromatic to read as a
         // background — emitting it verbatim would leave a vivid step 1 above a near-gray scale.
-        const scale = colorScale('#FFEB3B', {});
+        const scale = colorScale('#FFEB3B', { baseStep: 1 });
         expect(scale[0]).toBe('#ffffff');
         expect(scale[0]).not.toBe('#FFEB3B');
     });
@@ -39,7 +39,7 @@ describe('colorScale exact base', () => {
     it('respects a custom light background instead of overriding it with the tint', () => {
         // The color is darker than the requested background, so it is not the extreme end and the
         // supplied base must be preserved rather than overwritten.
-        const scale = colorScale('#eeeeee', { background: '#f8f8f8' });
+        const scale = colorScale('#eeeeee', { baseStep: 1, background: '#f8f8f8' });
         expect(scale[0]).not.toBe('#eeeeee');
     });
 
@@ -51,5 +51,19 @@ describe('colorScale exact base', () => {
             mix: { color: '#787878', ratio: 0.4 },
         });
         expect(scale[0]).toBe('#F5F3EF');
+    });
+
+    it('does not trigger for a light accent color below the near-white threshold', () => {
+        // #D8DEEC (light blue-gray, L≈0.90) is a UI accent, not a background, so it must not anchor.
+        const scale = colorScale('#D8DEEC', { baseStep: 1 });
+        expect(scale[0]).toBe('#ffffff');
+        expect(scale[0]).not.toBe('#D8DEEC');
+    });
+
+    it('never anchors when no baseStep is given (accent scales and the bold theme)', () => {
+        // A scale that does not define the page background opts out of the exact base entirely.
+        const scale = colorScale('#F5F3EF', {});
+        expect(scale[0]).toBe('#ffffff');
+        expect(scale[0]).not.toBe('#F5F3EF');
     });
 });

--- a/packages/colors/src/transformations.test.ts
+++ b/packages/colors/src/transformations.test.ts
@@ -35,4 +35,21 @@ describe('colorScale exact base', () => {
         expect(scale[0]).toBe('#ffffff');
         expect(scale[0]).not.toBe('#FFEB3B');
     });
+
+    it('respects a custom light background instead of overriding it with the tint', () => {
+        // The color is darker than the requested background, so it is not the extreme end and the
+        // supplied base must be preserved rather than overwritten.
+        const scale = colorScale('#eeeeee', { background: '#f8f8f8' });
+        expect(scale[0]).not.toBe('#eeeeee');
+    });
+
+    it('anchors an exact base even when a neutral mix is supplied (tint === primary)', () => {
+        // getTintMixColor blends neutral into the tint when it equals the primary color; that must
+        // not darken a near-white tint out of the exact-base path.
+        const scale = colorScale('#F5F3EF', {
+            baseStep: 1,
+            mix: { color: '#787878', ratio: 0.4 },
+        });
+        expect(scale[0]).toBe('#F5F3EF');
+    });
 });

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -84,9 +84,10 @@ export const colorMixMapping = {
 
 /**
  * Light mode has no equivalent to the dark base bound (nothing is lighter than white), so a tint
- * at or above this lightness is treated as an explicit, near-white background (e.g. a warm `#F5F3EF`).
+ * at or above this lightness is treated as an explicit, near-white background (e.g. a warm `#F5F3EF`
+ * at L≈0.96). Kept high so light UI accent colors (around L≈0.90) aren't mistaken for backgrounds.
  */
-const EXACT_BASE_LIGHT_THRESHOLD = 0.9;
+const EXACT_BASE_LIGHT_THRESHOLD = 0.95;
 
 /**
  * Only a near-neutral tint reads as a background. A saturated color would keep the exact hue at the
@@ -175,10 +176,10 @@ export type ColorScaleOptions = {
     foreground?: string;
 
     /**
-     * The 1-indexed scale step that the consuming theme renders as the page background
-     * (1 = `clean`/`bold` → `tint-base`, 2 = `muted` → `tint-subtle`). When a tint sits at the
-     * extreme light/dark end and is taken as the exact base, the supplied color is anchored to
-     * this step so the page background matches it exactly regardless of theme. Defaults to 1.
+     * The 1-indexed scale step this scale renders as the page background (1 = `tint-base` for
+     * `clean`, 2 = `tint-subtle` for `muted`). When set, an extreme near-neutral tint is taken as
+     * the exact background, anchored to this step so it matches exactly. Omit for scales that don't
+     * define the page background (accents, or the two-tone `bold` theme) — they never anchor.
      */
     baseStep?: number;
 
@@ -202,7 +203,7 @@ export function colorScale(
         darkMode = false,
         background = darkMode ? DARK_BASE : LIGHT_BASE,
         foreground = darkMode ? LIGHT_BASE : DARK_BASE,
-        baseStep = 1,
+        baseStep,
         mix,
     }: ColorScaleOptions = {}
 ) {
@@ -214,16 +215,18 @@ export function colorScale(
 
     // A near-neutral tint at the extreme end of the scale is taken as the exact page background
     // rather than tinting pure black/white with it — letting brands set an exact background such as
-    // a warm `#F5F3EF`. In light mode the base is pure white by default, so a near-white tint also
-    // qualifies (nothing is lighter than white); a custom, lower background is respected instead.
-    // Decided on the raw color so a neutral mix (below) can't darken a tint out of the exact base.
+    // a warm `#F5F3EF`. Only scales that define the page background opt in (via `baseStep`). In light
+    // mode the base is pure white by default, so a near-white tint also qualifies (nothing is lighter
+    // than white); a custom, lower background is respected instead. Decided on the raw color so a
+    // neutral mix (below) can't darken a tint out of the exact base.
     const isExtremeBase = darkMode
         ? baseColor.L < backgroundColor.L
         : backgroundColor.L >= LIGHT_BASE_L
           ? baseColor.L > EXACT_BASE_LIGHT_THRESHOLD
           : baseColor.L > backgroundColor.L;
-    const isExactBase = isExtremeBase && baseColor.C < EXACT_BASE_NEUTRAL_CHROMA;
-    const exactBaseIndex = baseStep - 1;
+    const isExactBase =
+        baseStep !== undefined && isExtremeBase && baseColor.C < EXACT_BASE_NEUTRAL_CHROMA;
+    const exactBaseIndex = (baseStep ?? 1) - 1;
 
     if (mixColor && mix?.ratio && mix.ratio > 0 && !isExactBase) {
         // Mix a little of the mix color into the base — but not when the tint is the exact base,

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -272,7 +272,9 @@ export function colorScale(
                 case 11:
                     return 0.1;
                 default:
-                    return index * 0.05;
+                    // When the tint is the exact base, hold the low steps at its chroma instead of
+                    // desaturating to gray, so the background end stays consistently tinted.
+                    return isExactBase ? 1 : index * 0.05;
             }
         })();
 

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -83,6 +83,18 @@ export const colorMixMapping = {
 };
 
 /**
+ * Light mode has no equivalent to the dark base bound (nothing is lighter than white), so a tint
+ * at or above this lightness is treated as an explicit, near-white background (e.g. a warm `#F5F3EF`).
+ */
+const EXACT_BASE_LIGHT_THRESHOLD = 0.9;
+
+/**
+ * Only a near-neutral tint reads as a background. A saturated color would keep the exact hue at the
+ * anchored step while the rest of the low scale stays ~gray, so those keep the normal accent ramp.
+ */
+const EXACT_BASE_NEUTRAL_CHROMA = 0.05;
+
+/**
  * Convert a hex color to an RGB color.
  */
 export function hexToRgb(hex: string): string {
@@ -159,6 +171,14 @@ export type ColorScaleOptions = {
     /** Define a custom foreground color to use. If left undefined, the global `light`/`dark` values (in `colors.ts`) will be used. */
     foreground?: string;
 
+    /**
+     * The 1-indexed scale step that the consuming theme renders as the page background
+     * (1 = `clean`/`bold` → `tint-base`, 2 = `muted` → `tint-subtle`). When a tint sits at the
+     * extreme light/dark end and is taken as the exact base, the supplied color is anchored to
+     * this step so the page background matches it exactly regardless of theme. Defaults to 1.
+     */
+    baseStep?: number;
+
     mix?: {
         /** If set to a hex code, this color will be additionally mixed into the generated scale according to `mix.ratio`. */
         color: string;
@@ -179,6 +199,7 @@ export function colorScale(
         darkMode = false,
         background = darkMode ? DARK_BASE : LIGHT_BASE,
         foreground = darkMode ? LIGHT_BASE : DARK_BASE,
+        baseStep = 1,
         mix,
     }: ColorScaleOptions = {}
 ) {
@@ -195,24 +216,37 @@ export function colorScale(
         baseColor.H = mix.color === DEFAULT_TINT_COLOR ? baseColor.H : mixColor.H;
     }
 
-    if (
-        (darkMode && baseColor.L < backgroundColor.L) ||
-        (!darkMode && baseColor.L > backgroundColor.L)
-    ) {
-        // If the supplied color is outside of our lightness bounds, use the supplied color's lightness.
-        // This is mostly used to allow darker-than-dark backgrounds for brands that specifically want that look.
+    // A near-neutral tint at the extreme end of the scale (darker than our dark base, or near-white
+    // in light mode) is taken as the exact page background rather than tinting pure black/white with
+    // it — letting brands set an exact background such as a warm `#F5F3EF`.
+    const isExtremeBase = darkMode
+        ? baseColor.L < backgroundColor.L
+        : baseColor.L > EXACT_BASE_LIGHT_THRESHOLD;
+    const isExactBase = isExtremeBase && baseColor.C < EXACT_BASE_NEUTRAL_CHROMA;
+    const exactBaseIndex = baseStep - 1;
+
+    if (isExactBase) {
         const difference = (backgroundColor.L - baseColor.L) / backgroundColor.L;
-        backgroundColor.L = baseColor.L;
         // At the edges of the scale, the subtle lightness changes stop being perceptible. We need to amp up our mapping to still stand out.
         const amplifier = 1;
         mapping = mapping.map((step, index) =>
             index < 9 ? step + step * amplifier * difference : step
         );
+
+        // Anchor the supplied color to the step the theme renders as the background, solving the
+        // background lightness so neighbouring steps stay continuous with it.
+        const baseMix = mapping[exactBaseIndex]!;
+        backgroundColor.L = (baseColor.L - foregroundColor.L * baseMix) / (1 - baseMix);
     }
 
     const result = [];
 
     for (let index = 0; index < mapping.length; index++) {
+        if (isExactBase && index === exactBaseIndex) {
+            result.push(hex);
+            continue;
+        }
+
         const step = mapping[index]!;
         const targetL = foregroundColor.L * step + backgroundColor.L * (1 - step);
 

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -94,6 +94,9 @@ const EXACT_BASE_LIGHT_THRESHOLD = 0.9;
  */
 const EXACT_BASE_NEUTRAL_CHROMA = 0.05;
 
+/** Lightness of the default white light background (≈0.99999, not exactly 1). */
+const LIGHT_BASE_L = rgbToOklch(hexToRgbArray(LIGHT_BASE)).L;
+
 /**
  * Convert a hex color to an RGB color.
  */
@@ -209,21 +212,26 @@ export function colorScale(
     const backgroundColor = rgbToOklch(hexToRgbArray(background));
     let mapping = darkMode ? colorMixMapping.dark : colorMixMapping.light;
 
-    if (mixColor && mix?.ratio && mix.ratio > 0) {
-        // If defined, we mix in a (tiny) bit of the mix color with the base color.
+    // A near-neutral tint at the extreme end of the scale is taken as the exact page background
+    // rather than tinting pure black/white with it — letting brands set an exact background such as
+    // a warm `#F5F3EF`. In light mode the base is pure white by default, so a near-white tint also
+    // qualifies (nothing is lighter than white); a custom, lower background is respected instead.
+    // Decided on the raw color so a neutral mix (below) can't darken a tint out of the exact base.
+    const isExtremeBase = darkMode
+        ? baseColor.L < backgroundColor.L
+        : backgroundColor.L >= LIGHT_BASE_L
+          ? baseColor.L > EXACT_BASE_LIGHT_THRESHOLD
+          : baseColor.L > backgroundColor.L;
+    const isExactBase = isExtremeBase && baseColor.C < EXACT_BASE_NEUTRAL_CHROMA;
+    const exactBaseIndex = baseStep - 1;
+
+    if (mixColor && mix?.ratio && mix.ratio > 0 && !isExactBase) {
+        // Mix a little of the mix color into the base — but not when the tint is the exact base,
+        // where it must stay true to the supplied color (and match `--header-background`).
         baseColor.L = mixColor.L * mix.ratio + baseColor.L * (1 - mix.ratio);
         baseColor.C = mixColor.C * mix.ratio + baseColor.C * (1 - mix.ratio);
         baseColor.H = mix.color === DEFAULT_TINT_COLOR ? baseColor.H : mixColor.H;
     }
-
-    // A near-neutral tint at the extreme end of the scale (darker than our dark base, or near-white
-    // in light mode) is taken as the exact page background rather than tinting pure black/white with
-    // it — letting brands set an exact background such as a warm `#F5F3EF`.
-    const isExtremeBase = darkMode
-        ? baseColor.L < backgroundColor.L
-        : baseColor.L > EXACT_BASE_LIGHT_THRESHOLD;
-    const isExactBase = isExtremeBase && baseColor.C < EXACT_BASE_NEUTRAL_CHROMA;
-    const exactBaseIndex = baseStep - 1;
 
     if (isExactBase) {
         const difference = (backgroundColor.L - baseColor.L) / backgroundColor.L;

--- a/packages/colors/src/transformations.ts
+++ b/packages/colors/src/transformations.ts
@@ -272,9 +272,10 @@ export function colorScale(
                 case 11:
                     return 0.1;
                 default:
-                    // When the tint is the exact base, hold the low steps at its chroma instead of
-                    // desaturating to gray, so the background end stays consistently tinted.
-                    return isExactBase ? 1 : index * 0.05;
+                    // When the tint is the exact base, hold the steps from the base toward the
+                    // accents at its chroma so the background stays tinted; steps lighter than the
+                    // base (e.g. cards in `muted`) keep desaturating toward white.
+                    return isExactBase && index >= exactBaseIndex ? 1 : index * 0.05;
             }
         })();
 

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -80,15 +80,13 @@ export async function CustomizationRootLayout(props: {
     const tintColor = getTintColor(customization);
     const mixColor = getTintMixColor(customization.styling.primaryColor, tintColor);
     const sidebarStyles = getSidebarStyles(customization);
-    // `muted` (and `bold` with a filled sidebar) render the second scale step (tint-subtle) as the
-    // page background; other themes use the first. When a tint is taken as the exact base, this is
-    // the step it anchors to.
-    const usesSubtleBackground =
-        'theme' in customization.styling &&
-        (customization.styling.theme === CustomizationTheme.Muted ||
-            (customization.styling.theme === CustomizationTheme.Bold &&
-                sidebarStyles.background === CustomizationSidebarBackgroundStyle.Filled));
-    const tintBaseStep = usesSubtleBackground ? 2 : 1;
+    const theme = 'theme' in customization.styling ? customization.styling.theme : undefined;
+    // Which scale step the theme renders as the page background — the step an exact light/dark tint
+    // anchors to. `muted` uses tint-subtle (step 2), other themes tint-base (step 1). `bold` is
+    // intentionally two-tone and already uses the tint for the header, so it opts out entirely
+    // (undefined) and keeps a neutral page background.
+    const tintBaseStep =
+        theme === CustomizationTheme.Bold ? undefined : theme === CustomizationTheme.Muted ? 2 : 1;
     const { infoColor, successColor, warningColor, dangerColor } = getSemanticColors(customization);
     const fontData = getFontData(customization.styling.font, 'content');
     // Temporarily add a if here while the cache is being warmed up.

--- a/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
+++ b/packages/gitbook/src/components/RootLayout/CustomizationRootLayout.tsx
@@ -2,6 +2,7 @@ import {
     CustomizationDefaultThemeMode,
     CustomizationSidebarBackgroundStyle,
     CustomizationSidebarListStyle,
+    CustomizationTheme,
     type CustomizationThemedColor,
     type CustomizationTint,
     type SiteCustomizationSettings,
@@ -79,6 +80,15 @@ export async function CustomizationRootLayout(props: {
     const tintColor = getTintColor(customization);
     const mixColor = getTintMixColor(customization.styling.primaryColor, tintColor);
     const sidebarStyles = getSidebarStyles(customization);
+    // `muted` (and `bold` with a filled sidebar) render the second scale step (tint-subtle) as the
+    // page background; other themes use the first. When a tint is taken as the exact base, this is
+    // the step it anchors to.
+    const usesSubtleBackground =
+        'theme' in customization.styling &&
+        (customization.styling.theme === CustomizationTheme.Muted ||
+            (customization.styling.theme === CustomizationTheme.Bold &&
+                sidebarStyles.background === CustomizationSidebarBackgroundStyle.Filled));
+    const tintBaseStep = usesSubtleBackground ? 2 : 1;
     const { infoColor, successColor, warningColor, dangerColor } = getSemanticColors(customization);
     const fontData = getFontData(customization.styling.font, 'content');
     // Temporarily add a if here while the cache is being warmed up.
@@ -158,7 +168,7 @@ export async function CustomizationRootLayout(props: {
                 >{`
                     :root, .light, .dark [data-color-scheme$="light"], .dark [data-follow-color-scheme="true"]:has([data-color-scheme$="light"]) {
                         ${generateColorVariable('primary', customization.styling.primaryColor.light)}
-                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { mix: mixColor && { color: mixColor.color.light, ratio: mixColor.ratio.light } })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.light : DEFAULT_TINT_COLOR, { baseStep: tintBaseStep, mix: mixColor && { color: mixColor.color.light, ratio: mixColor.ratio.light } })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR)}
 
                         --header-background: ${
@@ -185,7 +195,7 @@ export async function CustomizationRootLayout(props: {
 
                     .dark, :root:not(.dark) [data-color-scheme^="dark"], :root:not(.dark) [data-follow-color-scheme="true"]:has([data-color-scheme^="dark"]) {
                         ${generateColorVariable('primary', customization.styling.primaryColor.dark, { darkMode: true })}
-                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, mix: mixColor && { color: mixColor?.color.dark, ratio: mixColor.ratio.dark } })}
+                        ${generateColorVariable('tint', tintColor ? tintColor.dark : DEFAULT_TINT_COLOR, { darkMode: true, baseStep: tintBaseStep, mix: mixColor && { color: mixColor?.color.dark, ratio: mixColor.ratio.dark } })}
                         ${generateColorVariable('neutral', DEFAULT_TINT_COLOR, { darkMode: true })}
 
                         --header-background: ${hexToRgb(customization.header.backgroundColor?.dark ?? tintColor?.dark ?? customization.styling.primaryColor.dark)};


### PR DESCRIPTION
## Overview

The color scale already treats a very dark tint as the deepest dark of a theme. This extends the same idea to the light end, so brands can set an exact background such as a warm `#F5F3EF`.

- A **near-white tint** is now taken as the exact page background, preserving its exact lightness, **hue and chroma** instead of forcing pure white.
- The exact color is anchored to whichever scale step the active theme renders as the page background — step 1 (`tint-base`) for `clean`/`bold`, step 2 (`tint-subtle`) for `muted` and for `bold` with a filled sidebar — via a new `baseStep` option on `colorScale`. So the background matches exactly regardless of theme.
- The trigger is gated on **low chroma**: only near-neutral tints become the exact background. Saturated colors keep their normal accent ramp.

## Before → After 

<img width="1638" height="1084" alt="CleanShot 2026-07-13 at 12 12 15@2x" src="https://github.com/user-attachments/assets/acdc5dff-aefe-4a2e-8083-f4ce4a91e382" />
<img width="1636" height="1084" alt="CleanShot 2026-07-13 at 12 12 13@2x" src="https://github.com/user-attachments/assets/1e5c419c-2119-4c88-9a18-35f3cebf0b52" />


## Why the chroma gate

The exact color is only emitted at the anchored step; the rest of the low scale follows the usual near-achromatic ramp. For a true off-white like `#F5F3EF` (chroma ≈ 0.006) that's seamless. For a *saturated* light color it would produce a vivid step 1 above an otherwise near-gray scale — and because `colorScale` is shared, that would also corrupt the `primary`, semantic (`info`/`warning`/`danger`/`success`) and favicon scales whenever a light color is chosen. Gating on chroma (< 0.05) keeps the feature scoped to genuine background colors; real off-whites and near-black brand backgrounds sit at ≤ 0.038, saturated colors start at ~0.089.

## Notes for reviewers

- **Behavior change (light):** a site with a **near-neutral** tint of lightness > 0.9 now gets that tint as its background instead of pure white. Saturated light tints are unaffected.
- **Behavior change (dark):** a *saturated* dark tint (chroma ≥ 0.05) now falls back to the standard `#1D1D1D` scale rather than anchoring its own lightness. Such tints only ever rendered achromatic anyway; near-neutral near-blacks (`#0D1117`, `#111111`, …) still work exactly as before.
- The header already uses the raw tint, so it matches the background for free.
- Verified by exercising `colorScale` directly against the real OKLCH conversions plus unit tests in `transformations.test.ts` (the `colors` package had none before). No screenshots: reproducing this needs a live site configured with a near-neutral tint, which isn't injectable here.

*— Authored by Claude*