### PR TITLE
Attribute markdown and ask events to their space

### DIFF
--- a/.changeset/markdown-events-space-attribution.md
+++ b/.changeset/markdown-events-space-attribution.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Attribute the markdown and ask events tracked from the middleware to their space, and record the goal passed alongside a question.

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -753,12 +753,14 @@ function encodePathInSiteContent(
 } {
     let pathname = removeLeadingSlash(removeTrailingSlash(siteURLData.pathname));
 
+    // The optional fields are coerced to null, otherwise they are dropped from the JSON payload
+    // instead of being sent as the `string | null` the API expects.
     const eventLocation: Partial<SiteInsightsEventLocation> = {
-        siteSection: siteURLData.siteSection,
+        siteSection: siteURLData.siteSection ?? null,
         siteSpace: siteURLData.siteSpace,
-        siteShareKey: siteURLData.shareKey,
+        siteShareKey: siteURLData.shareKey ?? null,
         space: siteURLData.space,
-        revision: siteURLData.revision,
+        revision: siteURLData.revision ?? null,
         displayContext: SiteInsightsDisplayContext.Server,
     };
 
@@ -881,24 +883,19 @@ function encodePathInSiteContent(
                               }`
                             : `~gitbook/markdown/${encodePagePath(pagePathWithoutMD)}`,
                     routeType: 'static',
-                    // TODO: track pageId / spaceId when possible
-                    // We don't do it at the moment as we can't easily extract it from the URL.
                     events: ask
                         ? [
                               {
                                   type: 'ask_question',
                                   query: ask,
-                                  location: {
-                                      displayContext: SiteInsightsDisplayContext.Server,
-                                  },
+                                  ...(goal ? { goal } : {}),
+                                  location: eventLocation,
                               },
                           ]
                         : [
                               {
                                   type: 'page_markdown_request',
-                                  location: {
-                                      displayContext: SiteInsightsDisplayContext.Server,
-                                  },
+                                  location: eventLocation,
                               },
                           ],
                 };


### PR DESCRIPTION
`page_markdown_request` and the `ask_question` the middleware emits for `?ask=` carried only a `displayContext`, so they were stored with an empty `spaceId` and an unparseable `siteSpaceId`. Any space- or section-scoped query dropped them, and the markdown traffic of a space read as zero.

They now reuse the `eventLocation` the middleware already builds from the URL resolution — the one `rss_request` has used since #4242 — carrying `space`, `siteSpace`, `siteSection`, `siteShareKey` and `revision`.

The two `llms_request` branches deliberately keep their own location. `llms.txt` and `llms-full.txt` walk every section and site-space of the site, so stamping the single `space` the URL resolved to would attribute a site-wide document to one of them.

`ask_question` also gains the `goal`. It was already parsed off the query string to be encoded into the rewrite target, but never put on the event, so `eventAskGoal` was always empty.

### pageId

The TODO also asked for `pageId`. It is not derivable from the URL — `PublishedSiteContent` has no `page` — and the only path→page endpoints return a full page object. Resolving it in the middleware costs one extra API call per document served, on routes that are otherwise fully cache-served, and it has to complete *before* the tracking call can be sent — which on Vercel puts a network round-trip in front of a `waitUntil` that has no lifecycle-extension primitive today.

It belongs on `resolvePublishedContentByUrl`, which the middleware already calls on every request. Follow-up in gitbook-x.
