### PR TITLE
Only show the assistant activity heading when there's activity to reveal

### DIFF
--- a/.changeset/collapsible-reasoning-heading.md
+++ b/.changeset/collapsible-reasoning-heading.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Assistant: the "Explored briefly" activity heading no longer appears when there's nothing to show. It now renders only when the answer is preceded by a real preamble or one or more tool calls, so a simple answer with an empty reasoning step no longer surfaces an empty collapsible.

--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -832,10 +832,20 @@ function updateAIChatMessageActivity(
             return {
                 ...activity,
                 currentPhase: event.phase,
-                hasCommentary:
-                    activity.hasCommentary || event.phase === AIMessageStepPhase.Commentary,
                 hasFinalAnswer:
                     activity.hasFinalAnswer || event.phase === AIMessageStepPhase.FinalAnswer,
+            };
+        }
+        case 'response_document': {
+            // A commentary phase can start without ever producing anything visible. Only a
+            // commentary step that emits document content is a real preamble worth collapsing
+            // behind the activity heading, so flag it here rather than on phase start.
+            return {
+                ...activity,
+                hasCommentary:
+                    activity.hasCommentary ||
+                    (activity.currentPhase === AIMessageStepPhase.Commentary &&
+                        event.blocks.length > 0),
             };
         }
         case 'response_tool_call': {


### PR DESCRIPTION
## Overview

- The assistant collapses its reasoning and tool calls behind an activity heading ("Explored briefly" / "Explored with N tools") before the final answer. That heading was rendering even when the collapsible had nothing inside it.
- Root cause: `hasCommentary` was flipped to `true` the moment a commentary *phase started* (`response_step_start`), before that step produced anything. But the collapsible only ever renders a commentary step's document content plus its tool calls, so a commentary step that emitted no content and made no tool calls left the collapsible empty while the heading still showed.
- Fix: flip `hasCommentary` only when a commentary-phase step actually emits document blocks (`response_document` with non-empty `blocks`). Tool-only exploration is still covered by the existing `toolCount > 0` check, and `currentPhase` is still set on step start so the live status indicator is unaffected.

Resulting behavior:
- Empty commentary step, no tools → **no heading**.
- Real preamble text → heading shows ("Explored briefly").
- Tool calls (with or without a preamble) → heading shows ("Explored with N tools").

## Demo

No screenshot: this only manifests mid-stream when the backend opens a commentary step that yields nothing, which isn't deterministically reproducible against the local dev proxy. Verified by tracing the stream-event → render paths ([`AIMessageView`](packages/gitbook/src/components/AI/server-actions/AIMessageView.tsx) renders only `step.content` + tool calls for commentary steps) and by typechecking.

*— Authored by Claude*