### PR TITLE
Fix Docs Embed being stuck on the Search tab (RND-12435)

### DIFF
--- a/.changeset/embed-search-tab-navigation.md
+++ b/.changeset/embed-search-tab-navigation.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix switching from the Search tab to the Docs or Assistant tab in the embed doing nothing.

--- a/packages/gitbook/src/components/Search/useSearchController.tsx
+++ b/packages/gitbook/src/components/Search/useSearchController.tsx
@@ -176,7 +176,7 @@ export function useSearchController(
 
     const onClose = React.useCallback(
         async (to?: string) => {
-            setSearchState((prev) => {
+            await setSearchState((prev) => {
                 if (!prev) return null;
 
                 if (prev.query !== null) {


### PR DESCRIPTION
In the Docs Embed, clicking the Docs or Assistant tab from the Search tab did nothing.

Fix: await the state update so the URL write lands before the push.

Tested against `gitbook.com/docs/~gitbook/embed/search`