### PR TITLE
Don't forward cookies through the OpenAPI Scalar proxy

### DIFF
--- a/.changeset/openapi-scalar-proxy-cookies.md
+++ b/.changeset/openapi-scalar-proxy-cookies.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Improve cookie handling in the OpenAPI "Test it" request proxy.

--- a/packages/gitbook/src/routes/openapi-proxy.test.ts
+++ b/packages/gitbook/src/routes/openapi-proxy.test.ts
@@ -179,6 +179,7 @@ describe('handleOpenAPIProxyRequest', () => {
                     referer: 'http://localhost:3000/docs',
                     'x-forwarded-for': '127.0.0.1',
                     accept: 'application/json',
+                    cookie: 'gitbook_visitor=secret',
                     'x-scalar-cookie': 'session=abc123',
                     'x-scalar-user-agent': 'ScalarClient/1.0',
                 },
@@ -192,7 +193,7 @@ describe('handleOpenAPIProxyRequest', () => {
         expect(headers.get('x-forwarded-for')).toBeNull();
         // Kept
         expect(headers.get('accept')).toBe('application/json');
-        // Remapped
+        // The browser's own cookie must not leak to the target; only the scalar cookie is sent.
         expect(headers.get('cookie')).toBe('session=abc123');
         expect(headers.get('user-agent')).toBe('ScalarClient/1.0');
         // Host set to target
@@ -208,6 +209,7 @@ describe('handleOpenAPIProxyRequest', () => {
                         'content-encoding': 'gzip',
                         'transfer-encoding': 'chunked',
                         'content-type': 'application/json',
+                        'set-cookie': 'evil=1; Domain=.gitbook.com; Path=/',
                     },
                 })
             )
@@ -222,6 +224,8 @@ describe('handleOpenAPIProxyRequest', () => {
         expect(res.headers.get('content-type')).toBe('application/json');
         expect(res.headers.get('content-encoding')).toBeNull();
         expect(res.headers.get('transfer-encoding')).toBeNull();
+        // A target must not be able to set cookies on GitBook's own origin.
+        expect(res.headers.get('set-cookie')).toBeNull();
     });
 
     it('returns 502 when upstream fetch fails', async () => {

--- a/packages/gitbook/src/routes/openapi-proxy.ts
+++ b/packages/gitbook/src/routes/openapi-proxy.ts
@@ -18,6 +18,7 @@ const REQUEST_HEADERS_TO_STRIP = new Set([
     'origin',
     'referer',
     'connection',
+    'cookie',
     'x-scalar-cookie',
     'x-scalar-user-agent',
     'x-forwarded-for',
@@ -36,6 +37,7 @@ const RESPONSE_HEADERS_TO_STRIP = new Set([
     'transfer-encoding',
     'connection',
     'keep-alive',
+    'set-cookie',
 ]);
 
 const CORS_HEADERS = {
@@ -236,11 +238,7 @@ export async function handleOpenAPIProxyRequest(request: NextRequest): Promise<R
         for (const [key, value] of response.headers.entries()) {
             const lower = key.toLowerCase();
             if (!RESPONSE_HEADERS_TO_STRIP.has(lower) && !lower.startsWith('access-control-')) {
-                if (lower === 'set-cookie') {
-                    responseHeaders.append(key, value);
-                } else {
-                    responseHeaders.set(key, value);
-                }
+                responseHeaders.set(key, value);
             }
         }
 


### PR DESCRIPTION
The OpenAPI "Test it" proxy runs on GitBook's own origin. Stop forwarding the browser's `Cookie` to the target and the target's `Set-Cookie` back, so the proxy neither reads nor sets cookies on GitBook's origin. The target API's own cookies still flow through the existing `x-scalar-cookie` → `Cookie` translation, so cookie-authenticated "Test it" requests are unaffected.
