### PR TITLE
Update customer e2e test URL after redirect

### DIFF
--- a/packages/gitbook/e2e/customers.spec.ts
+++ b/packages/gitbook/e2e/customers.spec.ts
@@ -218,8 +218,8 @@ const testCases: TestsCase[] = [
         tests: [{ name: 'Home', url: '/', run: waitForCookiesDialog }],
     },
     {
-        name: 'docs.cherry-ai.com',
-        contentBaseURL: 'https://docs.cherry-ai.com',
+        name: 'docs.cherryai.com.cn',
+        contentBaseURL: 'https://docs.cherryai.com.cn',
         tests: [{ name: 'Home', url: '/', run: waitForCookiesDialog }],
     },
     {


### PR DESCRIPTION
## Overview

- `docs.cherry-ai.com` now returns a `301` redirect to `docs.cherryai.com.cn`.
- Update the customer e2e test entry to point at the new canonical domain (both `name` and `contentBaseURL`), so the test hits the destination directly instead of following a redirect.

Verified the redirect before updating: `https://docs.cherry-ai.com/` → `301` → `https://docs.cherryai.com.cn/` (which responds `200`).

*— Authored by Claude*