### PR TITLE
Add support for visitor token revalidation without redirection

### DIFF
--- a/packages/gitbook/src/lib/visitors.test.ts
+++ b/packages/gitbook/src/lib/visitors.test.ts
@@ -21,6 +21,18 @@ describe('getVisitorAuthToken', () => {
         ).toEqual({ source: 'url', token: '123' });
     });
 
+    it('should return a revalidation token for requests from the revalidation worker', () => {
+        expect(
+            getVisitorToken({
+                cookies: [],
+                headers: new Headers({
+                    'User-Agent': 'GitBook-Open-Revalidation-Worker',
+                }),
+                url: new URL('https://example.com?jwt_token=123'),
+            })
+        ).toEqual({ source: 'revalidation', token: '123' });
+    });
+
     it('should return the token from the cookie root basepath', () => {
         const visitorAuth = getVisitorToken({
             cookies: [

--- a/packages/gitbook/src/lib/visitors.ts
+++ b/packages/gitbook/src/lib/visitors.ts
@@ -135,7 +135,7 @@ export function getVisitorToken({
 
     // Allow the empty string to come through
     if (fromUrl !== null && fromUrl !== undefined) {
-        if(headers.get('user-agent')?.toLowerCase() === "gitbook-open-revalidation-worker") {
+        if (headers.get('user-agent')?.toLowerCase() === 'gitbook-open-revalidation-worker') {
             return { source: 'revalidation', token: fromUrl };
         }
 

--- a/packages/gitbook/src/lib/visitors.ts
+++ b/packages/gitbook/src/lib/visitors.ts
@@ -79,6 +79,11 @@ export type VisitorTokenLookup =
           source: 'visitor-oauth-protected';
           token: string;
       }
+    | {
+          /** A visitor token used for revalidation purposes. This is coming from our backend and we don't want to redirect in this case */
+          source: 'revalidation';
+          token: string;
+      }
     /** Not visitor token was found */
     | undefined;
 
@@ -130,6 +135,10 @@ export function getVisitorToken({
 
     // Allow the empty string to come through
     if (fromUrl !== null && fromUrl !== undefined) {
+        if(headers.get('user-agent')?.toLowerCase() === "gitbook-open-revalidation-worker") {
+            return { source: 'revalidation', token: fromUrl };
+        }
+
         return { source: 'url', token: fromUrl };
     }
 

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -341,7 +341,10 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         // on the redirect response.
         //
         const normalizedVisitorURL = normalizeVisitorURL(incomingURL);
-        if (normalizedVisitorURL.toString() !== incomingURL.toString() && visitorToken?.source !== 'revalidation') {
+        if (
+            normalizedVisitorURL.toString() !== incomingURL.toString() &&
+            visitorToken?.source !== 'revalidation'
+        ) {
             return writeResponseCookies(
                 NextResponse.redirect(normalizedVisitorURL.toString()),
                 cookies

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -335,11 +335,13 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         // Make sure the URL is clean of any va token after a successful lookup,
         // and of any visitor.* params that may have been passed to the URL.
         //
+        // We only redirect if the visitor token is not coming from a revalidation request, as we don't want to redirect in that case.
+        //
         // The token and the visitor.* params value are stored in cookies that are set
         // on the redirect response.
         //
         const normalizedVisitorURL = normalizeVisitorURL(incomingURL);
-        if (normalizedVisitorURL.toString() !== incomingURL.toString()) {
+        if (normalizedVisitorURL.toString() !== incomingURL.toString() && visitorToken?.source !== 'revalidation') {
             return writeResponseCookies(
                 NextResponse.redirect(normalizedVisitorURL.toString()),
                 cookies


### PR DESCRIPTION
Implement visitor token revalidation to avoid redirection for specific requests. 
Include tests to ensure functionality.