### PR TITLE
Disable metadata fetching in revision-related API calls

### DIFF
--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -326,7 +326,7 @@ const getRevision = cache(
                     params.spaceId,
                     params.revisionId,
                     {
-                        metadata: true,
+                        metadata: false,
                     },
                     {
                         ...noCacheFetchOptions,
@@ -430,6 +430,7 @@ const getRevisionPageMarkdown = cache(
                         {
                             format: 'markdown',
                             'format.markdown.refs': 'stable',
+                            metadata: false,
                         },
                         {
                             ...noCacheFetchOptions,
@@ -537,7 +538,9 @@ const getRevisionPageByPath = cache(
                         params.spaceId,
                         params.revisionId,
                         encodedPath,
-                        {},
+                        {
+                            metadata: false,
+                        },
                         {
                             ...noCacheFetchOptions,
                         }

--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -324,7 +324,7 @@ const getRevision = cache(
                     params.spaceId,
                     params.revisionId,
                     {
-                        metadata: true,
+                        metadata: false,
                     },
                     {
                         ...noCacheFetchOptions,
@@ -428,6 +428,7 @@ const getRevisionPageMarkdown = cache(
                         {
                             format: 'markdown',
                             'format.markdown.refs': 'stable',
+                            metadata: false,
                         },
                         {
                             ...noCacheFetchOptions,
@@ -535,7 +536,9 @@ const getRevisionPageByPath = cache(
                         params.spaceId,
                         params.revisionId,
                         encodedPath,
-                        {},
+                        {
+                            metadata: false,
+                        },
                         {
                             ...noCacheFetchOptions,
                         }


### PR DESCRIPTION
Pass metadata false whenever we can so that we improve cache hit on Hive