### PR TITLE
Stabilize visual CI tests

### DIFF
--- a/packages/gitbook/e2e/customers.spec.ts
+++ b/packages/gitbook/e2e/customers.spec.ts
@@ -360,7 +360,9 @@ const testCases: TestsCase[] = [
     {
         name: 'docs.verifone.com',
         contentBaseURL: 'https://docs.verifone.com',
-        tests: [{ name: 'Home', url: '/', run: waitForCookiesDialog }],
+        // Verifone's custom Cookiebot integration races with and suppresses GitBook's built-in
+        // banner, so waitForCookiesDialog is not a stable invariant here.
+        tests: [{ name: 'Home', url: '/' }],
     },
     // Deactivate it because of a custom Ask AI that causes flakiness.
     // {

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -2413,7 +2413,7 @@ const testCases: TestsCase[] = [
                         actions.nth(1).click(),
                     ]);
                     // Verify the new page would have opened with the expected URL
-                    expect(newPage.url()).toContain('gitbook.com');
+                    await expect(newPage).toHaveURL(/gitbook\.com/);
                     // Close it immediately to avoid navigation
                     await newPage.close();
 
@@ -2561,7 +2561,7 @@ const testCases: TestsCase[] = [
                         openInNewTabButton.click(),
                     ]);
                     // Verify the new page would have opened with the expected URL
-                    expect(newPage.url()).toContain('gitbook.gitbook.io');
+                    await expect(newPage).toHaveURL(/gitbook\.gitbook\.io/);
                     // Close it immediately to avoid navigation
                     await newPage.close();
                 },


### PR DESCRIPTION
## Summary
Fix race conditions and flaky assertions in e2e tests. Removed the cookies dialog check from Verifone tests since their Cookiebot integration races with GitBook's banner. Replaced synchronous `url().toContain()` assertions with async Playwright `toHaveURL()` for more reliable window URL verification.

## Changes
- Remove unstable waitForCookiesDialog from Verifone tests
- Replace sync `expect().toContain()` with async `expect().toHaveURL()` for better test reliability