### PR TITLE
Force software rendering in Playwright for consistent images

### DIFF
--- a/.changeset/argos-image-rendering-drift.md
+++ b/.changeset/argos-image-rendering-drift.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Force software rendering (SwiftShader) in Playwright Chromium to eliminate image downscaling drift between GPU-equipped local runs and headless CI runs in Argos screenshots.

--- a/packages/gitbook/playwright.config.ts
+++ b/packages/gitbook/playwright.config.ts
@@ -26,6 +26,12 @@ export default defineConfig({
                         '--disable-lcd-text',
                         // Disable font hinting so glyph rasterization is platform-independent.
                         '--font-render-hinting=none',
+                        // Force software rendering everywhere so image compositing/downscaling
+                        // always goes through the same filter, whether or not a GPU is present —
+                        // a machine with a real GPU renders images more sharply than headless CI
+                        // (no GPU, SwiftShader fallback), causing smooth-vs-pixelated diffs.
+                        '--disable-gpu',
+                        '--use-gl=swiftshader',
                     ],
                 },
             },


### PR DESCRIPTION
## Summary

Disables GPU rendering in Playwright Chromium to ensure consistent image rendering across different machine configurations. This prevents visual differences between CI environments (which use SwiftShader fallback) and machines with dedicated GPUs, eliminating false positives in visual regression testing with Argos.

The change includes disabling GPU acceleration and forcing software rendering via SwiftShaker, ensuring smooth/pixelated image filtering is consistent regardless of the rendering backend available.

## Testing

Run the Argos visual regression tests to verify consistent image rendering across environments. The change applies globally to all Playwright tests in the GitBook package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)