### PR TITLE
Fix icons rendering invisible on pages with a background cover

### DIFF
--- a/.changeset/icons-cover-background.md
+++ b/.changeset/icons-cover-background.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix icons being invisible in headings and paragraphs on pages with a background cover

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -330,7 +330,6 @@
 }
 
 @utility text-contrast-cover {
-  color: transparent;
   -webkit-text-fill-color: transparent;
   background-image: linear-gradient(
     to bottom,


### PR DESCRIPTION
Icons in headings and paragraphs are invisible on pages with a background cover. 

Before: 
<img width="1292" height="730" alt="image" src="https://github.com/user-attachments/assets/d2382e08-7fd6-4907-81bc-290688a51025" />

After:
<img width="1272" height="435" alt="image" src="https://github.com/user-attachments/assets/037ac99c-f3f1-40aa-8eb6-fe68219b22ea" />
