### PR TITLE
Fix overlapping search highlights for adjacent multi-word matches

### DIFF
--- a/.changeset/fix-search-highlight-adjacent-matches.md
+++ b/.changeset/fix-search-highlight-adjacent-matches.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix search results rendering adjacent matched words from a multi-word query (e.g. "maria db" matching "MariaDB") as two overlapping highlight pills instead of one.

--- a/packages/gitbook/src/components/Search/HighlightQuery.tsx
+++ b/packages/gitbook/src/components/Search/HighlightQuery.tsx
@@ -1,4 +1,5 @@
 import { type ClassValue, tcls } from '@/lib/tailwind';
+import { matchString } from './HighlightQuery.utils';
 
 /**
  * Match a string against a query and render the matching text in bold.
@@ -43,46 +44,4 @@ export function HighlightQuery(props: {
             ))}
         </span>
     );
-}
-
-interface TextMatch {
-    text: string;
-    match?: string;
-}
-
-function matchString(text: string, query: string): TextMatch[] {
-    const words = splitQuery(query);
-    const initialParts = [{ text }];
-
-    return words.reduce((parts, word) => matchWordInParts(parts, word), initialParts);
-}
-
-function matchWordInParts(parts: TextMatch[], word: string): TextMatch[] {
-    return parts.reduce((result, part) => {
-        if (part.match) {
-            result.push(part);
-            return result;
-        }
-
-        const { text } = part;
-        const index = text.toLowerCase().indexOf(word);
-        if (index >= 0) {
-            const before = text.slice(0, index);
-            const inner = text.slice(index, index + word.length);
-            const after = text.slice(index + word.length);
-
-            if (before.length > 0) result.push({ text: before });
-            if (inner.length > 0) result.push({ text: inner, match: word });
-            if (after.length > 0) result.push({ text: after });
-
-            return result;
-        }
-
-        result.push({ text });
-        return result;
-    }, [] as TextMatch[]);
-}
-
-function splitQuery(text: string): string[] {
-    return text.toLowerCase().split(' ');
 }

--- a/packages/gitbook/src/components/Search/HighlightQuery.utils.test.ts
+++ b/packages/gitbook/src/components/Search/HighlightQuery.utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { matchString } from './HighlightQuery.utils';
+
+describe('matchString', () => {
+    it('returns the whole text as a single non-match when nothing matches', () => {
+        expect(matchString('MariaDB Cloud', 'postgres')).toEqual([{ text: 'MariaDB Cloud' }]);
+    });
+
+    it('highlights a single matching word', () => {
+        expect(matchString('MariaDB Cloud', 'cloud')).toEqual([
+            { text: 'MariaDB ' },
+            { text: 'Cloud', match: 'cloud' },
+        ]);
+    });
+
+    it('coalesces adjacent word matches into one highlight span', () => {
+        // "maria db" matches "MariaDB" as two touching tokens; they must render
+        // as a single highlight, not two overlapping pills.
+        expect(matchString('MariaDB Cloud', 'maria db cloud')).toEqual([
+            { text: 'MariaDB', match: 'mariadb' },
+            { text: ' ' },
+            { text: 'Cloud', match: 'cloud' },
+        ]);
+    });
+
+    it('keeps non-adjacent matches as separate spans', () => {
+        expect(matchString('MariaDB is a cloud database', 'maria cloud')).toEqual([
+            { text: 'Maria', match: 'maria' },
+            { text: 'DB is a ' },
+            { text: 'cloud', match: 'cloud' },
+            { text: ' database' },
+        ]);
+    });
+});

--- a/packages/gitbook/src/components/Search/HighlightQuery.utils.ts
+++ b/packages/gitbook/src/components/Search/HighlightQuery.utils.ts
@@ -1,0 +1,65 @@
+export interface TextMatch {
+    text: string;
+    match?: string;
+}
+
+/**
+ * Split `text` into consecutive parts, flagging the ones that match `query`.
+ */
+export function matchString(text: string, query: string): TextMatch[] {
+    const words = splitQuery(query);
+    const initialParts = [{ text }];
+    const parts = words.reduce((parts, word) => matchWordInParts(parts, word), initialParts);
+
+    return coalesceAdjacentMatches(parts);
+}
+
+function matchWordInParts(parts: TextMatch[], word: string): TextMatch[] {
+    return parts.reduce((result, part) => {
+        if (part.match) {
+            result.push(part);
+            return result;
+        }
+
+        const { text } = part;
+        const index = text.toLowerCase().indexOf(word);
+        if (index >= 0) {
+            const before = text.slice(0, index);
+            const inner = text.slice(index, index + word.length);
+            const after = text.slice(index + word.length);
+
+            if (before.length > 0) result.push({ text: before });
+            if (inner.length > 0) result.push({ text: inner, match: word });
+            if (after.length > 0) result.push({ text: after });
+
+            return result;
+        }
+
+        result.push({ text });
+        return result;
+    }, [] as TextMatch[]);
+}
+
+/**
+ * Multi-word queries match each word independently, so a phrase like "maria db"
+ * against "MariaDB" produces two touching match parts. Rendered as separate
+ * spans their negative margins and rounded corners overlap into a doubled pill,
+ * so contiguous matches are merged into one highlight span.
+ */
+function coalesceAdjacentMatches(parts: TextMatch[]): TextMatch[] {
+    return parts.reduce((result, part) => {
+        const previous = result[result.length - 1];
+        if (part.match && previous?.match) {
+            previous.text += part.text;
+            previous.match += part.match;
+            return result;
+        }
+
+        result.push({ ...part });
+        return result;
+    }, [] as TextMatch[]);
+}
+
+function splitQuery(text: string): string[] {
+    return text.toLowerCase().split(' ');
+}


