### PR TITLE
Skip rendering work for off-screen OpenAPI blocks

### DIFF
--- a/.changeset/openapi-blocks-content-visibility.md
+++ b/.changeset/openapi-blocks-content-visibility.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Skip the rendering work for off-screen OpenAPI blocks, so pages with many operations stay smooth to scroll.

--- a/packages/gitbook/e2e/style-perf.spec.ts
+++ b/packages/gitbook/e2e/style-perf.spec.ts
@@ -111,6 +111,28 @@ function expectWithinBudgets(measurements: Measurement[], total: number) {
     }
 }
 
+const countElements = (page: Page) =>
+    page.evaluate(() => document.getElementsByTagName('*').length);
+
+// Not `networkidle`: third-party subresources on this customer site can hang, so it never settles.
+async function waitForStableElementCount(page: Page): Promise<number> {
+    let previous = await countElements(page);
+
+    await expect
+        .poll(
+            async () => {
+                const current = await countElements(page);
+                const stable = current === previous;
+                previous = current;
+                return stable;
+            },
+            { message: 'the tree never stopped changing', timeout: 15_000 }
+        )
+        .toBe(true);
+
+    return previous;
+}
+
 async function openLargePage(page: Page) {
     await page.goto(getContentTestURL(LARGE_PAGE_URL));
     await waitForCookiesDialog(page);
@@ -118,10 +140,9 @@ async function openLargePage(page: Page) {
     // Measure a settled page: before hydration the tree is smaller and no popup can open at all.
     await page.locator('html.hydrated').waitFor();
     await expect(page.getByLabel('OpenAPI Select').first()).toBeAttached();
-    await page.waitForLoadState('networkidle');
 
+    const totalElements = await waitForStableElementCount(page);
     const client = await page.context().newCDPSession(page);
-    const totalElements = await page.evaluate(() => document.getElementsByTagName('*').length);
 
     return { client, totalElements };
 }
@@ -136,6 +157,20 @@ async function expectIdle(page: Page, client: CDPSession) {
     expect(restyled, 'an idle page should barely restyle').toBeLessThan(IDLE_RESTYLE_TOLERANCE);
 }
 
+// Both checks below probe a block's children, never the block itself: `content-visibility: auto`
+// skips an element's *contents*, so the element carrying it keeps reporting visible and every block
+// would look rendered. Same reason `toBeVisible()` is no use here — a skipped child still has a box.
+function countRenderedBlocks(page: Page): Promise<number> {
+    return page.evaluate(
+        () =>
+            [...document.querySelectorAll('.openapi-block')].filter((block) =>
+                [...block.children].some((child) =>
+                    child.checkVisibility({ contentVisibilityAuto: true })
+                )
+            ).length
+    );
+}
+
 test('off-screen OpenAPI blocks skip their rendering work', async ({ page }) => {
     await openLargePage(page);
 
@@ -144,12 +179,7 @@ test('off-screen OpenAPI blocks skip their rendering work', async ({ page }) => 
     expect(total, 'the fixture needs enough blocks for some to sit off-screen').toBeGreaterThan(4);
 
     await page.evaluate(() => window.scrollTo(0, 0));
-    const rendered = await page.evaluate(
-        () =>
-            [...document.querySelectorAll('.openapi-block')].filter((element) =>
-                element.checkVisibility({ contentVisibilityAuto: true })
-            ).length
-    );
+    const rendered = await countRenderedBlocks(page);
     expect(
         rendered,
         `${rendered} of ${total} blocks rendered from the top of the page`
@@ -158,7 +188,17 @@ test('off-screen OpenAPI blocks skip their rendering work', async ({ page }) => 
     // Un-skipping on approach is what keeps #anchors and find-in-page working.
     const last = blocks.last();
     await last.scrollIntoViewIfNeeded();
-    await expect(last).toBeVisible();
+    await expect
+        .poll(
+            () =>
+                last.evaluate((block) =>
+                    [...block.children].some((child) =>
+                        child.checkVisibility({ contentVisibilityAuto: true })
+                    )
+                ),
+            { message: 'the last block never rendered after being scrolled to' }
+        )
+        .toBe(true);
 });
 
 test('opening a popup restyles a bounded part of a large API reference', async ({ page }) => {

--- a/packages/gitbook/e2e/style-perf.spec.ts
+++ b/packages/gitbook/e2e/style-perf.spec.ts
@@ -136,6 +136,31 @@ async function expectIdle(page: Page, client: CDPSession) {
     expect(restyled, 'an idle page should barely restyle').toBeLessThan(IDLE_RESTYLE_TOLERANCE);
 }
 
+test('off-screen OpenAPI blocks skip their rendering work', async ({ page }) => {
+    await openLargePage(page);
+
+    const blocks = page.locator('.openapi-block');
+    const total = await blocks.count();
+    expect(total, 'the fixture needs enough blocks for some to sit off-screen').toBeGreaterThan(4);
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+    const rendered = await page.evaluate(
+        () =>
+            [...document.querySelectorAll('.openapi-block')].filter((element) =>
+                element.checkVisibility({ contentVisibilityAuto: true })
+            ).length
+    );
+    expect(
+        rendered,
+        `${rendered} of ${total} blocks rendered from the top of the page`
+    ).toBeLessThan(total / 2);
+
+    // Un-skipping on approach is what keeps #anchors and find-in-page working.
+    const last = blocks.last();
+    await last.scrollIntoViewIfNeeded();
+    await expect(last).toBeVisible();
+});
+
 test('opening a popup restyles a bounded part of a large API reference', async ({ page }) => {
     const { client, totalElements } = await openLargePage(page);
     await expectIdle(page, client);

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -13,6 +13,28 @@
     @apply gap-0;
 }
 
+/* A reference page can hold a hundred of these, each with its own sticky preview pane; skipping the
+   render work for the off-screen ones is what keeps such a page scrollable. The DOM is untouched,
+   so the server HTML, find-in-page and #anchors all still work. */
+.openapi-block {
+    content-visibility: auto;
+    /* Only the block axis: the inline size comes from the flex parent. Plain length first, as a
+       fallback for engines without the `auto` keyword, where a skipped block would collapse to 0. */
+    contain-intrinsic-height: 1200px;
+    contain-intrinsic-height: auto 1200px;
+}
+
+/* PDF export lays the whole space out off-screen, so nothing there may be skipped. */
+body:has(.print-mode) .openapi-block {
+    content-visibility: visible;
+}
+
+@media print {
+    .openapi-block {
+        content-visibility: visible;
+    }
+}
+
 .openapi-schemas-title {
     @apply tabular-nums text-[0.813rem] leading-4 font-mono shrink-0 font-medium text-tint-strong;
 }

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -17,20 +17,25 @@
    render work for the off-screen ones is what keeps such a page scrollable. The DOM is untouched,
    so the server HTML, find-in-page and #anchors all still work. */
 .openapi-block {
+    /* Below Safari 18 / Firefox 125 this is ignored and every block renders, as it does today. */
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
     content-visibility: auto;
     /* Only the block axis: the inline size comes from the flex parent. Plain length first, as a
-       fallback for engines without the `auto` keyword, where a skipped block would collapse to 0. */
+       fallback for engines without the `auto` keyword, where a skipped block would collapse to 0.
+       The length is a rough guess — `auto` swaps in the real size once a block has rendered. */
     contain-intrinsic-height: 1200px;
     contain-intrinsic-height: auto 1200px;
 }
 
 /* PDF export lays the whole space out off-screen, so nothing there may be skipped. */
 body:has(.print-mode) .openapi-block {
+    /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
     content-visibility: visible;
 }
 
 @media print {
     .openapi-block {
+        /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
         content-visibility: visible;
     }
 }


### PR DESCRIPTION
A customer page with 95 OpenAPI blocks — `oeconnection.gitbook.io/partstech-partner-api/api-reference/v3` — is effectively unscrollable. Measured from its shipped HTML: 95 operation blocks, ~45,700 DOM elements, 6.4 MB of markup (8.2 MB with the RSC payload), and 95 `position: sticky` preview panes. Every operation is styled, laid out and painted on every frame, whether or not it is anywhere near the viewport. This is not specific to computed pages — it happens on any hand-authored page that drops many `openapi-*` blocks into a document, which is what this customer did.

`content-visibility: auto` on `.openapi-block` lets the browser skip that work for blocks that are off screen. The DOM is untouched, so the server HTML, find-in-page, `#anchors` and the outline all keep working — which is why this is CSS rather than unmounting nodes: SEO is the whole point of these pages.

`contain-intrinsic-height: auto 1200px` gives a skipped block its placeholder height. The `auto` keyword makes the browser remember each block's real height once rendered, so the estimate only ever applies to blocks never scrolled to; the plain-length declaration before it is a fallback for engines without `auto` sizing, where a skipped block would collapse to 0. **1200px is a reasoned guess, not a measurement** — worth tuning on the preview with:

```js
const h = [...document.querySelectorAll('.openapi-block')]
    .map((e) => e.getBoundingClientRect().height).sort((a, b) => a - b);
h[Math.floor(h.length / 2)];
```

PDF export lays the whole space out off screen, so `body:has(.print-mode)` and `@media print` opt out.

**Not covered by this PR:** hydration cost is unchanged — every block is a client component rendered with `next/dynamic({ ssr: true })`, so React still builds ~45k fibers on load. If scrolling is still rough on the preview, deferring hydration of off-screen blocks is the next lever. Payload size is also unchanged.
