### PR TITLE
Fix TOC groups losing expand/active state during client-side navigation (RND-11931)

### DIFF
--- a/.changeset/toc-stable-group-state.md
+++ b/.changeset/toc-stable-group-state.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the table-of-contents feeling unstable: sidebar groups no longer expand/collapse or lose their expanded context when navigating between pages.

--- a/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageDocumentItem.tsx
@@ -15,6 +15,7 @@ export function PageDocumentItem(props: { page: ClientTOCPageDocument }) {
     return (
         <li className="page-document-item flex flex-col [.page-group-item+&]:mt-4">
             <ToggleableLinkItem
+                id={page.id}
                 href={page.href ?? '#'}
                 pathnames={page.pathnames}
                 insights={{

--- a/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageGroupItem.tsx
@@ -9,12 +9,13 @@ import { ToggleChevron } from '../primitives';
 import { PagesList } from './PagesList';
 import { TOCPageIcon } from './TOCPageIcon';
 import { ToCButtonItemStyles } from './styles';
+import { useTOCGroupState } from './useTOCGroupState';
 
 export function PageGroupItem(props: { page: ClientTOCPageGroup; isFirst?: boolean }) {
     const { page, isFirst } = props;
     const descendants = page.descendants ?? [];
     const hasDescendants = descendants.length > 0;
-    const [isOpen, setIsOpen] = React.useState(true);
+    const [isOpen, setIsOpen] = useTOCGroupState(page.id, true);
     const { sentinelRef, isSticking } = useIsSticking();
 
     const handleToggle = () => {
@@ -22,7 +23,7 @@ export function PageGroupItem(props: { page: ClientTOCPageGroup; isFirst?: boole
             return;
         }
 
-        setIsOpen((prev) => !prev);
+        setIsOpen(!isOpen);
     };
 
     return (

--- a/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/ToggleableLinkItem.tsx
@@ -1,14 +1,16 @@
 'use client';
 import { AnimatePresence, motion } from 'motion/react';
-import React, { useRef } from 'react';
+import type React from 'react';
 import { useCurrentPagePath } from '../hooks';
 import { Button, Link, type LinkInsightsProps, type LinkProps, ToggleChevron } from '../primitives';
+import { useTOCGroupState } from './useTOCGroupState';
 
 /**
  * Client component for a page document to toggle its children and be marked as active.
  */
 export function ToggleableLinkItem(
     props: {
+        id: string;
         href: string;
         pathnames: string[];
         children: React.ReactNode;
@@ -17,30 +19,15 @@ export function ToggleableLinkItem(
         tag?: React.ReactNode;
     } & LinkInsightsProps
 ) {
-    const { href, children, descendants, pathnames, insights, icon, tag } = props;
+    const { id, href, children, descendants, pathnames, insights, icon, tag } = props;
 
     const currentPagePath = useCurrentPagePath();
     const isActive = pathnames.some((pathname) => pathname === currentPagePath);
+    // Auto-expand to reveal the active page; the store keeps this open across navigations and
+    // remembers the visitor's own toggles instead of re-deriving (and flickering) on every remount.
     const defaultIsOpen =
         isActive || pathnames.some((pathname) => currentPagePath.startsWith(`${pathname}/`));
-    const [isOpen, setIsOpen] = React.useState(defaultIsOpen);
-    const hasBeenToggled = useRef(false);
-
-    // Update the visibility of the children if one of the descendants becomes active.
-    React.useEffect(() => {
-        if (defaultIsOpen && !hasBeenToggled.current) {
-            setIsOpen(defaultIsOpen);
-        }
-    }, [defaultIsOpen]);
-
-    const handleToggle = (newState: boolean | ((prev: boolean) => boolean)) => {
-        hasBeenToggled.current = true;
-        if (typeof newState === 'function') {
-            setIsOpen(newState);
-        } else {
-            setIsOpen(newState);
-        }
-    };
+    const [isOpen, setIsOpen] = useTOCGroupState(id, defaultIsOpen);
 
     if (!descendants) {
         return (
@@ -59,14 +46,18 @@ export function ToggleableLinkItem(
     }
 
     return (
-        <DescendantsRenderer descendants={descendants} isOpen={isOpen} setIsOpen={handleToggle}>
+        <DescendantsRenderer
+            descendants={descendants}
+            isOpen={isOpen}
+            onToggle={() => setIsOpen(!isOpen)}
+        >
             {({ descendants, toggler }) => (
                 <>
                     <LinkItem
                         href={href}
                         insights={insights}
                         isActive={isActive}
-                        onActiveClick={() => handleToggle(!isOpen)}
+                        onActiveClick={() => setIsOpen(!isOpen)}
                     >
                         {icon}
                         {tag ? (
@@ -126,24 +117,16 @@ function LinkItem(
 function DescendantsRenderer(props: {
     descendants: React.ReactNode;
     isOpen: boolean;
-    setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    onToggle: () => void;
     children: (renderProps: {
         descendants: React.ReactNode;
         toggler: React.ReactNode;
     }) => React.ReactNode;
 }) {
-    const { descendants, isOpen, setIsOpen } = props;
+    const { descendants, isOpen, onToggle } = props;
 
     return props.children({
-        toggler: (
-            <Toggler
-                isLinkActive={isOpen}
-                isOpen={isOpen}
-                onToggle={() => {
-                    setIsOpen((prev) => !prev);
-                }}
-            />
-        ),
+        toggler: <Toggler isLinkActive={isOpen} isOpen={isOpen} onToggle={onToggle} />,
         descendants: <Descendants isVisible={isOpen}>{descendants}</Descendants>,
     });
 }
@@ -193,8 +176,11 @@ function Descendants(props: {
     children: React.ReactNode;
 }) {
     const { isVisible, children } = props;
+    // `initial={false}` renders an already-open group without replaying the expand animation on
+    // mount: the layout remounts on navigation, and animating every time looked like the sidebar
+    // flickering. Visitor-initiated toggles still animate since they happen after mount.
     return (
-        <AnimatePresence>
+        <AnimatePresence initial={false}>
             {isVisible ? (
                 <motion.div
                     initial={hide}

--- a/packages/gitbook/src/components/TableOfContents/useTOCGroupState.ts
+++ b/packages/gitbook/src/components/TableOfContents/useTOCGroupState.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useCallback } from 'react';
+import * as zustand from 'zustand';
+
+type TOCGroupState = {
+    isOpen: boolean;
+    /** Whether the visitor toggled the group themselves, as opposed to it following the active page. */
+    userToggled: boolean;
+};
+
+// The table of contents lives in the site layout, whose client subtree is remounted on
+// client-side navigation (see useClearRouterCache and https://github.com/vercel/next.js/issues/67542).
+// Keeping each group's open/closed state in component-local `useState`/`useRef` therefore resets it on
+// every navigation, making the sidebar expand/collapse or lose its expanded context as visitors move
+// between pages. We keep the state in a module-level store so it survives those remounts.
+const useStore = zustand.create<{
+    groups: Record<string, TOCGroupState>;
+    setOpen: (id: string, isOpen: boolean) => void;
+}>((set) => ({
+    groups: {},
+    setOpen: (id, isOpen) =>
+        set((state) => ({
+            groups: { ...state.groups, [id]: { isOpen, userToggled: true } },
+        })),
+}));
+
+/**
+ * Persisted open/collapsed state for a collapsible table-of-contents group.
+ *
+ * Until the visitor toggles the group, it follows `defaultOpen` (e.g. the group containing the
+ * active page). Once toggled, their choice is remembered across navigations for the session, so
+ * navigating between pages no longer resets the sidebar.
+ */
+export function useTOCGroupState(
+    id: string,
+    defaultOpen: boolean
+): [boolean, (isOpen: boolean) => void] {
+    const stored = useStore((state) => state.groups[id]);
+    const setOpen = useStore((state) => state.setOpen);
+
+    const isOpen = stored?.userToggled ? stored.isOpen : defaultOpen;
+
+    const setIsOpen = useCallback((next: boolean) => setOpen(id, next), [id, setOpen]);
+
+    return [isOpen, setIsOpen];
+}


### PR DESCRIPTION
**Night-shift draft — not ready to merge; prepared for Zeno to review in the morning.**

Linear: [RND-11931](https://linear.app/gitbook-x/issue/RND-11931) — "TOC feels unstable: groups expand/collapse or briefly lose context while navigating"

## Proposed changes

**Root cause.** The sidebar table of contents is rendered inside the site layout (`SpaceLayout` → `TableOfContents`), i.e. the shared `(content)/layout.tsx`. In this app the layout's client subtree is remounted on client-side navigation — this is already documented in the codebase: `useClearRouterCache.tsx` keeps `previousContextId` in a module-level variable precisely because "the contextId gets reset on navigation … probably because of [Next.js #67542]" (a `useRef` there is wiped on every navigation, which only happens if the component remounts).

The two collapsible TOC components stored their expand/collapse state in component-local state, so that remount reset it on every navigation:

- `PageGroupItem.tsx` — `useState(true)`: a top-level group the visitor had collapsed snaps back open after navigating.
- `ToggleableLinkItem.tsx` — `useState(defaultIsOpen)` + a `useRef(hasBeenToggled)` + an effect: nested groups re-derived from the freshly-mounting active path, the visitor's manual toggles were forgotten, and because the descendants used `<AnimatePresence>` with `initial={hide}`, the expand animation *replayed on every mount* — which reads as the sidebar flickering / losing its expanded context.

**Fix.** Move the groups' open/collapsed state into a small module-level store (`useTOCGroupState`, a zustand store keyed by page id) so it survives the navigation remount. This mirrors patterns already in the repo: the module-level workaround in `useClearRouterCache` and the zustand `visitedPagesStore` in `useCurrentPage.tsx`.

- Until the visitor toggles a group, it follows the active page (unchanged behavior: auto-expand to reveal the current page). Once toggled, their choice is remembered for the session across navigations.
- `PageGroupItem` and `ToggleableLinkItem` now read/write this store instead of local state; the now-redundant `hasBeenToggled` ref + sync effect are removed.
- `Descendants` uses `<AnimatePresence initial={false}>` so an already-open group renders without replaying its expand animation on mount; visitor-initiated toggles still animate (they happen after mount).

No hydration risk: the store is empty on the server and on first client render, so the initial value equals the previous `defaultIsOpen`/`true`.

## Changelog
- [Fix] Table of contents no longer expands/collapses groups or loses its expanded context when navigating between pages.

## For Zeno
- **Judgment calls:**
  - Kept the fix scoped to state persistence + the mount-animation flag rather than trying to stop the layout remount itself (that's the underlying Next.js #67542 and would be a much larger, riskier change).
  - New behavior improvement: a visitor's manual expand/collapse now *persists* across navigations for the session (previously it was ephemeral because it was wiped on each remount). This felt like the intended UX and directly serves "stable", but flag if you'd rather keep toggles strictly ephemeral.
  - Store is keyed by `page.id` and lives for the SPA session (module-level, bounded by visited TOC items). Not persisted to storage — reloads start fresh, matching today's behavior.
- **Risks:** Low. If the layout does *not* remount in some configs, the change is behavior-neutral-to-better (no regression). The `AnimatePresence initial={false}` change affects only the enter animation on mount.
- **Verified:** `bun run typecheck` for `gitbook` (via `turbo`, 27 tasks green), `bun run format`, and `biome check` on the changed files — all clean.
- **Not verified:** I did **not** do a live browser reproduction. The reported site (app.neosecurity.dev, VA enabled) needs auth I don't have, and reproducing the exact remount requires the dynamic/adaptive path. Root cause is inferred from the code + the existing in-repo `useClearRouterCache` workaround for the same "state reset on navigation" behavior. Suggested manual check: on a multi-section/VA site, collapse a TOC group, navigate to another page, and confirm the group stays collapsed and the sidebar doesn't flash.
- **Tests:** No existing unit/Playwright tests cover these components, and per the repo's frontend testing guidance I didn't add a mocked React unit test. A Playwright test that navigates and asserts group `aria-expanded`/`data-active` persistence would be the right coverage but needs a fixture site whose layout actually remounts — worth a follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DaBLy53zu9DTce9sZhaARf)_