### PR TITLE
Add "On this page" on models page

### DIFF
--- a/.changeset/openapi-models-on-this-page.md
+++ b/.changeset/openapi-models-on-this-page.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add an "On this page" table of contents on OpenAPI models pages. Each model in a grouped/multi-model "Models" section is now listed as its own section, matching operations and webhooks.

--- a/packages/gitbook/src/lib/document-sections.test.ts
+++ b/packages/gitbook/src/lib/document-sections.test.ts
@@ -8,7 +8,11 @@ mock.module('./openapi/resolveOpenAPIOperationBlock', () => ({
 }));
 
 mock.module('./openapi/resolveOpenAPISchemasBlock', () => ({
-    resolveOpenAPISchemasBlock: async () => ({ data: null }),
+    resolveOpenAPISchemasBlock: async ({ block }: { block: { data: { schemas?: string[] } } }) => ({
+        data: {
+            schemas: (block.data.schemas ?? []).map((name) => ({ name, schema: {} })),
+        },
+    }),
 }));
 
 const { getDocumentSections } = await import('./document-sections');
@@ -223,6 +227,63 @@ describe('getDocumentSections', () => {
                 title: 'Heading 2 in update',
                 tags: ['improvements'],
             },
+        ]);
+    });
+
+    it('extracts a single-schema openapi-schemas block as one section', async () => {
+        const document: JSONDocument = {
+            object: 'document',
+            data: { schemaVersion: 2 },
+            nodes: [
+                {
+                    object: 'block',
+                    type: 'openapi-schemas',
+                    data: { schemas: ['User'], grouped: false },
+                    meta: { id: 'models-block' },
+                    isVoid: false,
+                    nodes: [],
+                } as unknown as JSONDocument['nodes'][number],
+            ],
+        };
+
+        const sections = await getDocumentSections(context, document);
+
+        expect(
+            sections.map((section) => ({
+                id: section.id,
+                depth: section.depth,
+                title: reactNodeToText(section.title),
+            }))
+        ).toEqual([{ id: 'models-block', depth: 1, title: 'The User object' }]);
+    });
+
+    it('extracts one section per model for grouped/multi-schema openapi-schemas blocks', async () => {
+        const document: JSONDocument = {
+            object: 'document',
+            data: { schemaVersion: 2 },
+            nodes: [
+                {
+                    object: 'block',
+                    type: 'openapi-schemas',
+                    data: { schemas: ['User', 'Pet Store'], grouped: true },
+                    meta: { id: 'models-block' },
+                    isVoid: false,
+                    nodes: [],
+                } as unknown as JSONDocument['nodes'][number],
+            ],
+        };
+
+        const sections = await getDocumentSections(context, document);
+
+        expect(
+            sections.map((section) => ({
+                id: section.id,
+                depth: section.depth,
+                title: reactNodeToText(section.title),
+            }))
+        ).toEqual([
+            { id: 'user', depth: 1, title: 'User' },
+            { id: 'pet-store', depth: 1, title: 'Pet Store' },
         ]);
     });
 });

--- a/packages/gitbook/src/lib/document-sections.ts
+++ b/packages/gitbook/src/lib/document-sections.ts
@@ -1,5 +1,6 @@
 import type { GitBookAnyContext } from '@/lib/context';
 import type { DocumentBlock, JSONDocument } from '@gitbook/api';
+import { getOpenAPISchemaAnchorId } from '@gitbook/openapi-parser';
 
 import type { ReactNode } from 'react';
 import { getDataOrNull } from './data';
@@ -142,31 +143,30 @@ async function getSectionsFromNodes(
                 continue;
             }
             case 'openapi-schemas': {
-                const id = block.meta?.id;
-                if (!id) {
-                    continue;
-                }
-                if (block.data.grouped || block.data.schemas.length !== 1) {
-                    // Skip grouped schemas, they are not sections
-                    continue;
-                }
-
                 const { data } = await resolveOpenAPISchemasBlock({
                     block,
                     context,
                 });
-                const schema = data?.schemas[0];
-                if (schema) {
-                    sections.push(
-                        withTags(
-                            {
-                                id,
-                                title: `The ${schema.name} object`,
-                                depth: 1,
-                            },
-                            tags
-                        )
-                    );
+
+                // A lone model anchors on the block's own id, like an operation.
+                if (!block.data.grouped && block.data.schemas.length === 1) {
+                    const id = block.meta?.id;
+                    const schema = data?.schemas[0];
+                    if (id && schema) {
+                        sections.push(
+                            withTags({ id, title: `The ${schema.name} object`, depth: 1 }, tags)
+                        );
+                    }
+                    continue;
+                }
+
+                // Grouped/multiple schemas each render as a deep-linkable model, keyed by name slug.
+                for (const schema of data?.schemas ?? []) {
+                    const id = getOpenAPISchemaAnchorId(schema.name);
+                    if (!id) {
+                        continue;
+                    }
+                    sections.push(withTags({ id, title: schema.name, depth: 1 }, tags));
                 }
                 continue;
             }


### PR DESCRIPTION
Adds an "On this page" table of contents on OpenAPI models pages: each model in a grouped/multi-model "Models" section is now emitted as its own section in `getDocumentSections`, so the page aside lists them (it renders when there is more than one section) and each entry deep-links to the model.

Depends on #4416 (model anchors) — the section ids reuse the `getOpenAPISchemaAnchorId` slug that PR introduces, so #4416 must merge first.

RND-12126