### PR TITLE
Fix inline code rendering as empty boxes over page covers (RND-12266)

### DIFF
--- a/.changeset/rnd-12266-inline-code-empty-boxes.md
+++ b/.changeset/rnd-12266-inline-code-empty-boxes.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix inline code rendering as empty boxes on published pages with a background cover.

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -353,6 +353,14 @@
       /* Firefox only has partial support for this, but it should be enough for our use case */
       background-clip: text;
       -webkit-background-clip: text;
+
+      /* Inline chips paint their own background, so the cover is never behind their glyphs. They
+         inherit the transparent fill above but get no text-clipped gradient of their own, which
+         renders them as empty boxes — give them back a solid, readable fill. */
+      & :is(code, kbd) {
+        color: var(--cover-text-below);
+        -webkit-text-fill-color: var(--cover-text-below);
+      }
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

Inline code (and keyboard `kbd`) chips render as **empty boxes** on published pages that use a **background cover** (e.g. a home page). RND-12266 reports this affects all inline code (`order_id`, `amount`, `Content-Type`, …), only after publishing, and persists in incognito.

**Root cause.** Cover-aware contrast text (introduced/reworked in #4477) marks page-body paragraphs and headings that overlap a background cover. An element that *crosses* the cover's bottom edge gets `data-over-cover="split"`, and the `text-contrast-cover` utility then paints it with `color: transparent` + `-webkit-text-fill-color: transparent` and a `background-image` gradient clipped to the text via `background-clip: text`.

That works for the paragraph's own text runs, but an inline `<code>`/`<kbd>` is a nested element:
- it **inherits** the transparent `color` / `-webkit-text-fill-color`, so its glyphs are painted transparent;
- `background-image` and `background-clip` are **not** inherited, so it never gets a text-clipped gradient of its own to paint the glyphs back.

Because the chip also paints its own `bg-tint` background and `ring`, the result is a visible box with invisible text — an empty box. (The RecordCard fix in the same PR handled the analogous "paints its own background" case by opting out of cover-aware text; inline chips inside a legitimately cover-aware paragraph can't opt the whole paragraph out, so they need to reset their own fill.)

**Fix.** Inside the `split` rule of `text-contrast-cover`, restore a solid, readable fill for `code`/`kbd` descendants using `--cover-text-below` (the normal below-cover text color, theme-aware). These chips paint their own background, so the cover is never behind their glyphs and they don't need the gradient. Scoped to the `split` case only; the flat `full`-cover case was already fine.

## Changelog
- [Fix] Fix inline code rendering as empty boxes on published pages with a background cover.

🌙 Night-shift draft — root-caused but NOT verified in a running browser. Please sanity-check before marking ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGcATnYSXJ5aMDHjnZX1Pe)_