### PR TITLE
Tab - reinstate scroll hash

### DIFF
--- a/.changeset/funky-jobs-know.md
+++ b/.changeset/funky-jobs-know.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Update the URL hash when a tab is selected, so a copied link scrolls back to that tab

--- a/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
+++ b/packages/gitbook/src/components/DocumentView/Tabs/DynamicTabs.tsx
@@ -16,6 +16,7 @@ import {
     SELECT_UNPINNED_ATTR,
 } from '@/lib/select';
 import { tcls } from '@/lib/tailwind';
+import { resolveAnchorURL } from '@/lib/urls';
 import { Icon, type IconName } from '@gitbook/icons';
 
 export interface TabsItem {
@@ -68,10 +69,15 @@ export function DynamicTabs(props: {
     const selectTab = useCallback(
         (tabId: string) => {
             const tab = tabs.find((item) => item.id === tabId);
-            if (tab?.slug) {
-                activate(tab.slug);
-                setManualId(tabId);
+            if (!tab?.slug) {
+                return;
             }
+            activate(tab.slug);
+            setManualId(tabId);
+            // The hash is purely positional now — `select` carries the selection — so writing it just
+            // makes a copied URL land on this tab. We deliberately bypass the navigation context: it
+            // would report a hash change and scroll the tab the visitor is already looking at.
+            window.history.replaceState(null, '', resolveAnchorURL(`#${tab.id}`, window.location));
         },
         [tabs, activate]
     );


### PR DESCRIPTION
Clicking a tab no longer set the hash. Reinstating.