### PR DESCRIPTION
**Night-shift draft — not ready to merge; prepared for Zeno to review in the morning.**

Source: #published-docs-experience Slack thread where Nolann reported that searching `maria db cloud` renders **MariaDB** as two overlapping highlight pills (while `mariadb cloud` looks fine). Zeno diagnosed the cause in-thread; this implements that fix.

## Overview

- `HighlightQuery` highlights each query word independently (`matchString` reduces the text word-by-word). A multi-word query whose words are **contiguous** in the result text — e.g. `maria db` inside `MariaDB` — produced two touching `<span>` matches. Because each highlight span carries `-mx-0.5` (negative margin) and `rounded-sm`, adjacent spans overlap into a visually doubled/seamed pill.
- Fix: coalesce directly-adjacent matched parts into a single highlight span (`coalesceAdjacentMatches`). Non-adjacent matches (unmatched text between them) still render as separate highlights.
- The pure matching logic is moved to `HighlightQuery.utils.ts` so it can be unit-tested without pulling in the React JSX runtime (mirrors the existing `filter.ts` / `filter.test.ts` split). `HighlightQuery.tsx` now just imports `matchString` and renders.

## Test

`packages/gitbook/src/components/Search/HighlightQuery.utils.test.ts` (bun test) — covers no-match, single-word match, the adjacent-coalesce regression (`maria db cloud` → one `MariaDB` pill + one `Cloud` pill), and non-adjacent matches staying separate. The coalesce case fails on `main` and passes with this change. All 4 pass locally.

## For Zeno

- **Judgment call:** I merge on adjacency only (consecutive match parts), not on the raw query — so `maria cloud` against `MariaDB is a cloud database` still yields two separate pills, which is correct. Merged span's `match` value is the concatenation of the matched tokens; it's only used as a truthy styling flag, so the exact value doesn't matter downstream.
- **Extraction:** I split the pure logic into `HighlightQuery.utils.ts`. If you'd rather keep it inline in the `.tsx`, the test can instead import through the component — but then it needs the JSX runtime and doesn't run under `bun test` cleanly. Happy to fold it back if you prefer.
- **Not verified in-browser** in this environment (couldn't run the full dev server); the fix is verified at the unit level. Worth an eyeball on a real search dropdown before it leaves draft.
- Typecheck locally is blocked only by unbuilt internal packages (`@gitbook/icons`, `@gitbook/embed`, …) in the fresh container — no errors in the changed files. CI will confirm.

## Changelog
- [Fix] Search results no longer render adjacent matched words from a multi-word query (e.g. "maria db" matching "MariaDB") as two overlapping highlight pills.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4jiy83BeKXZjEH4Jqwn3Z)_