### PR TITLE
Fix off-center icon in breadcrumb (RND-12092)

### DIFF
--- a/.changeset/breadcrumb-icon-align.md
+++ b/.changeset/breadcrumb-icon-align.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix vertically off-center icon next to breadcrumb text.

--- a/packages/gitbook/src/components/PageBody/BreadcrumbItemDropdown.tsx
+++ b/packages/gitbook/src/components/PageBody/BreadcrumbItemDropdown.tsx
@@ -47,7 +47,10 @@ export function BreadcrumbItemDropdown(props: {
     const content = (
         <>
             {emoji || icon ? (
-                <PageIcon page={{ emoji, icon }} style="mr-1 inline size-[1em] shrink-0" />
+                <PageIcon
+                    page={{ emoji, icon }}
+                    style="mr-1 inline size-[1em] shrink-0 align-middle"
+                />
             ) : null}
             {label}
         </>


### PR DESCRIPTION
## Proposed changes

Fixes RND-12092: on published docs sites, the icon (emoji or custom icon) shown next to a breadcrumb crumb was vertically off-center relative to the crumb text.

Root cause: the breadcrumb is laid out entirely inline (`<ol className="inline">` → `<li className="inline">` → an inline `StyledLink`/`span`). The crumb icon (`PageIcon`) is therefore an inline element with the default `vertical-align: baseline`. Because the icon is a `1em` square (`size-[1em]`), its bottom edge sits on the text baseline, which pushes it visually upward relative to the line box (descenders extend below the baseline), so it reads as too high. The `items-center` already present on the link classes has no effect here because the element is inline, not flex.

The fix adds `align-middle` (`vertical-align: middle`) to the crumb icon so it centers against the text. This matches how inline icons/images are aligned elsewhere in the codebase (e.g. `InlineImage`, the shared button styles). The change is scoped to the single `PageIcon` render in `BreadcrumbItemDropdown.tsx`.

## Changelog
- [Fix] Vertically center the icon next to breadcrumb text so it no longer appears off-center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSEiRkE1nPdYDJjWwZBmys)_