### PR TITLE
Make the table search empty state more prominent

### DIFF
--- a/.changeset/table-search-empty-padding.md
+++ b/.changeset/table-search-empty-padding.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Make the table search "no results" empty state more prominent with vertical spacing so it no longer blends into the content below.

--- a/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
@@ -201,7 +201,7 @@ export function TableSearchEmpty(props: { className?: ClassValue }) {
 
     const trimmed = query.trim();
     return (
-        <div className={tcls('mx-auto text-center text-sm text-tint', props.className)}>
+        <div className={tcls('mx-auto py-8 text-center text-sm text-tint', props.className)}>
             {trimmed
                 ? tString(language, 'search_no_results_for', trimmed)
                 : tString(language, 'search_no_results')}


### PR DESCRIPTION
## Overview

- The table search "no results" empty state was easy to miss on text-heavy pages — with no spacing around it, the message read as part of the table/content below it.
- Adds **2rem of vertical space** above and below the empty-state message (`py-8`) so it stands out clearly as its own element.
- Applies to both grid and card table views, since the empty state is shared.

## Demo

The change is a single additive spacing class on the shared empty-state element. It only appears client-side after a user searches a table (≥7 rows) or filters cards with no matches, so it couldn't be exercised through the local `/url/` dev proxy in this environment. No before/after screenshot is attached for that reason.

Resolves RND-11987.

*— Authored by Claude*
