### PR TITLE
Fix: highlight a TOC link entry when on the page or section it points to (RND-11155)

### DIFF
--- a/.changeset/toc-link-active-highlight.md
+++ b/.changeset/toc-link-active-highlight.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Highlight a table-of-contents link entry as active when it points to the page — or the section of a page — you are currently viewing.

--- a/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
+++ b/packages/gitbook/src/components/TableOfContents/PageLinkItem.tsx
@@ -3,6 +3,7 @@
 import { SiteInsightsLinkPosition } from '@gitbook/api';
 import { Icon } from '@gitbook/icons';
 
+import { useCurrentPagePath, useHash } from '../hooks';
 import type { ClientTOCPageLink } from './encodeClientTableOfContents';
 import { TOCPageIcon } from './TOCPageIcon';
 import { Link } from '@/components/primitives';
@@ -13,11 +14,24 @@ export function PageLinkItem(props: { page: ClientTOCPageLink }) {
 
     const isExternal = page.target.kind === 'url';
 
+    const currentPagePath = useCurrentPagePath();
+    const hash = useHash();
+    const isOnTargetPage =
+        page.pathnames?.some((pathname) => pathname === currentPagePath) ?? false;
+    // A link to a section only lights up once the reader is at that section, so sibling links
+    // pointing at other sections of the same page don't all highlight together.
+    const isActive = isOnTargetPage && (!page.anchor || page.anchor === hash);
+
     return (
         <li className="page-link-item flex flex-col [.page-group-item+&]:mt-4">
             <Link
                 href={page.href ?? '#'}
-                classNames={['ToCLinkItemStyles']}
+                data-active={isActive}
+                aria-current={isActive ? 'page' : undefined}
+                classNames={[
+                    'ToCLinkItemStyles',
+                    ...(isActive ? ['ToCLinkItemActiveStyles' as const] : []),
+                ]}
                 insights={{
                     type: 'link_click',
                     link: {

--- a/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
+++ b/packages/gitbook/src/components/TableOfContents/encodeClientTableOfContents.ts
@@ -18,6 +18,10 @@ export type ClientTOCPageLink = {
     emoji?: string;
     icon?: string;
     target: ContentRef;
+    /** Paths of the page this link points to, when it resolves to a page in the current space. */
+    pathnames?: string[];
+    /** Anchor the link points to on that page, when the target is a section of it. */
+    anchor?: string;
 };
 
 export type ClientTOCPageDocument = {
@@ -96,6 +100,15 @@ export async function encodeClientTableOfContents(
             }
             case 'link': {
                 const resolved = await resolveContentRef(page.target, context);
+                // Links to a page (or a section of one) in the current space compute their active
+                // state the same way page entries do. Cross-space and external targets are left out
+                // to avoid over-highlighting.
+                const targetPage =
+                    (page.target.kind === 'page' || page.target.kind === 'anchor') &&
+                    resolved?.page &&
+                    resolved.space?.id === context.space.id
+                        ? resolved.page
+                        : undefined;
                 result.push(
                     removeUndefined({
                         id: page.id,
@@ -104,6 +117,13 @@ export async function encodeClientTableOfContents(
                         emoji: page.emoji,
                         icon: page.icon,
                         target: page.target,
+                        pathnames: targetPage
+                            ? getSiteSpacePagePaths(context.siteSpace, rootPages, targetPage)
+                            : undefined,
+                        anchor:
+                            targetPage && page.target.kind === 'anchor'
+                                ? page.target.anchor
+                                : undefined,
                         type: 'link',
                     })
                 );


### PR DESCRIPTION
## Overview

In a published site's table of contents, an entry of type `link` was never highlighted as active, even when the reader was on the exact page it points to. Page entries (`document`) compute their active state client-side from `pathnames` vs. `useCurrentPagePath()`; link entries were rendered as a plain `Link` with no active logic and no `pathnames` in their encoded payload.

- Adds optional `pathnames` and `anchor` to `ClientTOCPageLink`, populated in `encodeClientTableOfContents` when a link resolves to a page in the current space. Uses the same `getSiteSpacePagePaths` helper page entries use, so the two stay consistent.
- Makes `PageLinkItem` compute `isActive` and apply the same `data-active` / `aria-current="page"` / `ToCLinkItemActiveStyles` treatment as page entries.
- Covers links to a **section** of a page (`kind: 'anchor'`), not just whole-page links — these highlight only while the reader is at that section, matched on the current hash. A page commonly has several sibling links into different sections of it; without the hash condition all of them would light up at once.
- Cross-space links and external URLs never highlight (`resolved.space?.id === context.space.id`).

Repro: https://gitbook.com/docs/~/changes/1288/create-content/formatting/inline#buttons — the "Buttons" entry under "Blocks" points at a section of *Inline content*, and now highlights alongside the *Inline content* page entry.

### Testing

Verified against the repro URL on a local dev server. The encoded payload for the "Buttons" entry now carries its target:

```
"title":"Buttons","target":{"kind":"anchor","anchor":"buttons","page":"DfnNkU49..."},
"pathnames":["create-content/formatting/inline"],"anchor":"buttons","type":"link"
```

At `#buttons`, computed styles on the sidebar entries:

| Entry | `data-active` | color | weight | `::before` bar |
| --- | --- | --- | --- | --- |
| Inline content (page) | `true` | `rgb(254,85,27)` | 600 | primary |
| **Buttons** (section link) | `true` | `rgb(254,85,27)` | 600 | primary |
| Icons (section link, same page) | `false` | tint | 400 | none |
| Custom blocks (cross-space link) | `false` | tint | 400 | none |

Clicking "Icons" moves the highlight to Icons and leaves *Inline content* active.

Known limitation, inherited from the existing `useHash`: it updates on link clicks and on mount, not on browser back/forward, so a back-button hash change doesn't move the highlight until the next navigation. This is shared with the hook's other consumers rather than introduced here.

No automated test added: this is client-side rendering/navigation behavior driven by Next.js routing params, better covered by a Playwright test than a mocked unit test. Flagging it as a deliberate gap.

Commands run: `bun run lint`, `bunx oxfmt --check`, `bun run typecheck` (2 pre-existing errors on `main`, none added). The same computed-style checks were re-run against the deployed preview build and match.

## Demo

Preview build, with "Blocks" expanded in the sidebar: https://5d59f165-gitbook-open-v2-preview.gitbook.workers.dev/url/gitbook.com/docs/~/changes/1288/create-content/formatting/inline#buttons

_Sidebar at `.../create-content/formatting/inline#buttons` — "Buttons" highlighted alongside "Inline content":_

<!-- drag screenshot here -->

_Same sidebar after clicking "Icons" — highlight moves, "Inline content" stays active:_

<!-- drag screenshot here -->

## Changelog
- [Fix] Highlight a table-of-contents link entry as active when it points to the page — or the section of a page — you are currently viewing.

*— Authored by Claude*
