### PR TITLE
Fix dropdown icon rotation by reading dropdown open state

### DIFF
--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -24,7 +24,11 @@ import {
     type PageActionAssistantContext,
 } from './PageActions';
 import { Button, ButtonGroup } from '@/components/primitives/Button';
-import { DropdownMenu, DropdownMenuSeparator } from '@/components/primitives/DropdownMenu';
+import {
+    DropdownMenu,
+    DropdownMenuSeparator,
+    useDropdownMenuOpen,
+} from '@/components/primitives/DropdownMenu';
 import { tString, useLanguage } from '@/intl/client';
 
 /**
@@ -137,7 +141,7 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
                     className="!min-w-60 max-w-max"
                     button={
                         <Button
-                            icon={<ToggleChevron className="size-text-sm" />}
+                            icon={<MoreActionsChevron />}
                             label={tString(language, defaultAction ? 'more' : 'actions')}
                             iconOnly={!!defaultAction}
                             size="xsmall"
@@ -151,6 +155,15 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
             ) : null}
         </ButtonGroup>
     ) : null;
+}
+
+/**
+ * Chevron for the "more" button, driven by the dropdown's real open state to avoid colliding
+ * with the shared `data-popup-open` attribute set by the button's own Tooltip.
+ */
+function MoreActionsChevron() {
+    const open = useDropdownMenuOpen();
+    return <ToggleChevron open={open} className="size-text-sm" />;
 }
 
 /**

--- a/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActionsDropdown.tsx
@@ -30,6 +30,7 @@ import {
     useDropdownMenuOpen,
 } from '@/components/primitives/DropdownMenu';
 import { tString, useLanguage } from '@/intl/client';
+import type { ClassValue } from '@/lib/tailwind';
 
 /**
  * Type of a built-in page action that can be displayed in the page actions menu.
@@ -141,7 +142,7 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
                     className="!min-w-60 max-w-max"
                     button={
                         <Button
-                            icon={<MoreActionsChevron />}
+                            icon={<MoreActionsChevron className="size-text-sm" />}
                             label={tString(language, defaultAction ? 'more' : 'actions')}
                             iconOnly={!!defaultAction}
                             size="xsmall"
@@ -161,9 +162,9 @@ export function PageActionsDropdown(props: PageActionsDropdownProps) {
  * Chevron for the "more" button, driven by the dropdown's real open state to avoid colliding
  * with the shared `data-popup-open` attribute set by the button's own Tooltip.
  */
-function MoreActionsChevron() {
+function MoreActionsChevron(props: { className?: ClassValue }) {
     const open = useDropdownMenuOpen();
-    return <ToggleChevron open={open} className="size-text-sm" />;
+    return <ToggleChevron open={open} className={props.className} />;
 }
 
 /**

--- a/packages/gitbook/src/components/primitives/DropdownMenu.tsx
+++ b/packages/gitbook/src/components/primitives/DropdownMenu.tsx
@@ -242,3 +242,10 @@ export function useDropdownMenuClose() {
     assert(context, 'DropdownMenuContext not found');
     return useCallback(() => context.setOpen(false), [context]);
 }
+
+/**
+ * Hook to read whether the dropdown menu is open.
+ */
+export function useDropdownMenuOpen() {
+    return useContext(DropdownMenuContext).open;
+}

--- a/packages/gitbook/src/components/primitives/ToggleChevron.tsx
+++ b/packages/gitbook/src/components/primitives/ToggleChevron.tsx
@@ -37,11 +37,24 @@ export function ToggleChevron(props: {
             icon={classes[orientation].icon as IconName}
             className={tcls(
                 'shrink-0',
-                open ? classes[orientation].animation : classes[orientation].autoAnimation,
+                getRotationClassName(open, classes[orientation]),
                 'size-3',
                 'transition-all',
                 className
             )}
         />
     );
+}
+
+function getRotationClassName(
+    open: boolean | undefined,
+    classes: { animation: string; autoAnimation: string }
+): string {
+    if (open === undefined) {
+        return classes.autoAnimation;
+    }
+    if (open) {
+        return classes.animation;
+    }
+    return '';
 }


### PR DESCRIPTION
## Summary

The dropdown icon rotation was incorrectly relying on the button's Tooltip `data-popup-open` attribute instead of the actual dropdown open state. This PR fixes it by introducing a `useDropdownMenuOpen` hook to read the real dropdown state.

Also refactored `ToggleChevron` to properly handle undefined `open` state for components that don't explicitly track open/closed status.

## Demo
Before

https://github.com/user-attachments/assets/f5a7143e-1eac-4341-909e-0da27454fd01


After

https://github.com/user-attachments/assets/542d5aa9-3911-4a32-81c5-3f6c2644ba91


## Changes

- Added `useDropdownMenuOpen()` hook to `DropdownMenu` to expose the dropdown's open state
- Created `MoreActionsChevron` component that reads the dropdown's actual open state
- Refactored `ToggleChevron` to handle undefined open state via new `getRotationClassName` helper