### PR TITLE
Submit sendFeedback MCP tool findings through submitSiteAgentFeedback

### DIFF
--- a/.changeset/mcp-send-feedback-endpoint.md
+++ b/.changeset/mcp-send-feedback-endpoint.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Submit `sendFeedback` MCP tool findings through the dedicated `submitSiteAgentFeedback` API endpoint. The `pageUrl` is now required and an optional `goal` can be provided.

--- a/bun.lock
+++ b/bun.lock
@@ -360,7 +360,7 @@
     "react-dom": "catalog:",
   },
   "catalog": {
-    "@gitbook/api": "0.190.0",
+    "@gitbook/api": "0.191.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -756,7 +756,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.190.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-Ln+AOp0+GIsQPhW7JHuolC2MlfPII26EffLkvrDe8KR+aSOGV23I+wtQ/iLl64UBFodExGfd3fe+Mb6S6h+lSQ=="],
+    "@gitbook/api": ["@gitbook/api@0.191.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-Bizv/lGBeUqUCajS4AOu9uAtc9mDJBUh6BjEmgoCzolxVAa68rW/T4GugyiRl0JrAKIimLVmkYCPevPzXa6lLg=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
-            "@gitbook/api": "0.190.0",
+            "@gitbook/api": "0.191.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
@@ -1,8 +1,4 @@
-import {
-    CustomizationPageActionType,
-    SiteFindingType,
-    SiteInsightsDisplayContext,
-} from '@gitbook/api';
+import { CustomizationPageActionType, SiteInsightsDisplayContext } from '@gitbook/api';
 
 import { type RouteLayoutParams, getDynamicSiteContext } from '@/app/utils';
 import { isAIEnabled } from '@/components/utils/isAIChatEnabled';
@@ -350,11 +346,6 @@ export async function handleMcpRequest(
                 'sendFeedback',
                 `Report an issue in the documentation of ${site.title} so the team can fix it. Use it whenever, while helping a user, you come across content that is outdated, contradictory, missing information, or otherwise unhelpful. Also use it when the user themselves reports a problem with the docs, even if you could not verify it yourself. If it's your own observation, do a quick sanity check that the issue is real before reporting — no need to exhaustively re-read the page. Send one call per distinct issue and do not report the same issue twice in a conversation. Do not use this tool to confirm that a page is accurate; it is for reporting problems only.`,
                 {
-                    category: z
-                        .nativeEnum(SiteFindingType)
-                        .describe(
-                            'The kind of issue. "content-outdated": the content was correct at some point but no longer matches the current product or reality. "incoherence": the content contradicts itself or another page. "content-gap": information the reader needs is missing entirely, whether or not it was ever documented. "other": only as a last resort when none of the above fits.'
-                        ),
                     content: z
                         .string()
                         .min(1)
@@ -401,7 +392,7 @@ export async function handleMcpRequest(
                     idempotentHint: false,
                     openWorldHint: true,
                 },
-                async ({ category, content, pageUrl, goal }) => {
+                async ({ content, pageUrl, goal }) => {
                     try {
                         const match = findSiteSpaceByUrl(context.structure, pageUrl);
                         if (!match) {
@@ -428,23 +419,24 @@ export async function handleMcpRequest(
 
                         const trimmedGoal = goal?.trim() || undefined;
 
-                        trackMcpEvent({
-                            organizationId: context.organizationId,
-                            siteId: site.id,
-                            events: [
-                                {
-                                    type: 'agent_feedback',
-                                    feedback: { content, category },
-                                    location: {
-                                        displayContext: SiteInsightsDisplayContext.Mcp,
-                                        page: resolved.page.id,
-                                        space: match.siteSpace.space.id,
-                                        revision: match.siteSpace.space.revision,
-                                    },
-                                },
-                            ],
-                            request,
-                        });
+                        //!! DISABLED FOR NOW: We'll add this back in when we have a way to track agent feedback.
+                        // trackMcpEvent({
+                        //     organizationId: context.organizationId,
+                        //     siteId: site.id,
+                        //     events: [
+                        //         {
+                        //             type: 'agent_feedback',
+                        //             feedback: { content, category },
+                        //             location: {
+                        //                 displayContext: SiteInsightsDisplayContext.Mcp,
+                        //                 page: resolved.page.id,
+                        //                 space: match.siteSpace.space.id,
+                        //                 revision: match.siteSpace.space.revision,
+                        //             },
+                        //         },
+                        //     ],
+                        //     request,
+                        // });
 
                         const apiClient = await dataFetcher.api();
                         await apiClient.orgs.submitSiteAgentFeedback(

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/mcp/handler.ts
@@ -365,7 +365,7 @@ export async function handleMcpRequest(
                     pageUrl: z
                         .string()
                         .describe(
-                            `The full URL of the page the issue is about (e.g. ${siteUrl}/getting-started). Provide it whenever you can so the finding is linked to the exact page.`
+                            `The full URL of the page the issue is about (e.g. ${siteUrl}/getting-started), so the finding is linked to the exact page.`
                         )
                         .transform((value, ctx) => {
                             const candidate = URL.canParse(value)
@@ -386,8 +386,13 @@ export async function handleMcpRequest(
                             }
 
                             return candidate.toString();
-                        })
-                        .optional(),
+                        }),
+                    goal: z
+                        .string()
+                        .optional()
+                        .describe(
+                            'The broader end goal you were ultimately trying to accomplish (as/on behalf of the user) when you hit this issue. Gives the team the context you were working towards. Optional.'
+                        ),
                 },
                 {
                     title: 'Send feedback',
@@ -396,46 +401,32 @@ export async function handleMcpRequest(
                     idempotentHint: false,
                     openWorldHint: true,
                 },
-                async ({ category, content, pageUrl }) => {
+                async ({ category, content, pageUrl, goal }) => {
                     try {
-                        let pageLocation:
-                            | { page: string; space: string; revision: string }
-                            | undefined;
-
-                        if (pageUrl) {
-                            const match = findSiteSpaceByUrl(context.structure, pageUrl);
-                            if (!match) {
-                                return {
-                                    content: [
-                                        { type: 'text', text: `Page not found: "${pageUrl}"` },
-                                    ],
-                                    isError: true,
-                                };
-                            }
-
-                            const revision = await throwIfDataError(
-                                dataFetcher.getRevision({
-                                    spaceId: match.siteSpace.space.id,
-                                    revisionId: match.siteSpace.space.revision,
-                                })
-                            );
-
-                            const resolved = resolvePagePath(revision.pages, match.pagePath ?? '');
-                            if (!resolved) {
-                                return {
-                                    content: [
-                                        { type: 'text', text: `Page not found: "${pageUrl}"` },
-                                    ],
-                                    isError: true,
-                                };
-                            }
-
-                            pageLocation = {
-                                page: resolved.page.id,
-                                space: match.siteSpace.space.id,
-                                revision: match.siteSpace.space.revision,
+                        const match = findSiteSpaceByUrl(context.structure, pageUrl);
+                        if (!match) {
+                            return {
+                                content: [{ type: 'text', text: `Page not found: "${pageUrl}"` }],
+                                isError: true,
                             };
                         }
+
+                        const revision = await throwIfDataError(
+                            dataFetcher.getRevision({
+                                spaceId: match.siteSpace.space.id,
+                                revisionId: match.siteSpace.space.revision,
+                            })
+                        );
+
+                        const resolved = resolvePagePath(revision.pages, match.pagePath ?? '');
+                        if (!resolved) {
+                            return {
+                                content: [{ type: 'text', text: `Page not found: "${pageUrl}"` }],
+                                isError: true,
+                            };
+                        }
+
+                        const trimmedGoal = goal?.trim() || undefined;
 
                         trackMcpEvent({
                             organizationId: context.organizationId,
@@ -446,12 +437,27 @@ export async function handleMcpRequest(
                                     feedback: { content, category },
                                     location: {
                                         displayContext: SiteInsightsDisplayContext.Mcp,
-                                        ...pageLocation,
+                                        page: resolved.page.id,
+                                        space: match.siteSpace.space.id,
+                                        revision: match.siteSpace.space.revision,
                                     },
                                 },
                             ],
                             request,
                         });
+
+                        const apiClient = await dataFetcher.api();
+                        await apiClient.orgs.submitSiteAgentFeedback(
+                            context.organizationId,
+                            site.id,
+                            {
+                                feedback: content,
+                                url: pageUrl,
+                                spaceId: match.siteSpace.space.id,
+                                pageId: resolved.page.id,
+                                ...(trimmedGoal ? { goal: trimmedGoal } : {}),
+                            }
+                        );
 
                         return {
                             content: [{ type: 'text', text: 'Feedback recorded. Thank you.' }],


### PR DESCRIPTION
## What

The `sendFeedback` MCP tool now submits agent findings through the dedicated `submitSiteAgentFeedback` endpoint (added in `@gitbook/api@0.191.0`), in addition to the existing `agent_feedback` insights event (kept for now, as it also logs MCP usage).

## Changes

- Call `submitSiteAgentFeedback` (awaited) with the resolved page's `spaceId`/`pageId`, the page `url`, and the `feedback` text.
- Make `pageUrl` **required** so every finding is linked to a resolved page.
- Add an optional `goal` parameter (the broader end goal the agent was working towards), mirroring the `askQuestion` tool.
- Bump `@gitbook/api` to `0.191.0`.

The `agent_feedback` insights event is left in place on purpose; a later cleanup will trim it to just log the call.