### PR TITLE
Fix search results linking to section anchors on title matches (RND-11916)

### DIFF
--- a/.changeset/search-resulttype-page-linking.md
+++ b/.changeset/search-resulttype-page-linking.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Search results from a page/title-level match now link to the top of the page instead of a section anchor; only section-level matches deep-link to their section.

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
@@ -143,6 +143,12 @@ function transformSitePageResult(args: {
           ? toEmbeddableLinkForPublishedContent(linker, spaceURL, pageItem.path)
           : linker.toLinkForContent(joinPathWithBaseURL(spaceURL, pageItem.path));
 
+    // `resultType` marks whether the API matched the page at the title/page level or on a
+    // specific section. It is read defensively because it is not yet in the published
+    // `@gitbook/api` types; once present, page-level matches link to the top of the page.
+    const resultType = (pageItem as SearchPageResult & { resultType?: 'page' | 'section' })
+        .resultType;
+
     const page: ComputedPageResult = {
         type: 'page',
         id: `${spaceItem.id}/${pageItem.id}`,
@@ -151,6 +157,7 @@ function transformSitePageResult(args: {
         pageId: pageItem.id,
         spaceId: spaceItem.id,
         score: pageItem.score,
+        resultType,
         breadcrumbs,
     };
 

--- a/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
+++ b/packages/gitbook/src/components/Search/SearchPageResultItem.tsx
@@ -26,9 +26,15 @@ export const SearchPageResultItem = React.forwardRef(function SearchPageResultIt
     const language = useLanguage();
 
     const bestSection = item.type === 'page' ? item.bestSection : undefined;
-    // When the section snippet is displayed, link to the section anchor so the
-    // link matches what the user sees.
-    const href = bestSection?.body ? bestSection.href : 'href' in item ? item.href : item.pathname;
+    // Section-level matches deep-link to their section anchor; page/title-level matches
+    // link to the top of the page even when a section snippet is shown as a preview.
+    const isPageLevelMatch = item.type === 'page' && item.resultType === 'page';
+    const href =
+        bestSection?.body && !isPageLevelMatch
+            ? bestSection.href
+            : 'href' in item
+              ? item.href
+              : item.pathname;
 
     const emoji = 'emoji' in item ? item.emoji : undefined;
     const icon = 'icon' in item ? item.icon : undefined;

--- a/packages/gitbook/src/components/Search/search-types.ts
+++ b/packages/gitbook/src/components/Search/search-types.ts
@@ -20,6 +20,13 @@ export type ComputedPageResult = BaseComputedResult & {
     type: 'page';
     pageId: string;
     spaceId: string;
+    /**
+     * Whether the API matched this result at the page/title level or on a specific
+     * section. Page-level matches link to the top of the page; section-level matches
+     * keep the section anchor. Optional to stay backward-compatible with API responses
+     * that do not yet return it.
+     */
+    resultType?: 'page' | 'section';
     breadcrumbs?: Array<{ icon?: IconName; label: string }>;
     /** The highest-scoring section for this page, used as a body snippet preview. */
     bestSection?: {


### PR DESCRIPTION
## Proposed changes

Searching published docs often deep-links a result to a section anchor partway down the page, even when the match is really a page/title-level match. Customers (Vectra, Tom Bilen) find this confusing — a title/page match should take them to the top of the article, and only a section-specific match should jump to an anchor.

This uses the new **`resultType`** property on API search results (shipped by Utku on 2026-07-28) to decide the link target:

- **Page/title-level match** → link to the top of the page (no anchor).
- **Section-level match** → keep the existing section anchor behavior.

The section snippet is still shown as a preview when present; only the navigation target changes.

### Implementation

- `search-types.ts` — add an optional `resultType?: 'page' | 'section'` to `ComputedPageResult`. It threads through Reciprocal Rank Fusion automatically (`MergedPageResult` extends `ComputedPageResult`).
- `~gitbook/search/route.ts` — read `resultType` from the API page result and carry it onto the computed result.
- `SearchPageResultItem.tsx` — a page-level match links to `item.href` (page top) even when a section snippet is displayed; section-level matches (and results without `resultType`) keep the section anchor.

### Why this supersedes #4400 / #4434 / #4448

Those closed PRs implemented an interim hack — always link to the page top with a secondary clickable section link — which was abandoned because it was undiscoverable and not keyboard-accessible. Now that the backend distinguishes page- from section-level matches via `resultType`, we can pick the correct single link target directly, with no extra UI.

### ⚠️ Needs confirmation before merge

- `@gitbook/api` is pinned at `0.191.0`, which is also the latest published version and **does not yet include `resultType`** on `SearchPageResult`/`SearchSectionResult`. The property is therefore read **defensively** (via a local cast) and the feature is **inert until the api client is bumped** to a version that includes Utku's change.
- The assumed shape is `resultType: 'page' | 'section'` on the page-level result. Please confirm the exact property name, placement, and enum values against the backend change, then bump `@gitbook/api` — the client currently treats a missing/unknown `resultType` as the previous (anchor) behavior, so nothing changes until both are in place.

## Changelog
- [Fix] Search results from a page/title-level match now link to the top of the page instead of a section anchor; only section-level matches deep-link to their section.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqC63YhWSKfQPThUB2Qrk9)_