### PR TITLE
Reduce `:has()` style-recalculation cost

### DIFF
--- a/packages/gitbook/src/components/AI/useAIChat.tsx
+++ b/packages/gitbook/src/components/AI/useAIChat.tsx
@@ -202,6 +202,13 @@ const globalState = zustand.create<AIChatState>(() => {
     };
 });
 
+// Mirrored onto <html> because CSS (the `chat-open` variant) can't read the store.
+globalState.subscribe((state, prev) => {
+    if (state.opened !== prev.opened) {
+        document.documentElement.dataset.aiChatOpen = String(state.opened);
+    }
+});
+
 /**
  * Get the current state of the AI chat.
  */

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -64,6 +64,13 @@ export function AIChat() {
         []
     );
 
+    // AI chat can be disabled per space, so this view can go away while the store says opened.
+    React.useEffect(() => {
+        return () => {
+            delete document.documentElement.dataset.aiChatOpen;
+        };
+    }, []);
+
     // Track the view of the AI chat
     const trackEvent = useTrackEvent();
     React.useEffect(() => {

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -798,11 +798,12 @@ button.openapi-mcp {
     @apply border-tint-subtle transition-all border-b border-x overflow-auto rounded-corners:last:rounded-b-xl circular-corners:last:rounded-b-2xl straight-corners:last:rounded-b-xs rounded-corners:first:rounded-t-xl circular-corners:first:rounded-t-2xl straight-corners:first:rounded-t-xs first:border-t relative;
 }
 
-.openapi-disclosure-group:has(.openapi-disclosure-group-trigger:hover) {
+.openapi-disclosure-group:has(> .openapi-disclosure-group-trigger:hover) {
     @apply bg-tint-subtle;
 }
 
-.openapi-disclosure-group:has(.openapi-disclosure-group-trigger:hover):has(.openapi-select:hover) {
+/* Selects also live in the panel, so only a header select may clear the highlight. */
+.openapi-disclosure-group:has(> .openapi-disclosure-group-trigger .openapi-select:hover) {
     @apply !bg-transparent;
 }
 

--- a/packages/gitbook/src/components/primitives/SideSheet.tsx
+++ b/packages/gitbook/src/components/primitives/SideSheet.tsx
@@ -143,6 +143,18 @@ export function SideSheet(
         return () => observer.disconnect();
     }, [toggleClass, openState, onOpenChange]);
 
+    React.useEffect(() => {
+        if (!isModal || !isOpen) {
+            return;
+        }
+
+        document.documentElement.setAttribute('data-sheet-open', '');
+
+        return () => {
+            document.documentElement.removeAttribute('data-sheet-open');
+        };
+    }, [isModal, isOpen]);
+
     // Handle Escape key press to close the modal sheet
     React.useEffect(() => {
         if (!isModal || !isOpen) {

--- a/packages/gitbook/tailwind.config.ts
+++ b/packages/gitbook/tailwind.config.ts
@@ -674,11 +674,9 @@ const config: Config = {
              * Variant when the Table of Content navigation is open.
              */
             addVariant('navigation-open', 'body.navigation-open &');
-            addVariant('chat-open', 'body:has(.ai-chat[aria-expanded="true"]) &');
-            addVariant(
-                'sheet-open',
-                'html:has(.side-sheet[aria-modal="true"][aria-expanded="true"]) &, &:has(.side-sheet[aria-modal="true"][aria-expanded="true"])'
-            );
+            addVariant('chat-open', 'html[data-ai-chat-open="true"] &');
+            /* Second selector targets the elements carrying the attribute themselves (<html>). */
+            addVariant('sheet-open', ['html[data-sheet-open] &', '&[data-sheet-open]']);
 
             /**
              * Variant when a header is displayed.


### PR DESCRIPTION
`body:has()` / `html:has()` keep the whole document inside a `:has()` invalidation scope: every element under the subject is flagged, so each DOM mutation pays an ancestor walk plus a test against every argument selector.

### Changes

- `chat-open` and `sheet-open` now read a `data-*` attribute on `<html>` instead of a `:has()` selector. The AI chat store publishes its own state via `subscribe` (there are three places that set `opened`, so writing it at the store rather than in `onOpen`/`onClose` avoids missing one), and `SideSheet` sets the flag while a modal sheet is open.
- The two OpenAPI disclosure hover selectors are bounded to the group header (`:has(> …)`) instead of scoping over the panel, matching the form already used by `.openapi-disclosure` just below.

No utility classes changed in components — only the variant definitions, so all ~194 existing `chat-open:` / `sheet-open:` usages are untouched.

### Measurements

Snyk API reference through the dev proxy (~10.7k elements, 196 disclosure groups), Chrome via CDP `RecalcStyleDuration`, median of 7 trials:

| config | pointer sweep | class mutations | node insertions |
|---|---|---|---|
| main | 14329 ms | 528 ms | 8206 ms |
| OpenAPI selectors only | 14385 ms (+0.4%) | 552 ms (+4.4%) | 8246 ms (+0.5%) |
| `chat-open` only | 14503 ms (+1.2%) | 532 ms (+0.7%) | 8237 ms (+0.4%) |
| **this branch** | **7444 ms (−48.0%)** | **274 ms (−48.1%)** | **4209 ms (−48.7%)** |

Isolating each change shows the gain comes almost entirely from `sheet-open` — most plausibly because its second branch (`&:has(…)`) made `<html>` and `<body>` themselves `:has()` subjects. The OpenAPI bounding measured flat and is kept as an iso-behaviour tidy-up.

Numbers are from a dev server, so absolutes are inflated; the A/B is fair since both sides ran identically. The pointer-sweep figure is bimodal on main (first trials ~7400, then ~14400) and I can't fully explain that, so treat it as softer than the two mutation scenarios, which were within ±1%.

### Notes

- `SideSheet` deliberately does not ref-count. Two modal sheets open at once is a pre-existing bug (`mod+k` opens search regardless of what else is open); if it happens, the first close drops the scroll lock early rather than the state being silently papered over. Worth fixing separately.
- `AIChat` keeps a small unmount cleanup because `customization` resolves per site-space, so `ai.mode` can differ between spaces and the view can unmount while the store still says opened — the previous `:has()` cleared implicitly on unmount.