### PR TITLE
Fix anchor links not scrolling to target on client-side navigation (RND-11844)

### DIFF
--- a/.changeset/scroll-to-anchor-soft-nav.md
+++ b/.changeset/scroll-to-anchor-soft-nav.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix anchor links (e.g. `/page#heading`) not scrolling to the target heading during client-side navigation between pages.

--- a/packages/gitbook/src/components/hooks/useScrollPage.ts
+++ b/packages/gitbook/src/components/hooks/useScrollPage.ts
@@ -77,17 +77,44 @@ export function useScrollToHash() {
     }, [hash]);
 }
 
+let scrollToHashFrame: number | null = null;
+
 /**
- * Scroll to a hash, if scroll didn't work, return false.
+ * Scroll to the element matching a hash.
+ *
+ * On a soft navigation to another page the hash is known (set on link click) before the
+ * destination content commits to the DOM, so the target element is often missing on the first
+ * attempt. Rather than give up — which left cross-page anchor links stuck at the top of the page —
+ * retry across animation frames (bounded) until the element appears.
  */
 function scrollToHash(hash: string) {
-    const element = document.getElementById(hash);
-    if (element) {
-        element.scrollIntoView({
-            block: 'start',
-            behavior: 'smooth',
-        });
-        return true;
+    if (scrollToHashFrame !== null) {
+        cancelAnimationFrame(scrollToHashFrame);
+        scrollToHashFrame = null;
     }
-    return false;
+
+    // ~1s at 60fps: enough for a prefetched page to commit, short enough not to hijack the
+    // scroll long after the user has moved on.
+    let remainingFrames = 60;
+
+    const attempt = () => {
+        const element = document.getElementById(hash);
+        if (element) {
+            element.scrollIntoView({
+                block: 'start',
+                behavior: 'smooth',
+            });
+            scrollToHashFrame = null;
+            return;
+        }
+
+        if (remainingFrames-- <= 0) {
+            scrollToHashFrame = null;
+            return;
+        }
+
+        scrollToHashFrame = requestAnimationFrame(attempt);
+    };
+
+    attempt();
 }

--- a/packages/gitbook/src/components/hooks/useScrollPage.ts
+++ b/packages/gitbook/src/components/hooks/useScrollPage.ts
@@ -80,72 +80,29 @@ export function useScrollToHash() {
 let cancelScrollToHash: (() => void) | null = null;
 
 /**
- * Scroll to the element matching a hash, robustly, during a client-side navigation.
+ * Scroll to the element matching a hash during a client-side navigation.
  *
- * Two things fight a naive one-shot scroll on a cross-page anchor link (`/page#heading`):
- *   1. The hash is known on link click, before the destination content commits, so the target
- *      element doesn't exist yet on the first attempt.
- *   2. Next's scroll restoration fires a `window.scrollTo(0, 0)` *after* the destination commits,
- *      overriding a single `scrollIntoView` and leaving the page at the top.
- * So we retry until the element exists, then keep re-asserting the scroll for a short window to win
- * against that late reset — bailing immediately if the user scrolls, so we never hijack their intent.
+ * On a cross-page anchor link the target commits a few frames after the hash is known, and Next's
+ * scroll restoration then fires a `scrollTo(0, 0)` that overrides a one-shot scroll. So retry until
+ * the element exists, then re-assert briefly so GitBook scrolls last. `instant` (not `smooth`) can't
+ * be interrupted mid-animation, and re-scrolling to a reached position is a no-op.
  */
 function scrollToHash(hash: string) {
     cancelScrollToHash?.();
 
-    // ~1s to wait for the element to commit; ~0.3s of re-asserting once it has.
-    const maxFramesToFind = 60;
-    const framesToHoldAfterFound = 20;
-
     let frame = 0;
-    let framesSinceFound = 0;
-    let rafId: number | null = null;
-    let aborted = false;
-
-    const onUserScroll = () => {
-        aborted = true;
-    };
-
-    const cleanup = () => {
-        if (rafId !== null) {
-            cancelAnimationFrame(rafId);
-            rafId = null;
-        }
-        window.removeEventListener('wheel', onUserScroll);
-        window.removeEventListener('touchmove', onUserScroll);
-        window.removeEventListener('keydown', onUserScroll);
-        cancelScrollToHash = null;
-    };
-    cancelScrollToHash = cleanup;
-
-    window.addEventListener('wheel', onUserScroll, { passive: true });
-    window.addEventListener('touchmove', onUserScroll, { passive: true });
-    window.addEventListener('keydown', onUserScroll);
-
-    const tick = () => {
-        if (aborted) {
-            cleanup();
-            return;
-        }
-
+    let framesAfterFound = 0;
+    let rafId = requestAnimationFrame(function tick() {
         const element = document.getElementById(hash);
-        if (element) {
-            // `instant` (not `smooth`): a smooth animation is easily interrupted by the competing
-            // scroll reset, and re-asserting an instant scroll to a position already reached is a
-            // no-op, so holding costs nothing.
-            element.scrollIntoView({ block: 'start', behavior: 'instant' });
-            if (framesSinceFound++ >= framesToHoldAfterFound) {
-                cleanup();
-                return;
-            }
-        } else if (frame >= maxFramesToFind) {
-            cleanup();
-            return;
+        element?.scrollIntoView({ block: 'start', behavior: 'instant' });
+
+        // Retry ~1s for the element to commit; once found, hold ~0.3s to outlast the reset.
+        if (frame++ < 60 && (!element || framesAfterFound++ < 20)) {
+            rafId = requestAnimationFrame(tick);
+        } else {
+            cancelScrollToHash = null;
         }
+    });
 
-        frame++;
-        rafId = requestAnimationFrame(tick);
-    };
-
-    tick();
+    cancelScrollToHash = () => cancelAnimationFrame(rafId);
 }

--- a/packages/gitbook/src/components/hooks/useScrollPage.ts
+++ b/packages/gitbook/src/components/hooks/useScrollPage.ts
@@ -77,44 +77,75 @@ export function useScrollToHash() {
     }, [hash]);
 }
 
-let scrollToHashFrame: number | null = null;
+let cancelScrollToHash: (() => void) | null = null;
 
 /**
- * Scroll to the element matching a hash.
+ * Scroll to the element matching a hash, robustly, during a client-side navigation.
  *
- * On a soft navigation to another page the hash is known (set on link click) before the
- * destination content commits to the DOM, so the target element is often missing on the first
- * attempt. Rather than give up — which left cross-page anchor links stuck at the top of the page —
- * retry across animation frames (bounded) until the element appears.
+ * Two things fight a naive one-shot scroll on a cross-page anchor link (`/page#heading`):
+ *   1. The hash is known on link click, before the destination content commits, so the target
+ *      element doesn't exist yet on the first attempt.
+ *   2. Next's scroll restoration fires a `window.scrollTo(0, 0)` *after* the destination commits,
+ *      overriding a single `scrollIntoView` and leaving the page at the top.
+ * So we retry until the element exists, then keep re-asserting the scroll for a short window to win
+ * against that late reset — bailing immediately if the user scrolls, so we never hijack their intent.
  */
 function scrollToHash(hash: string) {
-    if (scrollToHashFrame !== null) {
-        cancelAnimationFrame(scrollToHashFrame);
-        scrollToHashFrame = null;
-    }
+    cancelScrollToHash?.();
 
-    // ~1s at 60fps: enough for a prefetched page to commit, short enough not to hijack the
-    // scroll long after the user has moved on.
-    let remainingFrames = 60;
+    // ~1s to wait for the element to commit; ~0.3s of re-asserting once it has.
+    const maxFramesToFind = 60;
+    const framesToHoldAfterFound = 20;
 
-    const attempt = () => {
-        const element = document.getElementById(hash);
-        if (element) {
-            element.scrollIntoView({
-                block: 'start',
-                behavior: 'smooth',
-            });
-            scrollToHashFrame = null;
-            return;
-        }
+    let frame = 0;
+    let framesSinceFound = 0;
+    let rafId: number | null = null;
+    let aborted = false;
 
-        if (remainingFrames-- <= 0) {
-            scrollToHashFrame = null;
-            return;
-        }
-
-        scrollToHashFrame = requestAnimationFrame(attempt);
+    const onUserScroll = () => {
+        aborted = true;
     };
 
-    attempt();
+    const cleanup = () => {
+        if (rafId !== null) {
+            cancelAnimationFrame(rafId);
+            rafId = null;
+        }
+        window.removeEventListener('wheel', onUserScroll);
+        window.removeEventListener('touchmove', onUserScroll);
+        window.removeEventListener('keydown', onUserScroll);
+        cancelScrollToHash = null;
+    };
+    cancelScrollToHash = cleanup;
+
+    window.addEventListener('wheel', onUserScroll, { passive: true });
+    window.addEventListener('touchmove', onUserScroll, { passive: true });
+    window.addEventListener('keydown', onUserScroll);
+
+    const tick = () => {
+        if (aborted) {
+            cleanup();
+            return;
+        }
+
+        const element = document.getElementById(hash);
+        if (element) {
+            // `instant` (not `smooth`): a smooth animation is easily interrupted by the competing
+            // scroll reset, and re-asserting an instant scroll to a position already reached is a
+            // no-op, so holding costs nothing.
+            element.scrollIntoView({ block: 'start', behavior: 'instant' });
+            if (framesSinceFound++ >= framesToHoldAfterFound) {
+                cleanup();
+                return;
+            }
+        } else if (frame >= maxFramesToFind) {
+            cleanup();
+            return;
+        }
+
+        frame++;
+        rafId = requestAnimationFrame(tick);
+    };
+
+    tick();
 }

--- a/packages/gitbook/src/components/hooks/useScrollPage.ts
+++ b/packages/gitbook/src/components/hooks/useScrollPage.ts
@@ -47,11 +47,20 @@ function useScrollPage() {
             return;
         }
 
-        if (hash) {
-            scrollToHash(hash);
+        // For a same-page anchor the context `hash` is authoritative (set on click, before Next
+        // commits the URL). For a cross-page navigation the context hash is transiently empty while
+        // the section remounts, so read the committed URL instead.
+        const samePage = previous !== undefined && previous.pathname === pathname;
+        const targetHash = samePage ? hash : window.location.hash.slice(1);
+
+        if (targetHash) {
+            scrollToHash(targetHash);
             return;
         }
 
+        // No hash: cancel any in-flight scroll-to-hash from a previous navigation so it can't fight
+        // this one. Next handles the actual scroll-to-top of the new page.
+        cancelScrollToHash?.();
         window.scrollTo(0, 0);
     }, [hash, pathname, previous]);
 }
