### PR TITLE
Lazy-load the Mermaid code block

### DIFF
--- a/.changeset/lazy-mermaid-code-block.md
+++ b/.changeset/lazy-mermaid-code-block.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Lazy-load the Mermaid code block so pages that have code blocks but no diagram no longer ship its rendering dependencies.

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/CodeBlock.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/CodeBlock.tsx
@@ -12,8 +12,9 @@ import type { BlockProps } from '../Block';
 import { Blocks } from '../Blocks';
 import { ClientCodeBlock } from './ClientCodeBlock';
 import { CodeBlockRenderer } from './CodeBlockRenderer';
-import { MermaidCodeBlock } from './MermaidCodeBlock';
-import { type RenderedInline, getInlines, highlight } from './highlight';
+import { MermaidCodeBlockLazy } from './MermaidCodeBlockLazy';
+import { highlight } from './highlight';
+import { type RenderedInline, getInlines } from './highlight-tokens';
 
 /**
  * Render a code block, can be client-side or server-side.
@@ -117,7 +118,7 @@ export async function CodeBlock(
     return (
         <React.Suspense fallback={null}>
             {isMermaid ? (
-                <MermaidCodeBlock {...clientProps} />
+                <MermaidCodeBlockLazy {...clientProps} />
             ) : (
                 <ClientCodeBlock {...clientProps} />
             )}

--- a/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlockLazy.tsx
+++ b/packages/gitbook/src/components/DocumentView/CodeBlock/MermaidCodeBlockLazy.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { ClientBlockProps } from './ClientCodeBlock';
+
+// Keeps react-aria and @panzoom/panzoom out of the entry chunk for the many pages that have code
+// blocks but no diagram. `ssr: true` so real diagram blocks still server-render their skeleton.
+const MermaidCodeBlock = dynamic(
+    () => import('./MermaidCodeBlock').then((mod) => mod.MermaidCodeBlock),
+    { ssr: true }
+);
+
+export function MermaidCodeBlockLazy(props: ClientBlockProps) {
+    return <MermaidCodeBlock {...props} />;
+}


### PR DESCRIPTION
`CodeBlock` only renders `MermaidCodeBlock` when the block's syntax is `mermaid`, but the import was static. Next inlines every `'use client'` module reachable from a route's server graph into that route's client entry (`next-flight-client-entry-loader` emits `import(/* webpackMode: "eager" */ …)`), so a runtime conditional in a server component doesn't split anything — the diagram viewer's dependencies shipped on every page that has any code block at all.

Moving the boundary into a `'use client'` wrapper puts them in an on-demand chunk instead. `ssr: true` is kept so real diagram blocks still server-render their skeleton.

Verified on a production build of this branch: `@panzoom/panzoom` and the Mermaid wrapper no longer appear in the route's entry chunks.

Initial client JS for the docs route:

| | |
|---|---|
| `nolann/perf-shiki-split` (base) | 1616.3 KB |
| this branch | 1604.2 KB |
| | **−12.1 KB** |

The byte saving is deliberately small — the Mermaid engine itself was already behind `import('mermaid')`. What changes is that pages with code blocks but no diagram stop loading the viewer's wrapper and its dependencies at all.
