### PR TITLE
Add supporting context to AI tool confirmation dialogs

### DIFF
--- a/.changeset/integration-tool-context.md
+++ b/.changeset/integration-tool-context.md
@@ -4,4 +4,4 @@
 "gitbook": patch
 ---
 
-Add an optional `context` property to the `confirmation` of custom AI tools (string, up to 512 characters), shown above the confirmation dialog to help the user understand what they are approving or rejecting. Available both to integrations (`GitBookIntegrationTool`) and to embed consumers (`GitBookToolDefinition`).
+Add an optional `context` property (string, up to 512 characters) to the `confirmation` of custom AI tools, shown above the confirmation dialog to help the user understand what they are approving or rejecting. The `confirmation` can now also be a function that receives the AI-provided input and returns the confirmation, so the context can be derived dynamically from the arguments the tool is about to run with. Available both to integrations (`GitBookIntegrationTool`) and to embed consumers (`GitBookToolDefinition`).

--- a/.changeset/integration-tool-context.md
+++ b/.changeset/integration-tool-context.md
@@ -4,4 +4,4 @@
 "gitbook": patch
 ---
 
-Add an optional `context` property to custom AI tools (string, up to 512 characters), shown above the confirmation dialog to help the user understand what they are approving or rejecting. Available both to integrations (`GitBookIntegrationTool`) and to embed consumers (`GitBookToolDefinition`).
+Add an optional `context` property to the `confirmation` of custom AI tools (string, up to 512 characters), shown above the confirmation dialog to help the user understand what they are approving or rejecting. Available both to integrations (`GitBookIntegrationTool`) and to embed consumers (`GitBookToolDefinition`).

--- a/.changeset/integration-tool-context.md
+++ b/.changeset/integration-tool-context.md
@@ -1,0 +1,6 @@
+---
+"@gitbook/browser-types": patch
+"gitbook": patch
+---
+
+Add an optional `context` property to `GitBookIntegrationTool` (string, up to 512 characters), shown above the confirmation dialog to help the user understand what they are approving or rejecting.

--- a/.changeset/integration-tool-context.md
+++ b/.changeset/integration-tool-context.md
@@ -1,6 +1,7 @@
 ---
 "@gitbook/browser-types": patch
+"@gitbook/embed": patch
 "gitbook": patch
 ---
 
-Add an optional `context` property to `GitBookIntegrationTool` (string, up to 512 characters), shown above the confirmation dialog to help the user understand what they are approving or rejecting.
+Add an optional `context` property to custom AI tools (string, up to 512 characters), shown above the confirmation dialog to help the user understand what they are approving or rejecting. Available both to integrations (`GitBookIntegrationTool`) and to embed consumers (`GitBookToolDefinition`).

