### PR TITLE
Serve noindex on internal search/assistant URLs (?q= / ?ask=)

### DIFF
--- a/.changeset/noindex-search-ask-urls.md
+++ b/.changeset/noindex-search-ask-urls.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Serve `X-Robots-Tag: noindex` on internal search/assistant URLs (`?q=` / `?ask=`) and stop disallowing them in robots.txt, so Google can crawl the directive and drop them from the index instead of reporting "Indexed, though blocked by robots.txt".

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -541,6 +541,11 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         response.headers.set('x-gitbook-route-type', routeType);
         response.headers.set('x-gitbook-route-site', siteURLWithoutProtocol);
 
+        // noindex search/assistant deep links, kept crawlable so Google sees the directive.
+        if (rewrittenURL.searchParams.has('ask') || rewrittenURL.searchParams.has('q')) {
+            response.headers.set('x-robots-tag', 'noindex');
+        }
+
         // Allow cross-origin requests from the same parent domain as the site.
         const allowedOrigin = getAllowedCORSOrigin(request, siteCanonicalURL);
         if (allowedOrigin) {

--- a/packages/gitbook/src/routes/robots.ts
+++ b/packages/gitbook/src/routes/robots.ts
@@ -27,9 +27,7 @@ export async function serveRobotsTxt(context: GitBookSiteContext) {
         ? [
               'User-agent: *',
               'Content-Signal: ai-train=yes, search=yes, ai-input=yes',
-              // Disallow only internal search
-              'Disallow: /*?*q=*',
-              'Disallow: /*?*ask=*',
+              // Internal search (?q= / ?ask=) is left crawlable and served noindex via middleware.
               // Allow dynamic assets (may include ?)
               'Allow: /~gitbook/image?*',
               'Allow: /~gitbook/icon?*',


### PR DESCRIPTION
## Problem

On published sites, the `?ask=` (AI Assistant) and `?q=` (search) URLs were showing up as
**"Indexed, though blocked by robots.txt"** in Google Search Console. That status occurs when
Google discovers a URL via links, is blocked from crawling it by robots.txt, and indexes the
URL anyway (URL-only). A robots.txt block prevents crawling but not indexing — and it also
prevents Google from ever seeing an on-page `noindex`.

## Fix

- Serve `X-Robots-Tag: noindex` on any request carrying `?ask=` or `?q=`, set in middleware
  per-request so the cached page body is unaffected.
- Remove the `Disallow: /*?*q=*` / `Disallow: /*?*ask=*` rules from robots.txt so Google can
  crawl these URLs, read the `noindex`, and drop them cleanly.

The Assistant and search features are unchanged — the URLs still work client-side for readers.
Existing GSC entries can be cleared with the Search Console Removals tool; new ones stop
appearing once the `noindex` is live.