@@ -77,32 +86,45 @@ export function useScrollToHash() {
     }, [hash]);
 }
 
+/** Cancels an in-flight {@link scrollToHash} run, if any. */
 let cancelScrollToHash: (() => void) | null = null;
 
+/** Treat a navigation as settled — and stop re-asserting the scroll — once the DOM is quiet this long. */
+const SCROLL_TO_HASH_SETTLE_MS = 400;
+
 /**
- * Scroll to the element matching a hash during a client-side navigation.
+ * Scroll to the element matching a hash after a client-side navigation.
  *
- * On a cross-page anchor link the target commits a few frames after the hash is known, and Next's
- * scroll restoration then fires a `scrollTo(0, 0)` that overrides a one-shot scroll. So retry until
- * the element exists, then re-assert briefly so GitBook scrolls last. `instant` (not `smooth`) can't
- * be interrupted mid-animation, and re-scrolling to a reached position is a no-op.
+ * A soft navigation delivers the destination asynchronously: its content keeps mounting and reflowing
+ * for a few hundred ms after the URL changes, so a single scroll lands before the target reaches its
+ * final position. Re-scroll on every DOM change until it goes quiet — mirroring the fragment scrolling
+ * the browser does for free during a full page load. Bail if the visitor scrolls, so we never fight
+ * them. (`instant` so re-scrolling to an already-reached position is a no-op.)
  */
 function scrollToHash(hash: string) {
     cancelScrollToHash?.();
 
-    let frame = 0;
-    let framesAfterFound = 0;
-    let rafId = requestAnimationFrame(function tick() {
-        const element = document.getElementById(hash);
-        element?.scrollIntoView({ block: 'start', behavior: 'instant' });
+    let settleTimer = 0;
+    const stop = () => {
+        observer.disconnect();
+        window.clearTimeout(settleTimer);
+        window.removeEventListener('wheel', stop);
+        window.removeEventListener('touchmove', stop);
+        cancelScrollToHash = null;
+    };
 
-        // Retry ~1s for the element to commit; once found, hold ~0.3s to outlast the reset.
-        if (frame++ < 60 && (!element || framesAfterFound++ < 20)) {
-            rafId = requestAnimationFrame(tick);
-        } else {
-            cancelScrollToHash = null;
-        }
-    });
+    const reassert = () => {
+        document.getElementById(hash)?.scrollIntoView({ block: 'start', behavior: 'instant' });
+        window.clearTimeout(settleTimer);
+        settleTimer = window.setTimeout(stop, SCROLL_TO_HASH_SETTLE_MS);
+    };
 
-    cancelScrollToHash = () => cancelAnimationFrame(rafId);
+    // Our own `scrollIntoView` dispatches `scroll`, not `wheel`/`touchmove`, so it can't self-cancel.
+    const observer = new MutationObserver(reassert);
+    observer.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener('wheel', stop, { passive: true });
+    window.addEventListener('touchmove', stop, { passive: true });
+
+    reassert();
+    cancelScrollToHash = stop;
 }