--- a/packages/browser-types/src/index.ts
+++ b/packages/browser-types/src/index.ts
@@ -7,18 +7,18 @@ export type GitBookIntegrationEventCallback = (...args: any[]) => void;
 
 export type GitBookIntegrationTool = AIToolDefinition & {
     /**
-     * Supporting context displayed to the user above the confirmation dialog,
-     * to help them understand what they are approving or rejecting.
-     * Limited to 512 characters.
-     */
-    context?: string;
-
-    /**
      * Confirmation action to be displayed to the user before executing the tool.
      */
     confirmation?: {
         icon?: IconName;
         label: string;
+
+        /**
+         * Supporting context displayed to the user above the confirmation dialog,
+         * to help them understand what they are approving or rejecting.
+         * Limited to 512 characters.
+         */
+        context?: string;
     };
 
     /**

--- a/packages/browser-types/src/index.ts
+++ b/packages/browser-types/src/index.ts
@@ -7,6 +7,13 @@ export type GitBookIntegrationEventCallback = (...args: any[]) => void;
 
 export type GitBookIntegrationTool = AIToolDefinition & {
     /**
+     * Supporting context displayed to the user above the confirmation dialog,
+     * to help them understand what they are approving or rejecting.
+     * Limited to 512 characters.
+     */
+    context?: string;
+
+    /**
      * Confirmation action to be displayed to the user before executing the tool.
      */
     confirmation?: {

--- a/packages/browser-types/src/index.ts
+++ b/packages/browser-types/src/index.ts
@@ -5,21 +5,28 @@ export type GitBookIntegrationEvent = 'load' | 'unload';
 
 export type GitBookIntegrationEventCallback = (...args: any[]) => void;
 
+export type GitBookIntegrationToolConfirmation = {
+    icon?: IconName;
+    label: string;
+
+    /**
+     * Supporting context displayed to the user above the confirmation dialog,
+     * to help them understand what they are approving or rejecting.
+     * Limited to 512 characters.
+     */
+    context?: string;
+};
+
 export type GitBookIntegrationTool = AIToolDefinition & {
     /**
      * Confirmation action to be displayed to the user before executing the tool.
+     * Provide a static object, or a function that receives the input provided by
+     * the AI assistant and returns the confirmation — useful to display dynamic
+     * context based on the arguments the tool is about to be executed with.
      */
-    confirmation?: {
-        icon?: IconName;
-        label: string;
-
-        /**
-         * Supporting context displayed to the user above the confirmation dialog,
-         * to help them understand what they are approving or rejecting.
-         * Limited to 512 characters.
-         */
-        context?: string;
-    };
+    confirmation?:
+        | GitBookIntegrationToolConfirmation
+        | ((input: object) => GitBookIntegrationToolConfirmation);
 
     /**
      * Callback when the tool is executed.

--- a/packages/embed/src/client/protocol.ts
+++ b/packages/embed/src/client/protocol.ts
@@ -6,6 +6,13 @@ import type { IconName } from '@gitbook/icons';
  */
 export type GitBookToolDefinition = AIToolDefinition & {
     /**
+     * Supporting context displayed to the user above the confirmation dialog,
+     * to help them understand what they are approving or rejecting.
+     * Limited to 512 characters.
+     */
+    context?: string;
+
+    /**
      * Confirmation action to be displayed to the user before executing the tool.
      */
     confirmation?: {

--- a/packages/embed/src/client/protocol.ts
+++ b/packages/embed/src/client/protocol.ts
@@ -6,18 +6,18 @@ import type { IconName } from '@gitbook/icons';
  */
 export type GitBookToolDefinition = AIToolDefinition & {
     /**
-     * Supporting context displayed to the user above the confirmation dialog,
-     * to help them understand what they are approving or rejecting.
-     * Limited to 512 characters.
-     */
-    context?: string;
-
-    /**
      * Confirmation action to be displayed to the user before executing the tool.
      */
     confirmation?: {
         icon?: IconName;
         label: string;
+
+        /**
+         * Supporting context displayed to the user above the confirmation dialog,
+         * to help them understand what they are approving or rejecting.
+         * Limited to 512 characters.
+         */
+        context?: string;
     };
 
     /**

--- a/packages/embed/src/client/protocol.ts
+++ b/packages/embed/src/client/protocol.ts
@@ -2,23 +2,31 @@ import type { AIToolCallResult, AIToolDefinition } from '@gitbook/api';
 import type { IconName } from '@gitbook/icons';
 
 /**
+ * Confirmation action to be displayed to the user before executing a tool.
+ */
+export type GitBookToolConfirmation = {
+    icon?: IconName;
+    label: string;
+
+    /**
+     * Supporting context displayed to the user above the confirmation dialog,
+     * to help them understand what they are approving or rejecting.
+     * Limited to 512 characters.
+     */
+    context?: string;
+};
+
+/**
  * Custom tool definition to be passed to the AI assistant.
  */
 export type GitBookToolDefinition = AIToolDefinition & {
     /**
      * Confirmation action to be displayed to the user before executing the tool.
+     * Provide a static object, or a function that receives the input provided by
+     * the AI assistant and returns the confirmation — useful to display dynamic
+     * context based on the arguments the tool is about to be executed with.
      */
-    confirmation?: {
-        icon?: IconName;
-        label: string;
-
-        /**
-         * Supporting context displayed to the user above the confirmation dialog,
-         * to help them understand what they are approving or rejecting.
-         * Limited to 512 characters.
-         */
-        context?: string;
-    };
+    confirmation?: GitBookToolConfirmation | ((input: object) => GitBookToolConfirmation);
 
     /**
      * Callback when the tool is executed.

--- a/packages/gitbook/src/components/AI/controls/ConfirmControl.tsx
+++ b/packages/gitbook/src/components/AI/controls/ConfirmControl.tsx
@@ -16,6 +16,13 @@ export const ConfirmControlDef = createAIControl({
     description:
         'Display a confirmation prompt to the user (Confirm / Cancel) to approve or abort a pending action. Use this when an operation is irreversible, sensitive, or should only proceed with explicit user consent. Returns either a `confirmed` or `cancelled` result based on the user’s click.',
     inputSchema: z.object({
+        context: z
+            .string()
+            .max(512)
+            .optional()
+            .describe(
+                'Supporting context shown above the prompt to help the user understand what they are approving or rejecting.'
+            ),
         icon: z
             .string()
             .optional()
@@ -29,10 +36,13 @@ export const ConfirmControlDef = createAIControl({
 });
 
 function ConfirmControl(props: GetAIControlProps<typeof ConfirmControlDef>) {
-    const { label, icon, onSubmit } = props;
+    const { label, icon, context, onSubmit } = props;
     const language = useLanguage();
     return (
         <AIToolContainer className="flex w-full flex-col gap-2">
+            {context ? (
+                <p className="whitespace-pre-line px-2 pt-1 text-sm text-tint">{context}</p>
+            ) : null}
             <Button
                 data-testid="ai-chat-tool-confirm-cancel"
                 onClick={() => {

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -435,8 +435,9 @@ export function AIChatProvider(props: {
                             const confirmation = 'confirmation' in toolDef && toolDef.confirmation;
                             if (confirmation) {
                                 const supportingContext =
-                                    'context' in toolDef && typeof toolDef.context === 'string'
-                                        ? toolDef.context.slice(0, 512)
+                                    'context' in confirmation &&
+                                    typeof confirmation.context === 'string'
+                                        ? confirmation.context.slice(0, 512)
                                         : undefined;
                                 globalState.setState((state) => ({
                                     ...state,

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -436,9 +436,11 @@ export function AIChatProvider(props: {
                             if (confirmation) {
                                 // The confirmation can be a static object or a function that
                                 // derives it from the AI-provided input (e.g. dynamic context).
+                                // The function call is awaited because, for embed-registered
+                                // tools, it arrives as an async proxy over the postMessage channel.
                                 const resolvedConfirmation =
                                     typeof confirmation === 'function'
-                                        ? confirmation(event.toolCall.input)
+                                        ? await confirmation(event.toolCall.input)
                                         : confirmation;
                                 const supportingContext =
                                     typeof resolvedConfirmation.context === 'string'

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -434,6 +434,10 @@ export function AIChatProvider(props: {
 
                             const confirmation = 'confirmation' in toolDef && toolDef.confirmation;
                             if (confirmation) {
+                                const supportingContext =
+                                    'context' in toolDef && typeof toolDef.context === 'string'
+                                        ? toolDef.context.slice(0, 512)
+                                        : undefined;
                                 globalState.setState((state) => ({
                                     ...state,
                                     control: ConfirmControlDef.createControl({
@@ -444,6 +448,7 @@ export function AIChatProvider(props: {
                                         input: {
                                             label: confirmation.label,
                                             icon: confirmation.icon,
+                                            context: supportingContext,
                                         },
                                         language,
                                         send: async (result) => {

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -434,10 +434,15 @@ export function AIChatProvider(props: {
 
                             const confirmation = 'confirmation' in toolDef && toolDef.confirmation;
                             if (confirmation) {
+                                // The confirmation can be a static object or a function that
+                                // derives it from the AI-provided input (e.g. dynamic context).
+                                const resolvedConfirmation =
+                                    typeof confirmation === 'function'
+                                        ? confirmation(event.toolCall.input)
+                                        : confirmation;
                                 const supportingContext =
-                                    'context' in confirmation &&
-                                    typeof confirmation.context === 'string'
-                                        ? confirmation.context.slice(0, 512)
+                                    typeof resolvedConfirmation.context === 'string'
+                                        ? resolvedConfirmation.context.slice(0, 512)
                                         : undefined;
                                 globalState.setState((state) => ({
                                     ...state,
@@ -447,8 +452,8 @@ export function AIChatProvider(props: {
                                             toolCallId: event.toolCallId,
                                         },
                                         input: {
-                                            label: confirmation.label,
-                                            icon: confirmation.icon,
+                                            label: resolvedConfirmation.label,
+                                            icon: resolvedConfirmation.icon,
                                             context: supportingContext,
                                         },
                                         language,
@@ -468,7 +473,7 @@ export function AIChatProvider(props: {
                                                                 text: tString(
                                                                     language,
                                                                     'tool_call_skipped',
-                                                                    confirmation.label
+                                                                    resolvedConfirmation.label
                                                                 ),
                                                             },
                                                         },


### PR DESCRIPTION
## Overview

- Adds an optional `context` property to the `GitBookIntegrationTool` type (`string`, up to 512 characters).
- When set on a tool that also declares a `confirmation`, the context is rendered above the Cancel / Confirm buttons in the confirmation dialog, so the user has supporting context to understand what they are approving or rejecting.
- The property is documented in `@gitbook/browser-types` for integration developers and defensively truncated to 512 characters at render time.

## Changes

- `packages/browser-types/src/index.ts` — new optional `context?: string` field on `GitBookIntegrationTool`, with JSDoc.
- `packages/gitbook/src/components/AI/controls/ConfirmControl.tsx` — `context` added to the control input schema (`z.string().max(512).optional()`) and rendered as a muted paragraph above the buttons when present.
- `packages/gitbook/src/components/AI/useAIChat.tsx` — passes the tool's `context` into the confirm control input (sliced to 512 chars).

## Reviewer notes

- The confirm dialog only appears when a registered integration tool with `confirmation` is invoked mid-chat, so this wasn't exercised in the local dev proxy; the change is a straightforward prop pass-through and conditional render.
- Type-check reports no errors in the changed files (unrelated `@gitbook/api` version-skew errors are pre-existing in the worktree).

*— Authored by Claude*