### PR TITLE
Fix text visibility issues on pages with background covers in Firefox and iOS Safari

### DIFF
--- a/.changeset/quiet-pans-listen.md
+++ b/.changeset/quiet-pans-listen.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix text disappearing in Firefox and iOS Safari on pages with a background cover

--- a/packages/gitbook/src/components/DocumentView/Heading.tsx
+++ b/packages/gitbook/src/components/DocumentView/Heading.tsx
@@ -46,6 +46,7 @@ export async function Heading(props: BlockProps<DocumentBlockHeading>) {
             )}
         >
             <span
+                data-cover-aware-text={context.isPageBody ? '' : undefined}
                 className={tcls(
                     'pointer-fine:flex-1',
                     'z-1',

--- a/packages/gitbook/src/components/DocumentView/Paragraph.tsx
+++ b/packages/gitbook/src/components/DocumentView/Paragraph.tsx
@@ -19,6 +19,7 @@ export function Paragraph(props: BlockProps<DocumentBlockParagraph>) {
 
     const paragraph = (
         <p
+            data-cover-aware-text={context.isPageBody ? '' : undefined}
             className={tcls(
                 // Cover-aware contrast text applies only to the page body, not to documents
                 // rendered in overlays (search answers, AI chat) on a background-cover page.

--- a/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/RecordCard.tsx
@@ -20,6 +20,12 @@ export async function RecordCard(
 ) {
     const { view, record, context, block, isOffscreen, document } = props;
 
+    // A card paints its own opaque background, so a background page cover is never behind its
+    // content. Cover-aware contrast text must not apply inside it: it leaves the glyphs transparent
+    // and relies on a viewport-fixed background clipped to text, which Firefox and iOS Safari fail
+    // to paint through the card's clipped stacking context — the text disappears entirely.
+    const cardProps = { ...props, context: { ...context, isPageBody: false } };
+
     const { dark, light } = getRecordCardCovers(record[1], view);
     const targetRef = view.targetDefinition
         ? (record[1].values[view.targetDefinition] as ContentRef)
@@ -154,7 +160,7 @@ export async function RecordCard(
                                     {definition.title}
                                 </div>
                                 <RecordColumnValue
-                                    {...props}
+                                    {...cardProps}
                                     column={column}
                                     ariaLabelledBy={ariaLabelledBy}
                                 />
@@ -162,7 +168,7 @@ export async function RecordCard(
                         );
                     }
 
-                    return <RecordColumnValue key={column} {...props} column={column} />;
+                    return <RecordColumnValue key={column} {...cardProps} column={column} />;
                 })}
             </div>
         </div>

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -43,7 +43,6 @@ export async function PageAside(props: {
             toggleClass="outline-open"
             withOverlay
             withCloseButton
-            data-cover-aware-text
             className={tcls(
                 'group/aside',
                 'order-last',
@@ -108,8 +107,10 @@ export async function PageAside(props: {
                 'max-xl:hydrated:site-background',
                 'layout-wide:max-3xl:hydrated:site-background',
                 'text-tint',
-                'contrast-more:text-tint-strong',
-                'xl:page-cover-background:text-contrast-cover'
+                'contrast-more:text-tint-strong'
+                // The cover-aware text color lives on the individual rows below, not here: the
+                // outline column is tall enough to always cross the cover's bottom edge, and a
+                // container can't carry a single correct color for text on both sides of it.
             )}
         >
             <div className="flex h-full w-full shrink-0 flex-col overflow-hidden">
@@ -128,7 +129,10 @@ export async function PageAside(props: {
                                 filterableTags.length > 0 && 'mt-4'
                             )}
                         >
-                            <ScrollToTopButton className="flex cursor-pointer items-center gap-1 font-semibold text-tint text-xs uppercase leading-wider">
+                            <ScrollToTopButton
+                                data-cover-aware-text
+                                className="flex cursor-pointer items-center gap-1 font-semibold text-tint text-xs uppercase leading-wider xl:page-cover-background:text-contrast-cover"
+                            >
                                 <Icon icon="block-quote" className="size-3" />{' '}
                                 {t(language, 'on_this_page')}
                             </ScrollToTopButton>

--- a/packages/gitbook/src/components/PageAside/PageAside.tsx
+++ b/packages/gitbook/src/components/PageAside/PageAside.tsx
@@ -43,6 +43,7 @@ export async function PageAside(props: {
             toggleClass="outline-open"
             withOverlay
             withCloseButton
+            data-cover-aware-text
             className={tcls(
                 'group/aside',
                 'order-last',

--- a/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
+++ b/packages/gitbook/src/components/PageAside/ScrollSectionsList.tsx
@@ -79,6 +79,7 @@ export function ScrollSectionsList({ sections }: { sections: DocumentSection[] }
                 >
                     <a
                         href={`#${section.id}`}
+                        data-cover-aware-text
                         className={tcls(
                             'relative',
                             'z-10',

--- a/packages/gitbook/src/components/PageBody/PageCover.tsx
+++ b/packages/gitbook/src/components/PageBody/PageCover.tsx
@@ -1,9 +1,5 @@
 import type { GitBookSiteContext } from '@/lib/context';
-import {
-    CustomizationHeaderPreset,
-    type RevisionPageDocument,
-    type RevisionPageDocumentCover,
-} from '@gitbook/api';
+import type { RevisionPageDocument, RevisionPageDocumentCover } from '@gitbook/api';
 import type { StaticImageData } from 'next/image';
 
 import { getImageAttributes } from '@/components/utils';
@@ -17,7 +13,6 @@ import { getCoverHeight } from './coverHeight';
 import defaultPageCoverSVG from './default-page-cover.svg';
 
 const defaultPageCover = defaultPageCoverSVG as StaticImageData;
-const DEFAULT_RESPONSIVE_COVER_CUTOFF = '56.25%';
 
 /**
  * Cover for the page.
@@ -31,24 +26,6 @@ export async function PageCover(props: {
     const { as, page, cover, context } = props;
     const height = getCoverHeight(cover);
     const mask = page.layout.coverMask === 'radial' ? 'radial' : 'none';
-
-    const initialCoverCutoff = () => {
-        if (!height) {
-            return DEFAULT_RESPONSIVE_COVER_CUTOFF;
-        }
-
-        let total = height;
-        if (context.customization.announcement?.enabled) {
-            total += 68;
-        }
-        if (context.customization.header.preset !== CustomizationHeaderPreset.None) {
-            total += 64;
-        }
-        if (context.visibleSections && context.visibleSections.list.length > 1) {
-            total += 45;
-        }
-        return `${total}px`;
-    };
 
     const [resolved, resolvedDark] = await Promise.all([
         cover.ref ? resolveContentRef(cover.ref, context) : null,
@@ -104,7 +81,6 @@ export async function PageCover(props: {
 
     return (
         <>
-            <style>{`:root { --cover-height: ${initialCoverCutoff()}; }`}</style>
             <div
                 data-gb-page-cover
                 data-cover-text-color={cover.textColor}

--- a/packages/gitbook/src/components/PageBody/PageHeader.tsx
+++ b/packages/gitbook/src/components/PageBody/PageHeader.tsx
@@ -188,6 +188,10 @@ export async function PageHeader(props: {
                 // content spans the full width with no navigation column, so the crumbs sit stranded.
                 <nav
                     aria-label="Breadcrumb"
+                    // A background cover starts at the top of the page body, so the header always
+                    // overlaps it: mark it here so it is never briefly unstyled before hydration.
+                    data-cover-aware-text
+                    data-over-cover
                     className="layout-wide:page-no-toc:hidden page-cover-background:text-contrast-cover text-tint text-xs leading-relaxed page-cover-background:opacity-9"
                 >
                     <ol className="inline">
@@ -229,6 +233,8 @@ export async function PageHeader(props: {
             <PageTags page={page} revision={revision} />
             {page.layout.title ? (
                 <h1
+                    data-cover-aware-text
+                    data-over-cover
                     className={tcls(
                         'text-2xl',
                         '@xs:text-3xl',
@@ -251,6 +257,8 @@ export async function PageHeader(props: {
             ) : null}
             {page.description && page.layout.description ? (
                 <p
+                    data-cover-aware-text
+                    data-over-cover
                     className={tcls(
                         CONTENT_STYLE_REDUCED,
                         'text-lg',

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -221,9 +221,7 @@
     interpolate-size: allow-keywords; /* Opt-in for modern browsers to interpolate "auto" values in transitions/animations. */
     overflow-x: hidden; /* We never want horizontal scroll of the whole page, it looks buggy and we should never have overflow anyway */
     --ai-chat-width: 24rem; /* Default AI chat panel width (= AI_CHAT_DEFAULT_WIDTH 384px); overridden client-side from local storage. */
-    --cover-height: 0px;
-    --cover-text-top: rgb(var(--tint-12));
-    --cover-text-bottom: rgb(var(--tint-12));
+    --cover-text: rgb(var(--tint-12));
   }
 
   :root:not(.dark):has(
@@ -232,7 +230,7 @@
   :root.dark:has(
       [data-gb-page-cover][data-cover-type="background"][data-cover-text-color-dark="black"]
     ) {
-    --cover-text-top: rgb(var(--contrast-tint-12));
+    --cover-text: rgb(var(--contrast-tint-12));
   }
 
   /* Modern browsers with `scrollbar-*` support */
@@ -315,40 +313,26 @@
   }
 }
 
-@utility contrast-cover {
-  background-clip: border-box;
-  background-image: linear-gradient(
-    to bottom,
-    var(--cover-text-top) 0,
-    var(--cover-text-top) var(--cover-height),
-    var(--cover-text-bottom) var(--cover-height),
-    var(--cover-text-bottom) 100vh
-  );
-  background-repeat: no-repeat;
-  background-size: 100% 100vh;
-  background-attachment: fixed;
-}
+/*
+  Recolor text that sits over a background page cover, so it stays readable against the cover image.
 
+  Whether an element actually overlaps the cover can't be expressed in CSS: it depends on layout,
+  and for the sticky page outline it also changes as the cover scrolls away. `useMarkTextOverCover`
+  measures it and marks the overlapping elements with `data-over-cover`.
+
+  This deliberately recolors with a plain `color`. A previous version painted a viewport-fixed
+  gradient through `background-clip: text` on transparent glyphs, which let CSS alone resolve the
+  cover edge — but neither Firefox nor iOS Safari paints a fixed-attachment background clipped to
+  text inside a clipped stacking context, so the text vanished entirely.
+
+  In high contrast the cover itself is all but hidden (`contrast-more:opacity-5`), so the rule is
+  dropped there and the element keeps its regular color.
+*/
 @utility text-contrast-cover {
-  color: transparent;
-  -webkit-text-fill-color: transparent;
-  background-image: linear-gradient(
-    to bottom,
-    var(--cover-text-top) 0,
-    var(--cover-text-top) var(--cover-height),
-    var(--cover-text-bottom) var(--cover-height),
-    var(--cover-text-bottom) 100vh
-  );
-  background-repeat: no-repeat;
-  background-size: 100% 100vh;
-  background-attachment: fixed;
-  background-clip: text;
-  -webkit-background-clip: text;
-
-  @media (prefers-contrast: more) {
-    color: var(--cover-text-bottom);
-    -webkit-text-fill-color: var(--cover-text-bottom);
-    background-image: none;
+  @media not (prefers-contrast: more) {
+    &[data-over-cover] {
+      color: var(--cover-text);
+    }
   }
 }
 

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -222,6 +222,8 @@
     overflow-x: hidden; /* We never want horizontal scroll of the whole page, it looks buggy and we should never have overflow anyway */
     --ai-chat-width: 24rem; /* Default AI chat panel width (= AI_CHAT_DEFAULT_WIDTH 384px); overridden client-side from local storage. */
     --cover-text: rgb(var(--tint-12));
+    /* Color to fall back to below the cover, for text that crosses its bottom edge. */
+    --cover-text-below: rgb(var(--tint-12));
   }
 
   :root:not(.dark):has(
@@ -316,22 +318,41 @@
 /*
   Recolor text that sits over a background page cover, so it stays readable against the cover image.
 
-  Whether an element actually overlaps the cover can't be expressed in CSS: it depends on layout,
-  and for the sticky page outline it also changes as the cover scrolls away. `useMarkTextOverCover`
-  measures it and marks the overlapping elements with `data-over-cover`.
+  Whether an element overlaps the cover can't be expressed in CSS: it depends on layout, and for the
+  sticky page outline it also changes as the cover scrolls away. `useMarkTextOverCover` measures it
+  and marks the overlapping elements with `data-over-cover`.
 
-  This deliberately recolors with a plain `color`. A previous version painted a viewport-fixed
-  gradient through `background-clip: text` on transparent glyphs, which let CSS alone resolve the
-  cover edge — but neither Firefox nor iOS Safari paints a fixed-attachment background clipped to
-  text inside a clipped stacking context, so the text vanished entirely.
+  Text fully over the cover is recolored with a plain `color`, so the glyphs are never transparent.
+  Only an element crossing the cover's bottom edge needs the gradient, and that gradient is
+  element-relative: an earlier version anchored it to the viewport with `background-attachment:
+  fixed`, which neither Firefox nor iOS Safari paints when clipped to text inside a clipped stacking
+  context — leaving the transparent glyphs invisible.
 
-  In high contrast the cover itself is all but hidden (`contrast-more:opacity-5`), so the rule is
+  In high contrast the cover itself is all but hidden (`contrast-more:opacity-5`), so both rules are
   dropped there and the element keeps its regular color.
 */
 @utility text-contrast-cover {
   @media not (prefers-contrast: more) {
     &[data-over-cover] {
       color: var(--cover-text);
+    }
+
+    &[data-over-cover="split"] {
+      color: transparent;
+      -webkit-text-fill-color: transparent;
+      background-image: linear-gradient(
+        to bottom,
+        var(--cover-text) 0,
+        var(--cover-text) var(--cover-edge),
+        var(--cover-text-below) var(--cover-edge),
+        var(--cover-text-below) 100%
+      );
+      background-repeat: no-repeat;
+      /* Align the gradient with the box `--cover-edge` was measured from. */
+      background-origin: border-box;
+      /* Firefox only has partial support for this, but it should be enough for our use case */
+      background-clip: text;
+      -webkit-background-clip: text;
     }
   }
 }

--- a/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
+++ b/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
@@ -24,7 +24,7 @@ export function PageClientLayout({
     useRegisterPageMetadata({ pageMetaLinks });
 
     useStripFallbackQueryParam();
-    useSetCoverHeight();
+    useMarkTextOverCover();
     return null;
 }
 
@@ -63,30 +63,48 @@ function useRegisterPageMetadata(metadata: {
 }
 
 /**
- * Expose the visible bottom edge of the page cover as a viewport-relative CSS variable.
+ * Mark the text elements that overlap a background page cover, so they can be recolored to stay
+ * readable against it (see the `text-contrast-cover` utility).
+ *
+ * The elements that opt in carry `data-cover-aware-text`; the ones found to overlap get
+ * `data-over-cover`. Both edges are read in viewport coordinates, which is what makes this work for
+ * the sticky page outline too: it stays pinned while the cover scrolls away underneath it.
  */
-function useSetCoverHeight() {
+function useMarkTextOverCover() {
     React.useEffect(() => {
         const root = document.documentElement;
+        const pageCover = document.querySelector<HTMLElement>('[data-gb-page-cover]');
+
+        // Only a background cover sits behind the content; a hero/full cover pushes it down.
+        if (!pageCover || pageCover.dataset.coverType !== 'background') {
+            return;
+        }
+
         let animationFrame: number | null = null;
 
-        const updateCoverHeight = () => {
-            const pageCover = document.querySelector<HTMLElement>('[data-gb-page-cover]');
-            const isBackgroundCover = pageCover?.dataset.coverType === 'background';
+        const update = () => {
+            const coverBottom = pageCover.getBoundingClientRect().bottom;
+            const elements = Array.from(
+                document.querySelectorAll<HTMLElement>('[data-cover-aware-text]')
+            );
 
-            if (!isBackgroundCover) {
-                root.style.setProperty('--cover-height', '0px');
-                return;
-            }
+            // Measure everything before mutating, so we don't interleave layout reads and writes.
+            const isOverCover = elements.map((element) => {
+                const rect = element.getBoundingClientRect();
 
-            if (!pageCover) {
-                return;
-            }
+                // A `display: none` element has no box, and its empty rect reads as sitting at the
+                // very top of the document — keep the marking it was rendered with until it is
+                // actually laid out, rather than flipping it on a meaningless measurement.
+                if (rect.width === 0 && rect.height === 0) {
+                    return element.hasAttribute('data-over-cover');
+                }
 
-            const bottom = pageCover.getBoundingClientRect().bottom;
-            const height = Math.max(Math.min(bottom, window.innerHeight), 0);
+                return rect.top < coverBottom;
+            });
 
-            root.style.setProperty('--cover-height', `${height}px`);
+            elements.forEach((element, index) => {
+                element.toggleAttribute('data-over-cover', isOverCover[index]);
+            });
         };
 
         const scheduleUpdate = () => {
@@ -96,7 +114,7 @@ function useSetCoverHeight() {
 
             animationFrame = requestAnimationFrame(() => {
                 animationFrame = null;
-                updateCoverHeight();
+                update();
             });
         };
 
@@ -105,24 +123,25 @@ function useSetCoverHeight() {
         window.addEventListener('scroll', scheduleUpdate, { passive: true });
         window.addEventListener('resize', scheduleUpdate, { passive: true });
 
-        const pageCover = document.querySelector<HTMLElement>('[data-gb-page-cover]');
         const resizeObserver =
-            pageCover && typeof ResizeObserver !== 'undefined'
-                ? new ResizeObserver(() => {
-                      scheduleUpdate();
-                  })
-                : null;
+            typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleUpdate) : null;
+        resizeObserver?.observe(pageCover);
 
-        if (pageCover && resizeObserver) {
-            resizeObserver.observe(pageCover);
-        }
+        const mutationObserver =
+            typeof MutationObserver !== 'undefined' ? new MutationObserver(scheduleUpdate) : null;
 
         // Dismissing the announcement banner only toggles a class on <html> (see
         // dismissAnnouncement) — no scroll/resize event and no cover resize — yet it shifts the
-        // cover up. Watch <html> class changes so the cover height is recomputed in that case too.
-        const classObserver =
-            typeof MutationObserver !== 'undefined' ? new MutationObserver(scheduleUpdate) : null;
-        classObserver?.observe(root, { attributes: true, attributeFilter: ['class'] });
+        // cover up.
+        mutationObserver?.observe(root, { attributes: true, attributeFilter: ['class'] });
+
+        // Blocks that stream in late bring elements that still need measuring. Scoped to the page
+        // body so unrelated DOM churn elsewhere (portals, the AI chat streaming its answer) doesn't
+        // schedule a measurement pass.
+        const pageBody = document.querySelector('main');
+        if (pageBody) {
+            mutationObserver?.observe(pageBody, { childList: true, subtree: true });
+        }
 
         return () => {
             if (animationFrame !== null) {
@@ -130,7 +149,7 @@ function useSetCoverHeight() {
             }
 
             resizeObserver?.disconnect();
-            classObserver?.disconnect();
+            mutationObserver?.disconnect();
             window.removeEventListener('scroll', scheduleUpdate);
             window.removeEventListener('resize', scheduleUpdate);
         };

--- a/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
+++ b/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
@@ -62,6 +62,16 @@ function useRegisterPageMetadata(metadata: {
     }, [pageMetaLinks]);
 }
 
+/** How an element sits relative to the bottom edge of a background page cover. */
+type CoverOverlap =
+    | { kind: 'none' }
+    /** Entirely over the cover: one flat contrast color is enough. */
+    | { kind: 'full' }
+    /** Crosses the cover's bottom edge, `edge` px below the element's own top. */
+    | { kind: 'split'; edge: number }
+    /** Not measurable (no layout box) — leave whatever marking it already has. */
+    | { kind: 'keep' };
+
 /**
  * Mark the text elements that overlap a background page cover, so they can be recolored to stay
  * readable against it (see the `text-contrast-cover` utility).
@@ -69,6 +79,9 @@ function useRegisterPageMetadata(metadata: {
  * The elements that opt in carry `data-cover-aware-text`; the ones found to overlap get
  * `data-over-cover`. Both edges are read in viewport coordinates, which is what makes this work for
  * the sticky page outline too: it stays pinned while the cover scrolls away underneath it.
+ *
+ * An element that crosses the cover's bottom edge has to change color partway down, so it is marked
+ * `data-over-cover="split"` with the crossing point in `--cover-edge`.
  */
 function useMarkTextOverCover() {
     React.useEffect(() => {
@@ -89,22 +102,43 @@ function useMarkTextOverCover() {
             );
 
             // Measure everything before mutating, so we don't interleave layout reads and writes.
-            const isOverCover = elements.map((element) => {
+            const measured = elements.map((element): [HTMLElement, CoverOverlap] => {
                 const rect = element.getBoundingClientRect();
 
                 // A `display: none` element has no box, and its empty rect reads as sitting at the
                 // very top of the document — keep the marking it was rendered with until it is
                 // actually laid out, rather than flipping it on a meaningless measurement.
                 if (rect.width === 0 && rect.height === 0) {
-                    return element.hasAttribute('data-over-cover');
+                    return [element, { kind: 'keep' }];
                 }
 
-                return rect.top < coverBottom;
+                const edge = coverBottom - rect.top;
+
+                if (edge <= 0) {
+                    return [element, { kind: 'none' }];
+                }
+
+                return [element, edge >= rect.height ? { kind: 'full' } : { kind: 'split', edge }];
             });
 
-            elements.forEach((element, index) => {
-                element.toggleAttribute('data-over-cover', isOverCover[index]);
-            });
+            for (const [element, overlap] of measured) {
+                switch (overlap.kind) {
+                    case 'keep':
+                        break;
+                    case 'none':
+                        element.removeAttribute('data-over-cover');
+                        element.style.removeProperty('--cover-edge');
+                        break;
+                    case 'full':
+                        element.setAttribute('data-over-cover', '');
+                        element.style.removeProperty('--cover-edge');
+                        break;
+                    case 'split':
+                        element.setAttribute('data-over-cover', 'split');
+                        element.style.setProperty('--cover-edge', `${overlap.edge}px`);
+                        break;
+                }
+            }
         };
 
         const scheduleUpdate = () => {


### PR DESCRIPTION
Address text visibility problems that occur on pages with background covers specifically in Firefox and iOS Safari. Implemented a solution that ensures text remains readable by marking elements that overlap the cover and adjusting styles accordingly.