### PR TITLE
Add temporary origin badges for search debugging

### DIFF
--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -55,6 +55,14 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
               }
             : undefined;
 
+    // TEMP MOCK: origin badge for debugging local vs API results. Not for commit.
+    const originBadge =
+        item.type === 'local-page'
+            ? 'local'
+            : item.type === 'page' && 'pathname' in item
+              ? 'merged'
+              : 'API';
+
     return (
         <SearchResultItem
             ref={ref}
@@ -73,6 +81,25 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
             <Breadcrumbs breadcrumbs={item.breadcrumbs} />
             <p className="line-clamp-1 font-semibold text-base text-tint-strong leading-snug">
                 <HighlightQuery query={query} text={item.title} />
+                {/* TEMP MOCK: origin badge. Not for commit. */}
+                <span
+                    className={tcls(
+                        'ml-2',
+                        'rounded-full',
+                        'px-1.5',
+                        'py-0.5',
+                        'align-middle',
+                        'font-bold',
+                        'text-[10px]',
+                        'uppercase',
+                        'tracking-wide',
+                        originBadge === 'local' && 'bg-blue-200 text-blue-900',
+                        originBadge === 'API' && 'bg-purple-200 text-purple-900',
+                        originBadge === 'merged' && 'bg-green-200 text-green-900'
+                    )}
+                >
+                    {originBadge}
+                </span>
             </p>
             <div
                 className={tcls(

--- a/packages/gitbook/src/components/Search/SearchRecordResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchRecordResultItem.tsx
@@ -1,4 +1,5 @@
 import { tString, useLanguage } from '@/intl/client';
+import { tcls } from '@/lib/tailwind';
 import { Icon } from '@gitbook/icons';
 import React from 'react';
 import { Favicon } from '../utils';
@@ -47,6 +48,24 @@ export const SearchRecordResultItem = React.forwardRef(function SearchRecordResu
         >
             <p className="line-clamp-2 font-semibold text-base text-tint-strong leading-snug">
                 <HighlightQuery query={query} text={item.title} />
+                {/* TEMP MOCK: origin badge, records are always API-only. Not for commit. */}
+                <span
+                    className={tcls(
+                        'ml-2',
+                        'rounded-full',
+                        'bg-purple-200',
+                        'px-1.5',
+                        'py-0.5',
+                        'align-middle',
+                        'font-bold',
+                        'text-[10px]',
+                        'text-purple-900',
+                        'uppercase',
+                        'tracking-wide'
+                    )}
+                >
+                    API
+                </span>
             </p>
             {domain ? (
                 <p className="text-sm text-tint/7 group-[.is-active]:text-tint contrast-more:text-tint">


### PR DESCRIPTION
Add visual badges to search results showing whether items come from local pages or the API. This is a temporary debugging feature to help distinguish between local and merged results during development.