### PR TITLE
Show image thumbnails for file attachments

### DIFF
--- a/.changeset/svg-file-attachment-previews.md
+++ b/.changeset/svg-file-attachment-previews.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Show image thumbnails, including SVG previews, for file attachments on published sites.

--- a/packages/gitbook/src/components/DocumentView/File.tsx
+++ b/packages/gitbook/src/components/DocumentView/File.tsx
@@ -73,7 +73,9 @@ export async function File(props: BlockProps<DocumentBlockFile>) {
                         </Link>
                     </div>
                     <div className="text-sm text-tint-subtle">
-                        {contentType} · {getHumanFileSize(file.size)}
+                        {contentType
+                            ? `${contentType} · ${getHumanFileSize(file.size)}`
+                            : getHumanFileSize(file.size)}
                     </div>
                 </div>
                 <div className="flex shrink-0 flex-wrap gap-2">

--- a/packages/gitbook/src/components/DocumentView/File.tsx
+++ b/packages/gitbook/src/components/DocumentView/File.tsx
@@ -1,5 +1,6 @@
 import { type DocumentBlockFile, SiteInsightsLinkPosition } from '@gitbook/api';
 
+import { Image } from '@/components/utils';
 import { t } from '@/intl/translate';
 import { getSimplifiedContentType } from '@/lib/files';
 import { resolveContentRefInDocument } from '@/lib/references';
@@ -43,8 +44,23 @@ export async function File(props: BlockProps<DocumentBlockFile>) {
         <Caption {...props} withBorder>
             <div className="flex flex-wrap items-center gap-5 px-5 py-3">
                 <div className="flex min-w-14 flex-col items-center gap-1 border-tint-subtle border-r pr-5">
-                    <FileIcon contentType={contentType} className="size-5 text-primary" />
-                    <div className="text-hint text-xs">{getHumanFileSize(file.size)}</div>
+                    {contentType === 'image' ? (
+                        <Image
+                            alt={file.name}
+                            className="size-10 rounded object-cover"
+                            sizes={[{ width: 40 }]}
+                            resize={context.contentContext?.imageResizer}
+                            sources={{
+                                light: {
+                                    src: file.downloadURL,
+                                    size: { width: 40, height: 40 },
+                                },
+                            }}
+                            loading="lazy"
+                        />
+                    ) : (
+                        <FileIcon contentType={contentType} className="size-5 text-primary" />
+                    )}
                 </div>
                 <div className="min-w-24 flex-1">
                     <div className="text-base">
@@ -57,7 +73,9 @@ export async function File(props: BlockProps<DocumentBlockFile>) {
                             {file.name}
                         </Link>
                     </div>
-                    <div className="text-sm opacity-9 dark:opacity-8">{contentType}</div>
+                    <div className="text-sm text-tint-subtle">
+                        {contentType} · {getHumanFileSize(file.size)}
+                    </div>
                 </div>
                 <div className="flex shrink-0 flex-wrap gap-2">
                     <DownloadButton

--- a/packages/gitbook/src/components/DocumentView/File.tsx
+++ b/packages/gitbook/src/components/DocumentView/File.tsx
@@ -1,13 +1,12 @@
-import { type DocumentBlockFile, SiteInsightsLinkPosition } from '@gitbook/api';
-
-import { Image } from '@/components/utils';
 import { t } from '@/intl/translate';
 import { getSimplifiedContentType } from '@/lib/files';
 import { resolveContentRefInDocument } from '@/lib/references';
+import { type DocumentBlockFile, SiteInsightsLinkPosition } from '@gitbook/api';
 
 import { getSpaceLanguage } from '@/intl/server';
 import { Button, Link } from '../primitives';
 import { DownloadButton } from '../primitives/DownloadButton';
+import { Image } from '../utils';
 import type { BlockProps } from './Block';
 import { Caption } from './Caption';
 import { FileIcon } from './FileIcon';
@@ -43,17 +42,17 @@ export async function File(props: BlockProps<DocumentBlockFile>) {
     return (
         <Caption {...props} withBorder>
             <div className="flex flex-wrap items-center gap-5 px-5 py-3">
-                <div className="flex min-w-14 flex-col items-center gap-1 border-tint-subtle border-r pr-5">
+                <div className="flex min-h-8 min-w-14 flex-col items-center justify-center gap-1 border-tint-subtle border-r pr-4">
                     {contentType === 'image' ? (
                         <Image
                             alt={file.name}
-                            className="size-10 rounded object-cover"
+                            className="h-auto max-h-10 w-auto max-w-10 rounded object-contain"
                             sizes={[{ width: 40 }]}
                             resize={context.contentContext?.imageResizer}
                             sources={{
                                 light: {
                                     src: file.downloadURL,
-                                    size: { width: 40, height: 40 },
+                                    size: file.dimensions,
                                 },
                             }}
                             loading="lazy"


### PR DESCRIPTION
Displays image previews, including SVG files, for file attachments in the document view. When an attachment is an image, a thumbnail is shown instead of a generic file icon. File size information is now displayed alongside the content type.

## Changes
- Show 40x40 image thumbnails for image attachments
- Include SVG preview support
- Move file size indicator to the subtitle area alongside content type
- Lazy-load image previews for performance

## Demo
<img width="1464" height="815" alt="image" src="https://github.com/user-attachments/assets/0d3b61fa-dfe4-4044-933a-7cb5f79aada3" />
