### PR TITLE
RND-11832: button with select slug action

### DIFF
--- a/.changeset/jolly-breads-pull.md
+++ b/.changeset/jolly-breads-pull.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add the "Select" button action: clicking a button (e.g. a card) activates its slug, so any block containing that slug — tabs today — switches to it. This turns cards into content switchers.

--- a/.changeset/jolly-breads-pull.md
+++ b/.changeset/jolly-breads-pull.md
@@ -1,5 +1,0 @@
----
-"gitbook": patch
----
-
-Add the "Select" button action: clicking a button (e.g. a card) activates its slug, so any block containing that slug — tabs today — switches to it. This turns cards into content switchers.

--- a/.changeset/wild-suns-relate.md
+++ b/.changeset/wild-suns-relate.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Add select action to InlineButton
+Add the `select` action to InlineButton. Clicking the button activates its slug, so any block containing that slug switches to it.

--- a/.changeset/wild-suns-relate.md
+++ b/.changeset/wild-suns-relate.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add select action to InlineButton

--- a/bun.lock
+++ b/bun.lock
@@ -360,7 +360,7 @@
     "react-dom": "catalog:",
   },
   "catalog": {
-    "@gitbook/api": "0.191.0",
+    "@gitbook/api": "0.192.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -756,7 +756,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.191.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-Bizv/lGBeUqUCajS4AOu9uAtc9mDJBUh6BjEmgoCzolxVAa68rW/T4GugyiRl0JrAKIimLVmkYCPevPzXa6lLg=="],
+    "@gitbook/api": ["@gitbook/api@0.192.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-S9ceF3XspgSqXb7JH5feSHSytVkq1jRDwOKeEK4nnZs9pSiKFxHZMj/LnHi8k8anaue/FeLwWYo+Vk08Pdl0+g=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
         "clean": "turbo run clean"
     },
     "workspaces": {
-        "packages": [
-            "packages/*"
-        ],
+        "packages": ["packages/*"],
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,13 @@
         "clean": "turbo run clean"
     },
     "workspaces": {
-        "packages": ["packages/*"],
+        "packages": [
+            "packages/*"
+        ],
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
-            "@gitbook/api": "0.191.0",
+            "@gitbook/api": "0.192.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/components/DocumentView/InlineButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineButton.tsx
@@ -8,6 +8,8 @@ import { Button, type ButtonProps } from '../primitives';
 import type { InlineProps } from './Inline';
 import { InlineActionButton } from './InlineActionButton';
 import { NotFoundRefHoverCard } from './NotFoundRefHoverCard';
+import { SelectActionButton } from './SelectActionButton';
+import { getSelectAction } from './selectAction';
 
 // Editor button sizes render one step smaller here; the editor default (`large`) keeps the previous `medium`.
 const BUTTON_SIZE_MAP: Record<
@@ -30,6 +32,13 @@ export function InlineButton(props: InlineProps<api.DocumentInlineButton>) {
     };
 
     const ButtonImplementation = () => {
+        // Skip the select action in print/PDF: the client store isn't mounted, so it falls through
+        // to the plain disabled button below.
+        const selectAction = context.mode !== 'print' ? getSelectAction(inline.data) : null;
+        if (selectAction) {
+            return <SelectActionButton value={selectAction.value} buttonProps={buttonProps} />;
+        }
+
         // In print/PDF mode, skip interactive action buttons (AI/search providers are not mounted).
         if (context.mode !== 'print' && 'action' in inline.data && 'query' in inline.data.action) {
             return (

--- a/packages/gitbook/src/components/DocumentView/SelectActionButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/SelectActionButton.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useSelect } from '@/components/Select';
+import { slugifySelectValue } from '@/lib/select';
+import { Button, type ButtonProps } from '../primitives';
+
+/**
+ * Renders a "Select" button action: clicking it activates the slug derived from `value`, so any
+ * block containing that slug (tabs, and future consumers) switches to it. This is what turns cards
+ * into content switchers.
+ */
+export function SelectActionButton(props: { value: string; buttonProps: ButtonProps }) {
+    const { value, buttonProps } = props;
+    const { activate } = useSelect();
+    const slug = slugifySelectValue(value);
+    return <Button {...buttonProps} disabled={!slug} onClick={() => activate(slug)} />;
+}

--- a/packages/gitbook/src/components/DocumentView/SelectActionButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/SelectActionButton.tsx
@@ -13,5 +13,10 @@ export function SelectActionButton(props: { value: string; buttonProps: ButtonPr
     const { value, buttonProps } = props;
     const { activate } = useSelect();
     const slug = slugifySelectValue(value);
-    return <Button {...buttonProps} disabled={!slug} onClick={() => activate(slug)} />;
+    const label = `Select "${slug}"`;
+    return (
+        <Button {...buttonProps} disabled={!slug} onClick={() => activate(slug)} label={label}>
+            {label !== buttonProps.label ? buttonProps.label : null}
+        </Button>
+    );
 }

--- a/packages/gitbook/src/components/DocumentView/selectAction.test.ts
+++ b/packages/gitbook/src/components/DocumentView/selectAction.test.ts
@@ -7,7 +7,7 @@ const data = (value: unknown) => value as api.DocumentInlineButton['data'];
 
 describe('getSelectAction', () => {
     it('returns the action for a select button', () => {
-        expect(getSelectAction(data({ action: { action: 'select', value: 'Python' } }))).toEqual({
+        expect(getSelectAction(data({ action: { action: 'select', slug: 'Python' } }))).toEqual({
             action: 'select',
             value: 'Python',
         });
@@ -24,6 +24,6 @@ describe('getSelectAction', () => {
 
     it('returns null when the value is missing or not a string', () => {
         expect(getSelectAction(data({ action: { action: 'select' } }))).toBeNull();
-        expect(getSelectAction(data({ action: { action: 'select', value: 42 } }))).toBeNull();
+        expect(getSelectAction(data({ action: { action: 'select', slug: 42 } }))).toBeNull();
     });
 });

--- a/packages/gitbook/src/components/DocumentView/selectAction.test.ts
+++ b/packages/gitbook/src/components/DocumentView/selectAction.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import type * as api from '@gitbook/api';
+import { getSelectAction } from './selectAction';
+
+// The action shapes are cast because the installed @gitbook/api doesn't type the select variant yet.
+const data = (value: unknown) => value as api.DocumentInlineButton['data'];
+
+describe('getSelectAction', () => {
+    it('returns the action for a select button', () => {
+        expect(getSelectAction(data({ action: { action: 'select', value: 'Python' } }))).toEqual({
+            action: 'select',
+            value: 'Python',
+        });
+    });
+
+    it('returns null for ask/search actions', () => {
+        expect(getSelectAction(data({ action: { action: 'ask', query: 'hi' } }))).toBeNull();
+        expect(getSelectAction(data({ action: { action: 'search' } }))).toBeNull();
+    });
+
+    it('returns null for a link (ref) button', () => {
+        expect(getSelectAction(data({ ref: { kind: 'url', url: 'https://x.dev' } }))).toBeNull();
+    });
+
+    it('returns null when the value is missing or not a string', () => {
+        expect(getSelectAction(data({ action: { action: 'select' } }))).toBeNull();
+        expect(getSelectAction(data({ action: { action: 'select', value: 42 } }))).toBeNull();
+    });
+});

--- a/packages/gitbook/src/components/DocumentView/selectAction.ts
+++ b/packages/gitbook/src/components/DocumentView/selectAction.ts
@@ -22,9 +22,9 @@ export function getSelectAction(
     if (!('action' in data)) {
         return null;
     }
-    const action = data.action as { action?: string; value?: unknown };
-    if (action.action === 'select' && typeof action.value === 'string') {
-        return { action: 'select', value: action.value };
+    const action = data.action as { action?: string; slug?: unknown };
+    if (action.action === 'select' && typeof action.slug === 'string') {
+        return { action: 'select', value: action.slug };
     }
     return null;
 }

--- a/packages/gitbook/src/components/DocumentView/selectAction.ts
+++ b/packages/gitbook/src/components/DocumentView/selectAction.ts
@@ -1,0 +1,30 @@
+import type * as api from '@gitbook/api';
+
+/**
+ * The "Select" button action: clicking the button activates the slug derived from `value`, so any
+ * block containing that slug (tabs today) reacts.
+ *
+ * TODO(RND-11832): this is a local bridge. Remove it once `@gitbook/api`'s `DocumentAction` gains
+ * the `{ action: 'select'; value: string }` variant, and read `inline.data.action` directly.
+ */
+export interface SelectDocumentAction {
+    action: 'select';
+    value: string;
+}
+
+/**
+ * Detect a "Select" action on a button's data, tolerating the fact that the installed `@gitbook/api`
+ * doesn't type it yet. Returns the action (with its `value`) or `null` for link/ask/search buttons.
+ */
+export function getSelectAction(
+    data: api.DocumentInlineButton['data']
+): SelectDocumentAction | null {
+    if (!('action' in data)) {
+        return null;
+    }
+    const action = data.action as { action?: string; value?: unknown };
+    if (action.action === 'select' && typeof action.value === 'string') {
+        return { action: 'select', value: action.value };
+    }
+    return null;
+}

--- a/packages/gitbook/src/components/DocumentView/selectAction.ts
+++ b/packages/gitbook/src/components/DocumentView/selectAction.ts
@@ -1,30 +1,15 @@
 import type * as api from '@gitbook/api';
 
 /**
- * The "Select" button action: clicking the button activates the slug derived from `value`, so any
- * block containing that slug (tabs today) reacts.
- *
- * TODO(RND-11832): this is a local bridge. Remove it once `@gitbook/api`'s `DocumentAction` gains
- * the `{ action: 'select'; value: string }` variant, and read `inline.data.action` directly.
+ * Detect a "Select" action on a button's data returns the action (with its `value`) or `null` if the button is not a select action.
  */
-export interface SelectDocumentAction {
-    action: 'select';
-    value: string;
-}
-
-/**
- * Detect a "Select" action on a button's data, tolerating the fact that the installed `@gitbook/api`
- * doesn't type it yet. Returns the action (with its `value`) or `null` for link/ask/search buttons.
- */
-export function getSelectAction(
-    data: api.DocumentInlineButton['data']
-): SelectDocumentAction | null {
+export function getSelectAction(data: api.DocumentInlineButton['data']) {
     if (!('action' in data)) {
         return null;
     }
-    const action = data.action as { action?: string; slug?: unknown };
-    if (action.action === 'select' && typeof action.slug === 'string') {
-        return { action: 'select', value: action.slug };
+    const action = data.action;
+    if (action.action === 'select') {
+        return { action: action.action, value: action.slug };
     }
     return null;
 }

--- a/packages/gitbook/src/components/DocumentView/selectAction.ts
+++ b/packages/gitbook/src/components/DocumentView/selectAction.ts
@@ -8,7 +8,7 @@ export function getSelectAction(data: api.DocumentInlineButton['data']) {
         return null;
     }
     const action = data.action;
-    if (action.action === 'select') {
+    if (action.action === 'select' && typeof action.slug === 'string') {
         return { action: action.action, value: action.slug };
     }
     return null;


### PR DESCRIPTION
Adds a ‘select’ action to InlineButton so it can activate a slug in the client-side select api.