### PR TITLE
Fix search results linking to section anchors on title matches (RND-11916)

### DIFF
--- a/.changeset/search-title-match-page-top.md
+++ b/.changeset/search-title-match-page-top.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Search results that match a page title now link to the top of the page instead of a mid-page section anchor; section-level matches keep their heading anchor.

--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -7,6 +7,7 @@ import { Tooltip } from '../primitives';
 import { Emoji } from '../primitives/Emoji/Emoji';
 import { HighlightQuery } from './HighlightQuery';
 import { SearchResultItem } from './SearchResultItem';
+import { isPageTitleMatch } from './isPageTitleMatch';
 import type { MergedPageResult } from './reciprocalRankFusion';
 import type { ComputedPageResult } from './search-types';
 import type { LocalPageResult } from './useLocalSearchResults';
@@ -26,9 +27,12 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
     const language = useLanguage();
 
     const bestSection = item.type === 'page' ? item.bestSection : undefined;
-    // When the section snippet is displayed, link to the section anchor so the
-    // link matches what the user sees.
-    const href = bestSection?.body ? bestSection.href : 'href' in item ? item.href : item.pathname;
+    const pageHref = 'href' in item ? item.href : item.pathname;
+    // Link to the section anchor only when a section snippet is shown AND the
+    // query is not a title match. Title/page matches link to the top of the page;
+    // section-level matches keep their heading anchor.
+    const href =
+        bestSection?.body && !isPageTitleMatch(query, item.title) ? bestSection.href : pageHref;
 
     const emoji = 'emoji' in item ? item.emoji : undefined;
     const icon = 'icon' in item ? item.icon : undefined;

--- a/packages/gitbook/src/components/Search/isPageTitleMatch.test.ts
+++ b/packages/gitbook/src/components/Search/isPageTitleMatch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+import { isPageTitleMatch } from './isPageTitleMatch';
+
+describe('isPageTitleMatch', () => {
+    it('matches when every query word is a substring of the title', () => {
+        expect(isPageTitleMatch('EDR Integrations', 'EDR Integrations')).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+        expect(isPageTitleMatch('edr integrations', 'EDR Integrations')).toBe(true);
+    });
+
+    it('matches when the title contains the query as part of a longer title', () => {
+        expect(isPageTitleMatch('EDR', 'EDR Integrations')).toBe(true);
+    });
+
+    it('does not match a section-level query whose words are not all in the title', () => {
+        expect(isPageTitleMatch('selecting crowdstrike URL', 'EDR Integrations')).toBe(false);
+    });
+
+    it('requires every query word to appear in the title', () => {
+        expect(isPageTitleMatch('EDR missing', 'EDR Integrations')).toBe(false);
+    });
+
+    it('returns false for an empty query', () => {
+        expect(isPageTitleMatch('', 'EDR Integrations')).toBe(false);
+    });
+
+    it('returns false for a whitespace-only query', () => {
+        expect(isPageTitleMatch('   ', 'EDR Integrations')).toBe(false);
+    });
+
+    it('ignores extra whitespace between query words', () => {
+        expect(isPageTitleMatch('  EDR   Integrations  ', 'EDR Integrations')).toBe(true);
+    });
+
+    it('matches substrings within a title word (substring heuristic)', () => {
+        expect(isPageTitleMatch('api', 'Rapid start')).toBe(true);
+    });
+});

--- a/packages/gitbook/src/components/Search/isPageTitleMatch.ts
+++ b/packages/gitbook/src/components/Search/isPageTitleMatch.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether a search query matches a page by its title.
+ *
+ * There is no server-provided title-vs-section flag on search results, so we
+ * infer a title match the same way title scoring does in `reciprocalRankFusion`:
+ * a match when every whitespace-split query word appears (case-insensitively)
+ * as a substring of the title.
+ *
+ * Used to decide whether a result should link to the top of the page (title
+ * match) or keep its section anchor (section-level match).
+ */
+export function isPageTitleMatch(query: string, title: string): boolean {
+    const queryWords = query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((word) => word.length > 0);
+
+    if (queryWords.length === 0) {
+        return false;
+    }
+
+    const lowerTitle = title.toLowerCase();
+    return queryWords.every((word) => lowerTitle.includes(word));
+}


### PR DESCRIPTION
**🌙 Night-shift draft — not merged, no reviewers. Recovers RND-11916 (was draft #4434).**

## Proposed changes

Search results whose query matches a page title now link to the top of the page instead of jumping to a mid-page section anchor. Section-level matches still keep their heading anchor, so deep-linking to the matched section continues to work when the query is genuinely a section-level match.

Previously `SearchPageResultItem` always linked to `bestSection.href` whenever a section snippet was present, even when the query clearly matched the page title. Customer report (Vectra AI / Tom Bilen, Pylon #2456): searching "EDR Integrations" landed the user in the middle of the "EDR Integrations" page rather than at its top.

The change adds a small pure helper, `isPageTitleMatch(query, title)`, that infers a title match the same way title scoring already does in `reciprocalRankFusion`: every whitespace-split query word must appear (case-insensitively) as a substring of the title. `SearchPageResultItem` now links to the section anchor only when a section snippet is shown AND the query is not a title match; otherwise it links to the top of the page.

This recovers the approach from the previously-closed draft #4434 for RND-11916, reproduced on a stable branch so it does not get orphaned again.

## Changelog
- [Fix] Search results that match a page title now link to the top of the page instead of a mid-page section anchor; section-level matches keep their heading anchor.

---

### For Zeno

Judgment calls:
- **Substring vs word-boundary title matching**: kept the substring heuristic (every query word is a substring of the title) deliberately, to mirror the existing title-scoring notion in `reciprocalRankFusion` rather than introduce a second, divergent matching rule. Side effect: a short query like `api` matches the title `Rapid start` (documented in a test). A word-boundary rule would be stricter but would drift from how titles are already scored; not worth the inconsistency for this fix.
- **Section snippet still shown on title match**: only the link target changes. The section snippet/preview a user sees is unchanged — we only stop pointing the anchor at it when the match is really a title match.

Validation (this repo uses bun):
- `bun install` → 1761 packages installed, lockfile saved. OK.
- `cd packages/gitbook && bun test isPageTitleMatch` → 9 pass, 0 fail (9 expect() calls). OK.
- `bun x biome check --write` on the 3 changed source files → checked 3 files, no fixes needed (already formatted). OK. (`bun run format` scans the whole repo and surfaces 250 pre-existing warnings in vendored files unrelated to this change.)
- `bun run typecheck --filter=gitbook` → 27/27 tasks successful (`tsc --noEmit`). OK.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1rctbY7mEtGP1ZwVowxoE)_