### PR TITLE
Fix truncated page titles in auto-generated social preview image (RND-11313)

### DIFF
--- a/.changeset/rnd-11313-ogimage-long-titles.md
+++ b/.changeset/rnd-11313-ogimage-long-titles.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Prevent long page titles from being cut off in the auto-generated social/link preview image by wrapping and scaling the title font size to fit.

--- a/packages/gitbook/src/routes/ogimage.tsx
+++ b/packages/gitbook/src/routes/ogimage.tsx
@@ -20,6 +20,10 @@ import { getExtension } from '@/lib/paths';
 import { getCacheTag } from '@gitbook/cache-tags';
 import { SiteDefaultIcon } from './icon';
 
+// Upper bound on the rendered title length. Kept generous so full titles are
+// shown (the font scales down to fit); only pathological titles get clipped.
+const MAX_TITLE_LENGTH = 128;
+
 /**
  * Render the OpenGraph image for a site content.
  */
@@ -40,8 +44,8 @@ export async function serveOGImage(baseContext: GitBookSiteContext, params: Page
 
     // Compute all text to load only the necessary fonts
     const pageTitle = page
-        ? page.title.length > 64
-            ? `${page.title.slice(0, 64)}...`
+        ? page.title.length > MAX_TITLE_LENGTH
+            ? `${page.title.slice(0, MAX_TITLE_LENGTH)}...`
             : page.title
         : 'Not found';
     const pageDescription =
@@ -199,7 +203,8 @@ export async function serveOGImage(baseContext: GitBookSiteContext, params: Page
             {/* Title and description */}
             <div tw="flex flex-col">
                 <h1
-                    tw={`text-8xl my-0 tracking-tight leading-none text-left text-[${colors.title}] font-bold`}
+                    tw={`my-0 tracking-tight leading-none text-left text-[${colors.title}] font-bold`}
+                    style={{ fontSize: getTitleFontSize(pageTitle.length) }}
                 >
                     {transformText(pageTitle)}
                 </h1>
@@ -344,6 +349,24 @@ function transformText(text: string) {
     }
 
     return '';
+}
+
+/**
+ * Scale the title font size down as the title gets longer, so long titles wrap
+ * across a few lines and stay within the fixed-height image instead of being
+ * cropped. Sizes mirror Tailwind's text-8xl down to text-5xl.
+ */
+function getTitleFontSize(length: number): number {
+    if (length <= 32) {
+        return 96;
+    }
+    if (length <= 64) {
+        return 72;
+    }
+    if (length <= 96) {
+        return 60;
+    }
+    return 48;
 }
 
 type Theme = CustomizationDefaultThemeMode.Dark | CustomizationDefaultThemeMode.Light;


### PR DESCRIPTION
## Proposed changes

The auto-generated OpenGraph / Twitter social preview image (`packages/gitbook/src/routes/ogimage.tsx`) rendered the page title at a fixed `text-8xl` (96px) with `leading-none`. Because the image has a fixed height of 630px, long titles overflowed that box and were visually cropped. On top of that, any title longer than 64 characters was hard-truncated with an ellipsis, so long titles were lost twice over.

This change makes the title font size responsive to the title length, scaling down through 96 → 72 → 60 → 48px as the title grows (thresholds at 32 / 64 / 96 characters). At smaller sizes the title wraps across a few lines and stays within the fixed 630px image instead of being clipped. The hard-truncation cap is also raised from 64 to 128 characters (`MAX_TITLE_LENGTH`), so realistic long titles render in full and only pathological ones get an ellipsis.

🌙 Night-shift draft — not merged, no reviewers. Reinstates RND-11313 (was closed draft #4441, never human-reviewed).

## Changelog
- [Fix] Long page titles are no longer cut off in the auto-generated social/link preview image.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WALQYKu6GghT1N1du6UKeQ)_