### PR TITLE
Link search title/page matches to the page top instead of a section anchor (RND-11916)

### DIFF
--- a/.changeset/search-title-match-page-top.md
+++ b/.changeset/search-title-match-page-top.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Search: link page/title matches to the top of the page instead of a section anchor. Section-level matches keep their heading anchor.

--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from '../primitives';
 import { Emoji } from '../primitives/Emoji/Emoji';
 import { HighlightQuery } from './HighlightQuery';
 import { SearchResultItem } from './SearchResultItem';
+import { isPageTitleMatch } from './isPageTitleMatch';
 import type { MergedPageResult } from './reciprocalRankFusion';
 import type { ComputedPageResult } from './search-types';
 import type { LocalPageResult } from './useLocalSearchResults';
@@ -26,9 +27,12 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
     const language = useLanguage();
 
     const bestSection = item.type === 'page' ? item.bestSection : undefined;
-    // When the section snippet is displayed, link to the section anchor so the
-    // link matches what the user sees.
-    const href = bestSection?.body ? bestSection.href : 'href' in item ? item.href : item.pathname;
+    const pageHref = 'href' in item ? item.href : item.pathname;
+    // Link to the section anchor only for genuine section matches. On a page/title
+    // match, go to the top of the page even when a section snippet is shown, so
+    // clicking a title result lands where the user expects.
+    const href =
+        bestSection?.body && !isPageTitleMatch(query, item.title) ? bestSection.href : pageHref;
 
     const emoji = 'emoji' in item ? item.emoji : undefined;
     const icon = 'icon' in item ? item.icon : undefined;

--- a/packages/gitbook/src/components/Search/isPageTitleMatch.test.ts
+++ b/packages/gitbook/src/components/Search/isPageTitleMatch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { isPageTitleMatch } from './isPageTitleMatch';
+
+describe('isPageTitleMatch', () => {
+    it('matches when the query equals the title', () => {
+        expect(isPageTitleMatch('EDR Integrations', 'EDR Integrations')).toBe(true);
+    });
+
+    it('is case-insensitive and tolerant of extra whitespace', () => {
+        expect(isPageTitleMatch('  edr   integrations ', 'EDR Integrations')).toBe(true);
+    });
+
+    it('matches when word order differs', () => {
+        expect(isPageTitleMatch('integrations edr', 'EDR Integrations')).toBe(true);
+    });
+
+    it('matches a single title word', () => {
+        expect(isPageTitleMatch('integrations', 'EDR Integrations')).toBe(true);
+    });
+
+    it('does not match a section-level query whose words are absent from the title', () => {
+        expect(isPageTitleMatch('selecting crowdstrike URL', 'EDR Integrations')).toBe(false);
+    });
+
+    it('does not match when only some query words are in the title', () => {
+        expect(isPageTitleMatch('EDR onboarding guide', 'EDR Integrations')).toBe(false);
+    });
+
+    it('returns false for an empty query', () => {
+        expect(isPageTitleMatch('   ', 'EDR Integrations')).toBe(false);
+    });
+});

--- a/packages/gitbook/src/components/Search/isPageTitleMatch.ts
+++ b/packages/gitbook/src/components/Search/isPageTitleMatch.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether the query targets the page itself (its title) rather than a specific
+ * section within it. True when every word of the query appears in the page
+ * title. We treat that as a page/title match so the result links to the top of
+ * the page instead of dropping to a section anchor. Mirrors the per-word title
+ * matching used for scoring in `reciprocalRankFusion`.
+ */
+export function isPageTitleMatch(query: string, title: string): boolean {
+    const queryWords = query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((word) => word.length > 0);
+
+    if (queryWords.length === 0) {
+        return false;
+    }
+
+    const normalizedTitle = title.toLowerCase();
+    return queryWords.every((word) => normalizedTitle.includes(word));
+}


### PR DESCRIPTION
Linear: **RND-11916** — "Search results link to anchors instead of page top even on title matches" (reported by Vectra AI / Tom Bilen).

> **Night-shift draft — not ready to merge.** Prepared for Zeno to review in the morning. See the "For Zeno" note at the bottom for the judgment calls.

## Proposed changes

Search results are always rendered as **page** items with an optional `bestSection` (the highest-scoring section, attached to every page result). The link logic in `SearchPageResultItem.tsx` used `bestSection.href` (the `#anchor`) whenever a section snippet existed — regardless of whether the query matched the page **title** or a **section**. So clicking a result whose match is the article title dropped the reader to a mid-page heading instead of the top, which is what Tom reported ("if I click *EDR Integrations* I'd expect to go to the top of the article").

There is **no server-provided title-vs-section flag** in the search API response (`SearchPageResult` / `SearchSectionResult` carry only relevance `score`s and text). Rather than compare opaque scores, this reuses the "every query word appears in the title" notion the codebase already uses for title scoring in `reciprocalRankFusion`.

- **`isPageTitleMatch.ts`** (new): pure helper — true when every whitespace-split query word is found in the page title (case-insensitive).
- **`SearchPageResultItem.tsx`**: link to the section anchor only when there's a section snippet **and** it's not a title match; otherwise link to the page top. Section matches keep their anchor.
- **`isPageTitleMatch.test.ts`** (new): 7 unit tests, including the customer's exact examples (`EDR Integrations` → top; `selecting crowdstrike URL` → keeps anchor).

## Verification

- `bun test isPageTitleMatch.test.ts` → 7 pass.
- `bun run typecheck` in `packages/gitbook` → clean.
- Biome + format clean.

## Changelog

- [Fix] Search: page/title matches now link to the top of the page instead of dropping to a section anchor. Section-level matches keep their heading anchor.

---

### For Zeno — judgment calls before this ships

1. **Snippet vs link consistency.** The old behavior linked to the section "so the link matches what the user sees." On a title match we now show the section snippet but link to the top. That's exactly what the customer asked for, but you may want to also suppress/replace the snippet on title matches — I did **not**, because remote page results carry no `description` fallback, so suppressing would leave an empty line.
2. **Heuristic looseness.** "Every query word is a substring of the title" is the same looseness already used for title scoring, and it's substring (not word-boundary) — so `api` would match `Rapid`. Aligned with the ticket, but if you want it stricter it's a one-line change and the tests localize the behavior.
3. No Playwright test — small link-target change, covered by the pure-function unit test. Flag if you want e2e.

*— Night-shift draft, authored by Claude*

---
_Generated by [Claude Code](https://claude.ai/code/session_017xihqNNfTuEzwsux5wzMoF)_