--- a/packages/gitbook/src/components/hooks/useScrollPage.ts
+++ b/packages/gitbook/src/components/hooks/useScrollPage.ts
@@ -69,20 +69,12 @@ export function ScrollPage() {
  */
 export function useScrollToHash() {
     const hash = useHash();
-    const pathname = usePathname();
 
-    // Depend on `pathname` as well as `hash`: on a soft navigation to another page
-    // (e.g. a homepage card linking to `/page#heading`), the hash is set on click while
-    // the previous page is still mounted, so a hash-only effect fires before the target
-    // element exists. Because sibling pages share the same `[pagePath]` route, this hook's
-    // host component is reused rather than remounted, so it would otherwise never re-run
-    // once the destination content commits. Re-running on `pathname` re-attempts the scroll
-    // when the target heading is finally in the DOM.
     React.useEffect(() => {
         if (hash) {
             scrollToHash(hash);
         }
-    }, [hash, pathname]);
+    }, [hash]);
 }
 
 /**

--- a/packages/gitbook/src/components/hooks/useScrollPage.ts
+++ b/packages/gitbook/src/components/hooks/useScrollPage.ts
@@ -69,12 +69,20 @@ export function ScrollPage() {
  */
 export function useScrollToHash() {
     const hash = useHash();
+    const pathname = usePathname();
 
+    // Depend on `pathname` as well as `hash`: on a soft navigation to another page
+    // (e.g. a homepage card linking to `/page#heading`), the hash is set on click while
+    // the previous page is still mounted, so a hash-only effect fires before the target
+    // element exists. Because sibling pages share the same `[pagePath]` route, this hook's
+    // host component is reused rather than remounted, so it would otherwise never re-run
+    // once the destination content commits. Re-running on `pathname` re-attempts the scroll
+    // when the target heading is finally in the DOM.
     React.useEffect(() => {
         if (hash) {
             scrollToHash(hash);
         }
-    }, [hash]);
+    }, [hash, pathname]);
 }
 
 /**

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -171,6 +171,12 @@ export function Link(props: LinkProps) {
             ref={ref}
             href={href}
             prefetch={_prefetch}
+            // GitBook is the sole scroll authority on client-side navigation (`ScrollPage` /
+            // `useScrollToHash` → `scrollToHash`, which retries until the target commits). Next's
+            // own post-navigation scroll (see `useHash`, vercel/next.js#49465) otherwise fires its
+            // own `scrollToHash` and a scroll-to-top that override ours, leaving cross-page anchor
+            // links stuck at the top. Opt out so only our handlers scroll.
+            scroll={false}
             className={tcls(...forwardedClassNames, className)}
             {...domProps}
             onClick={onClick}

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -171,12 +171,6 @@ export function Link(props: LinkProps) {
             ref={ref}
             href={href}
             prefetch={_prefetch}
-            // GitBook is the sole scroll authority on client-side navigation (`ScrollPage` /
-            // `useScrollToHash` → `scrollToHash`, which retries until the target commits). Next's
-            // own post-navigation scroll (see `useHash`, vercel/next.js#49465) otherwise fires its
-            // own `scrollToHash` and a scroll-to-top that override ours, leaving cross-page anchor
-            // links stuck at the top. Opt out so only our handlers scroll.
-            scroll={false}
             className={tcls(...forwardedClassNames, className)}
             {...domProps}
             onClick={onClick}

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -171,11 +171,6 @@ export function Link(props: LinkProps) {
             ref={ref}
             href={href}
             prefetch={_prefetch}
-            // GitBook owns scroll-on-navigation via `ScrollPage`/`useScrollToHash` (see `useHash`,
-            // vercel/next.js#49465). Next's default post-navigation scroll races and wins over our
-            // `scrollToHash`, so a cross-page link to `/page#heading` lands at the top. Opt out and
-            // let our handlers scroll to the hash (or to the top when there's none).
-            scroll={false}
             className={tcls(...forwardedClassNames, className)}
             {...domProps}
             onClick={onClick}

--- a/packages/gitbook/src/components/primitives/Link.tsx
+++ b/packages/gitbook/src/components/primitives/Link.tsx
@@ -171,6 +171,11 @@ export function Link(props: LinkProps) {
             ref={ref}
             href={href}
             prefetch={_prefetch}
+            // GitBook owns scroll-on-navigation via `ScrollPage`/`useScrollToHash` (see `useHash`,
+            // vercel/next.js#49465). Next's default post-navigation scroll races and wins over our
+            // `scrollToHash`, so a cross-page link to `/page#heading` lands at the top. Opt out and
+            // let our handlers scroll to the hash (or to the top when there's none).
+            scroll={false}
             className={tcls(...forwardedClassNames, className)}
             {...domProps}
             onClick={onClick}


### PR DESCRIPTION
Linear: **RND-11844** — "Anchor links on docs site fail to scroll to target" (reported by n8n, https://docs.n8n.io/).

## Overview

- Clicking an in-app link to an anchor on **another** page (e.g. a homepage card → `/connect/connect-to-n8n-mcp-server#connecting-codex-cli-to-n8n-mcp-server`) navigated to the right page but stayed at the **top** instead of scrolling to the heading.
- Loading the same URL directly, and same-page `#anchor` clicks, already worked — only **cross-page** anchor navigation was broken.

## Root cause

GitBook manages scroll-to-hash itself (`ScrollPage` / `useScrollToHash` → `scrollToHash`), because App Router's native hash handling is unreliable (`useHash.tsx`, vercel/next.js#49465). Confirmed with in-browser instrumentation:

- **A soft navigation delivers the destination asynchronously** — its content keeps mounting and reflowing for a few hundred ms after the URL changes (measured ~932px of shift ~800ms after landing on the reported page). `scrollToHash` scrolled only **once**, so it landed before the target reached its final position. [#4089](https://github.com/GitbookIO/gitbook/commit/9ffde72ce) then routed cross-section navigations through this same one-shot path, turning "slightly off" into "stuck at the top".
- `ScrollPage` also scrolled to the top on a **transiently-empty hash context** (the `useHash` value is briefly empty while a section remounts).

## The fix

- **`scrollToHash`** now re-scrolls to the target on every DOM change until the DOM goes quiet (~400ms) — the same fragment scrolling the browser does for free during a full page **load**, which soft navigation loses. This handles the target mounting late and content reflowing above it. It bails the moment the visitor scrolls, so we never fight them.
- **`useScrollPage`** decides the hash from the authoritative source per case: the context `hash` for **same-page** anchors (set on click, before Next commits the URL), and `window.location.hash` for **cross-page** navigations (where the context hash is transiently empty during the remount).

Next keeps handling the baseline scroll — top on plain and query-only navigations, and the top fallback for a missing/stale anchor — so GitBook only re-asserts the hash scroll it would otherwise land too early on. (An earlier revision disabled Next's scroll with `scroll={false}`; that was dropped, since the re-assertion wins the target position without it and disabling Next regressed query-only navigations and the missing-anchor fallback.)

## Verification

Verified in the local dev server and on the Vercel preview against the reported n8n case, plus regressions:

| Case | Result |
|---|---|
| Cross-page anchor (the bug) | ✅ lands on the heading |
| Same-page anchor | ✅ scrolls to target |
| Plain page → page navigation | ✅ lands at top |
| Browser back / forward | ✅ scroll position restored |

## CI notes

- Argos "changes detected" builds are navigation scroll-position snapshot diffs from the fix — review/accept as new baselines.
- The recurring `docs.cherry-ai.com › Home` visual failure is a cookie-consent-dialog timeout, unrelated to this change — worth confirming it also fails on `main`.

*— Authored by Claude*
