### PR TITLE
Fix off-center icon in breadcrumb (RND-12092)

### DIFF
--- a/.changeset/breadcrumb-icon-alignment.md
+++ b/.changeset/breadcrumb-icon-alignment.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the page icon in breadcrumbs appearing vertically off-center next to its label.

--- a/packages/gitbook/src/components/PageBody/BreadcrumbItemDropdown.tsx
+++ b/packages/gitbook/src/components/PageBody/BreadcrumbItemDropdown.tsx
@@ -47,7 +47,7 @@ export function BreadcrumbItemDropdown(props: {
     const content = (
         <>
             {emoji || icon ? (
-                <PageIcon page={{ emoji, icon }} style="mr-1 inline size-[1em] shrink-0" />
+                <PageIcon page={{ emoji, icon }} style="mr-1 inline size-[1em] shrink-0 align-middle" />
             ) : null}
             {label}
         </>

--- a/packages/gitbook/src/components/PageBody/BreadcrumbItemDropdown.tsx
+++ b/packages/gitbook/src/components/PageBody/BreadcrumbItemDropdown.tsx
@@ -47,7 +47,10 @@ export function BreadcrumbItemDropdown(props: {
     const content = (
         <>
             {emoji || icon ? (
-                <PageIcon page={{ emoji, icon }} style="mr-1 inline size-[1em] shrink-0 align-middle" />
+                <PageIcon
+                    page={{ emoji, icon }}
+                    style="mr-1 inline size-[1em] shrink-0 align-middle"
+                />
             ) : null}
             {label}
         </>


### PR DESCRIPTION
## Proposed changes

The page icon shown in a breadcrumb crumb (`PageIcon` in `BreadcrumbItemDropdown`) was rendered as an inline element with the default `vertical-align: baseline`. Because the icon is a `1em` square, its bottom edge sits on the text baseline, which pushes the icon visually higher than the crumb label and makes it read as off-center.

The fix adds `align-middle` (`vertical-align: middle`) to that single inline crumb icon, so it centers against the label. This mirrors how inline icons are already aligned elsewhere in the app (`InlineImage`, the shared button styles in `primitives/styles.ts`). Only the inline crumb icon is touched; the dropdown sibling icons are laid out differently and are unchanged.

This is night-shift draft work restoring the previously orphaned PR #4423, which was closed unmerged when its ephemeral branch was reclaimed (not human-rejected). Opened as a draft for Zeno to review.

## Changelog
- [Fix] Fix the page icon in breadcrumbs appearing vertically off-center next to its label.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGdAqoovVywzCDzvEybztH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGdAqoovVywzCDzvEybztH)_