### PR TITLE
Detect and pass visitor type for site resolution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -360,7 +360,7 @@
     "react-dom": "catalog:",
   },
   "catalog": {
-    "@gitbook/api": "0.192.0",
+    "@gitbook/api": "0.195.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -760,7 +760,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.192.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-S9ceF3XspgSqXb7JH5feSHSytVkq1jRDwOKeEK4nnZs9pSiKFxHZMj/LnHi8k8anaue/FeLwWYo+Vk08Pdl0+g=="],
+    "@gitbook/api": ["@gitbook/api@0.195.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-66OGIiiKUfHB7dF8fb9Ai8PkhQldD4SSQXHZ+X+SSEki2WXpgn6ze+PEXRQvDsJj2JKEvD9A7FfaGzUYiYn9hA=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "catalog": {
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
-            "@gitbook/api": "0.192.0",
+            "@gitbook/api": "0.195.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/lib/visitors.test.ts
+++ b/packages/gitbook/src/lib/visitors.test.ts
@@ -6,6 +6,7 @@ import {
     getVisitorAuthCookieName,
     getVisitorAuthCookieValue,
     getVisitorToken,
+    getVisitorType,
     getVisitorUnsignedClaims,
     normalizeVisitorURL,
 } from './visitors';
@@ -443,5 +444,49 @@ describe('normalizeVisitorURL', () => {
         expect(normalizeVisitorURL(url2).toString()).toBe(
             'https://docs.example.com/?ask=this+is+a+question'
         );
+    });
+});
+
+describe('getVisitorType', () => {
+    const requestWith = (headers: Record<string, string>) => ({ headers: new Headers(headers) });
+
+    it('should classify a known AI agent user-agent as "agent"', () => {
+        expect(
+            getVisitorType(
+                requestWith({
+                    'user-agent':
+                        'Mozilla/5.0 (compatible; GPTBot/1.2; +https://openai.com/gptbot)',
+                })
+            )
+        ).toBe('agent');
+        expect(getVisitorType(requestWith({ 'user-agent': 'ClaudeBot/1.0' }))).toBe('agent');
+    });
+
+    it('should classify a request with a Signature-Agent header as "agent"', () => {
+        expect(
+            getVisitorType(
+                requestWith({
+                    'user-agent': 'SomeClient/1.0',
+                    'signature-agent': '"https://chatgpt.com"',
+                })
+            )
+        ).toBe('agent');
+    });
+
+    it('should classify a normal browser user-agent as "human"', () => {
+        expect(
+            getVisitorType(
+                requestWith({
+                    'user-agent':
+                        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+                    'sec-fetch-mode': 'navigate',
+                })
+            )
+        ).toBe('human');
+    });
+
+    it('should default to "human" when the user-agent is missing or empty', () => {
+        expect(getVisitorType(requestWith({}))).toBe('human');
+        expect(getVisitorType(requestWith({ 'user-agent': '' }))).toBe('human');
     });
 });

--- a/packages/gitbook/src/lib/visitors.ts
+++ b/packages/gitbook/src/lib/visitors.ts
@@ -1,3 +1,5 @@
+import type { SiteVisitorPayload } from '@gitbook/api';
+import { isAIAgent } from '@vercel/agent-readability';
 import { type JwtPayload, jwtDecode } from 'jwt-decode';
 import { type NextRequest, NextResponse } from 'next/server';
 import hash from 'object-hash';
@@ -86,6 +88,16 @@ export type VisitorTokenLookup =
       }
     /** Not visitor token was found */
     | undefined;
+
+/**
+ * Get the type of visitor, i.e human or agent, accessing the published site.
+ */
+export function getVisitorType(request: { headers: Headers }): NonNullable<
+    SiteVisitorPayload['type']
+> {
+    const detection = isAIAgent(request);
+    return detection.detected && detection.method !== 'heuristic' ? 'agent' : 'human';
+}
 
 /**
  * Get the visitor data for the request potentially including:

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -47,6 +47,7 @@ import {
     getPathScopedCookieName,
     getResponseCookiesForVisitorAuth,
     getVisitorData,
+    getVisitorType,
     normalizeVisitorURL,
     serveVisitorClaimsDataRequest,
 } from '@/lib/visitors';
@@ -219,6 +220,7 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
                 visitorPayload: {
                     jwtToken: visitorToken?.token ?? undefined,
                     unsignedClaims,
+                    type: getVisitorType(request),
                 },
                 // When the visitor auth token is pulled from the cookie, set redirectOnError when calling resolvePublishedContentByUrl to allow
                 // redirecting when the token is invalid as we could be dealing with stale token stored in the cookie.


### PR DESCRIPTION
This PR aims to detect and pass the visitor type for site resolution. This is following the changes in https://github.com/GitbookIO/gitbook-x/pull/24296.

It uses the result from `@vercel/agent-readability` `isAIAgent` and sends it as `visitor.type` during the site resolution, so sites can adapt content accordingly if they have conditional content that relies on the visitor type.