### PR TITLE
Link search title/page matches to the page top instead of a section anchor (RND-11916)

### DIFF
--- a/.changeset/search-title-match-page-top.md
+++ b/.changeset/search-title-match-page-top.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Search results that match a page title now link to the top of the page instead of a mid-page section anchor; section-level matches keep their heading anchor.

--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from '../primitives';
 import { Emoji } from '../primitives/Emoji/Emoji';
 import { HighlightQuery } from './HighlightQuery';
 import { SearchResultItem } from './SearchResultItem';
+import { isPageTitleMatch } from './isPageTitleMatch';
 import type { MergedPageResult } from './reciprocalRankFusion';
 import type { ComputedPageResult } from './search-types';
 import type { LocalPageResult } from './useLocalSearchResults';
@@ -26,9 +27,12 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
     const language = useLanguage();
 
     const bestSection = item.type === 'page' ? item.bestSection : undefined;
-    // When the section snippet is displayed, link to the section anchor so the
-    // link matches what the user sees.
-    const href = bestSection?.body ? bestSection.href : 'href' in item ? item.href : item.pathname;
+    const pageHref = 'href' in item ? item.href : item.pathname;
+    // Link to the section anchor only when a section snippet is shown AND the
+    // query is not a title match. Title/page matches link to the top of the page;
+    // section-level matches keep their heading anchor.
+    const href =
+        bestSection?.body && !isPageTitleMatch(query, item.title) ? bestSection.href : pageHref;
 
     const emoji = 'emoji' in item ? item.emoji : undefined;
     const icon = 'icon' in item ? item.icon : undefined;

--- a/packages/gitbook/src/components/Search/isPageTitleMatch.test.ts
+++ b/packages/gitbook/src/components/Search/isPageTitleMatch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+import { isPageTitleMatch } from './isPageTitleMatch';
+
+describe('isPageTitleMatch', () => {
+    it('matches when every query word is a substring of the title', () => {
+        expect(isPageTitleMatch('EDR Integrations', 'EDR Integrations')).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+        expect(isPageTitleMatch('edr integrations', 'EDR Integrations')).toBe(true);
+    });
+
+    it('matches when the title contains the query as part of a longer title', () => {
+        expect(isPageTitleMatch('EDR', 'EDR Integrations')).toBe(true);
+    });
+
+    it('does not match a section-level query whose words are not all in the title', () => {
+        expect(isPageTitleMatch('selecting crowdstrike URL', 'EDR Integrations')).toBe(false);
+    });
+
+    it('requires every query word to appear in the title', () => {
+        expect(isPageTitleMatch('EDR missing', 'EDR Integrations')).toBe(false);
+    });
+
+    it('returns false for an empty query', () => {
+        expect(isPageTitleMatch('', 'EDR Integrations')).toBe(false);
+    });
+
+    it('returns false for a whitespace-only query', () => {
+        expect(isPageTitleMatch('   ', 'EDR Integrations')).toBe(false);
+    });
+
+    it('ignores extra whitespace between query words', () => {
+        expect(isPageTitleMatch('  EDR   Integrations  ', 'EDR Integrations')).toBe(true);
+    });
+
+    it('matches substrings within a title word (substring heuristic)', () => {
+        expect(isPageTitleMatch('api', 'Rapid start')).toBe(true);
+    });
+});

--- a/packages/gitbook/src/components/Search/isPageTitleMatch.ts
+++ b/packages/gitbook/src/components/Search/isPageTitleMatch.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether a search query matches a page by its title.
+ *
+ * There is no server-provided title-vs-section flag on search results, so we
+ * infer a title match the same way title scoring does in `reciprocalRankFusion`:
+ * a match when every whitespace-split query word appears (case-insensitively)
+ * as a substring of the title.
+ *
+ * Used to decide whether a result should link to the top of the page (title
+ * match) or keep its section anchor (section-level match).
+ */
+export function isPageTitleMatch(query: string, title: string): boolean {
+    const queryWords = query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((word) => word.length > 0);
+
+    if (queryWords.length === 0) {
+        return false;
+    }
+
+    const lowerTitle = title.toLowerCase();
+    return queryWords.every((word) => lowerTitle.includes(word));
+}


### PR DESCRIPTION
> **Night-shift draft — not ready to merge, prepared for Zeno.** Please review in the morning; nothing here has been human-reviewed, and I've listed the judgment calls below.

## Proposed changes

**Report:** RND-11916 (Vectra AI / Tom Bilen). When a search result matched the page **title**, clicking it dropped the user into a mid-page section anchor (`#heading`) instead of the top of the article. Expected: title/page matches should go to the top of the page; section-level matches should keep their heading anchor.

**Root cause:** In `packages/gitbook/src/components/Search/SearchPageResultItem.tsx`, page results carry an optional `bestSection` (the highest-scoring section for that page). The link logic used `bestSection.href` (the `#anchor`) whenever a section snippet existed — regardless of whether the query actually matched the page title or a section. So a title match still linked to an arbitrary section anchor.

**Fix:** There is no server-provided title-vs-section flag on the search API response, so we infer a title match the same way title scoring already does in `reciprocalRankFusion`: every whitespace-split query word is a case-insensitive substring of the title. Added a small pure helper `isPageTitleMatch.ts` for this. The link now uses the section anchor only when a section snippet is shown **and** the query is not a title match; otherwise it links to the top of the page. Section-level matches are unchanged and keep their heading anchor.

This reproduces the approach from the earlier draft PR #4400 (closed only because its ephemeral branch was cleaned up — no review, no rejection) on the current stable branch.

Files changed:
- `packages/gitbook/src/components/Search/isPageTitleMatch.ts` (new) — pure helper.
- `packages/gitbook/src/components/Search/isPageTitleMatch.test.ts` (new) — unit tests, incl. the customer's examples (`EDR Integrations` → top; `selecting crowdstrike URL` → keeps anchor).
- `packages/gitbook/src/components/Search/SearchPageResultItem.tsx` — link logic.
- `.changeset/search-title-match-page-top.md` (new).

## Changelog
- [Fix] Search results that match a page title now link to the top of the page instead of a mid-page section anchor; section-level matches keep their heading anchor.

### For Zeno

Judgment calls to sanity-check:
- **The title-match heuristic is substring-based**, matching the existing `reciprocalRankFusion` title-scoring notion. This means short query words can match inside unrelated title words — e.g. `api` is a substring of `Rapid`, so a query "api" against a page titled "Rapid start" would be treated as a title match and link to the top. I kept it consistent with the existing scoring logic rather than introducing a stricter word-boundary rule; flag if you'd prefer word-boundary matching.
- **I did not suppress the section snippet on a title match** — the result still shows the `bestSection` body preview text; only the *link target* changes. Arguably on a title match we could hide the section snippet entirely for consistency, but that's a bigger UX change and I left the visible snippet as-is. Let me know if you want the snippet hidden too.
- **No Playwright test added.** The change is a pure link-target tweak covered by the unit test on the helper; a full browser test for search navigation felt like more than this fix warrants. Happy to add one if you want end-to-end coverage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4BRKDCFacoNMqgP5QyDPu)_