### PR TITLE
Fix variant switcher URL for non-default variants

### DIFF
--- a/.changeset/olive-pumas-invite.md
+++ b/.changeset/olive-pumas-invite.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the variant switcher linking to the wrong URL for non-default variants of the default section

--- a/packages/gitbook/src/lib/sites.test.ts
+++ b/packages/gitbook/src/lib/sites.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import type { SiteSpace } from '@gitbook/api';
+import type { SiteSection, SiteSpace, SiteStructure } from '@gitbook/api';
 import { TranslationLanguage } from '@gitbook/api';
 
-import { filterSiteSpacesByLocale } from './sites';
+import type { GitBookSiteContext } from '@/lib/context';
+import { filterSiteSpacesByLocale, getFallbackSiteSpacePath } from './sites';
 
 function makeSiteSpace(language: TranslationLanguage | undefined): SiteSpace {
     return { space: { language } } as unknown as SiteSpace;
@@ -27,5 +28,58 @@ describe('filterSiteSpacesByLocale', () => {
             undefinedLanguage,
             en,
         ]);
+    });
+});
+
+describe('getFallbackSiteSpacePath', () => {
+    function makeVariant(id: string, path: string, isDefault: boolean): SiteSpace {
+        return { id, path, default: isDefault } as unknown as SiteSpace;
+    }
+
+    function makeSection(
+        id: string,
+        path: string,
+        isDefault: boolean,
+        siteSpaces: SiteSpace[]
+    ): SiteSection {
+        return { id, path, default: isDefault, object: 'site-section', siteSpaces } as SiteSection;
+    }
+
+    function makeContext(structure: SiteStructure): GitBookSiteContext {
+        return { structure } as GitBookSiteContext;
+    }
+
+    const defaultVariant = makeVariant('sitesp_en', 'eng-landing-page', true);
+    const translationVariant = makeVariant('sitesp_ua', 'landing-page', false);
+    const otherVariant = makeVariant('sitesp_docs_ua', 'documentation', false);
+
+    const context = makeContext({
+        type: 'sections',
+        structure: [
+            makeSection('sitesc_home', 'main-ua', true, [defaultVariant, translationVariant]),
+            makeSection('sitesc_docs', 'novaposhta-docs', false, [otherVariant]),
+        ],
+    } as SiteStructure);
+
+    it('returns an empty path for the default variant of the default section', () => {
+        expect(getFallbackSiteSpacePath(context, defaultVariant)).toBe('');
+    });
+
+    it('keeps the section path for a non-default variant of the default section', () => {
+        expect(getFallbackSiteSpacePath(context, translationVariant)).toBe('main-ua/landing-page');
+    });
+
+    it('keeps the section path for a non-default section', () => {
+        expect(getFallbackSiteSpacePath(context, otherVariant)).toBe(
+            'novaposhta-docs/documentation'
+        );
+    });
+
+    it('returns the variant path on a site without sections', () => {
+        const withoutSections = makeContext({
+            type: 'siteSpaces',
+            structure: [defaultVariant, translationVariant],
+        } as SiteStructure);
+        expect(getFallbackSiteSpacePath(withoutSections, translationVariant)).toBe('landing-page');
     });
 });

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -204,8 +204,9 @@ export function getFallbackSiteSpacePath(context: GitBookSiteContext, siteSpace:
     // don't include the path for the default site space
     const siteSpacePath = siteSpace.default ? '' : siteSpace.path;
 
-    // for non-default site sections, include the section path.
-    if (found?.siteSection && !found?.siteSection.default) {
+    // The section path is only dropped for the default variant of the default section:
+    // its other variants are still published under the section path.
+    if (found?.siteSection && (!found.siteSection.default || !siteSpace.default)) {
         return joinPath(found.siteSection.path, siteSpacePath);
     }
 


### PR DESCRIPTION
Correct the linking of the variant switcher to ensure it points to the right URL for non-default variants of the default section. This change enhances the functionality of the `getFallbackSiteSpacePath` method to properly handle section paths for different variants.