### PR TITLE
Surface verified client identity on the site OAuth/MCP consent screen

### DIFF
--- a/.changeset/site-oauth-consent-verified-name.md
+++ b/.changeset/site-oauth-consent-verified-name.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Show the verified client identity ("Verified as …") on the site OAuth/MCP consent screen when the client is a recognized application.

--- a/packages/gitbook/src/components/SiteOAuthConsent/ConsentScreen.tsx
+++ b/packages/gitbook/src/components/SiteOAuthConsent/ConsentScreen.tsx
@@ -39,7 +39,10 @@ export function ConsentScreen(props: {
                     <div className="flex min-w-0 flex-col gap-0.5">
                         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                             <h1 className="font-semibold text-tint-strong">{client.name}</h1>
-                            <ClientTrustBadge verified={client.verified} />
+                            <ClientTrustBadge
+                                verified={client.verified}
+                                verifiedName={client.verifiedName}
+                            />
                         </div>
                         {client.uri ? (
                             <StyledLink
@@ -184,10 +187,17 @@ function parseRedirectURI(uri: string): { prefix: string; host: string; rest: st
 }
 
 /**
- * Inline verified/unverified indicator shown next to the client name.
+ * Inline verified/unverified indicator shown next to the client name. When the OAuth server matched
+ * the client to a known application, `verifiedName` is the identity GitBook vouches for — anchoring
+ * the trust signal to that name rather than the client-supplied (untrusted) name.
  */
-function ClientTrustBadge(props: { verified: boolean }) {
-    const { verified } = props;
+function ClientTrustBadge(props: { verified: boolean; verifiedName?: string }) {
+    const { verified, verifiedName } = props;
+
+    let label = 'Unverified';
+    if (verified) {
+        label = verifiedName ? `Verified as ${verifiedName}` : 'Verified';
+    }
 
     return (
         <span
@@ -197,7 +207,7 @@ function ClientTrustBadge(props: { verified: boolean }) {
             )}
         >
             <Icon icon={verified ? 'circle-check' : 'triangle-exclamation'} className="size-3" />
-            {verified ? 'Verified' : 'Unverified'}
+            {label}
         </span>
     );
 }


### PR DESCRIPTION
## Proposed changes

Iteration on the published-sites OAuth/MCP consent screen (RND-12071, parent RND-9866; follow-up to #4405 / #4428).

The sites OAuth server's `consent/start` response already returns a `verifiedName` for clients it recognizes from its known-clients registry (matched by the client's redirect URIs), alongside the **untrusted, client-supplied** `name`. GBO's `SiteOAuthConsentClient` type carried the field, but `ConsentScreen` never rendered it — the trust badge only ever said a bare "Verified".

This change anchors the trust signal to the identity GitBook actually vouches for: when a client is verified, the badge now reads **"Verified as {verifiedName}"**. It falls back to the previous "Verified" / "Unverified" labels when no verified name is present, so behavior is unchanged for unrecognized clients. Purely presentational and additive — no API, server, or data-flow change.

Why it matters: a client can self-report any `name` (e.g. impersonate a well-known app), but `verifiedName` only comes from a redirect-URI match against the registry, so surfacing it makes the anti-impersonation signal meaningful rather than cosmetic.

This is a deliberately minimal first step. Larger design iteration (showing the site's own branding, making `verifiedName` the primary heading, copy/a11y polish, optional render-layer URI hardening) is captured in the proposal doc and left for Zeno to drive — see the open questions.

Files:
- `packages/gitbook/src/components/SiteOAuthConsent/ConsentScreen.tsx` — pass `verifiedName` into `ClientTrustBadge`; render "Verified as {name}".
- `.changeset/site-oauth-consent-verified-name.md`

> Unverified night-shift draft prepared for Zeno. Dependencies are not installed in the sandbox, so `bun run format` and `bun run typecheck` could **not** be run — please run them before promoting. The change is a small, self-contained JSX/label edit.

## Changelog
- [Feature] Show the verified client identity ("Verified as …") on the site OAuth/MCP consent screen for recognized applications.

---
_Generated by [Claude Code](https://claude.ai/code/session_015dz2F7LM2xbaSCsMfuGax7)_