### PR TITLE
Fix the spacebar being swallowed in the search bar (RND-12484)

### DIFF
--- a/.changeset/search-input-spacebar.md
+++ b/.changeset/search-input-spacebar.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the spacebar being ignored in the search bar, which made multi-word queries impossible.

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -137,6 +137,23 @@ const searchTestCases: Test[] = [
         },
     },
     {
+        // `fill()` bypasses key events, so it can't catch a swallowed key. RND-12484.
+        name: 'Search - AI Mode: None - Typing multi-word queries',
+        url: getCustomizationURL({
+            ai: {
+                mode: CustomizationAIMode.None,
+            },
+        }),
+        screenshot: false,
+        run: async (page) => {
+            await waitForCookiesDialog(page);
+            const searchInput = page.getByTestId('search-input');
+            await searchInput.focus();
+            await searchInput.pressSequentially('getting started');
+            await expect(searchInput).toHaveValue('getting started');
+        },
+    },
+    {
         name: 'Search - AI Mode: None - URL query (Initial)',
         url: `${getCustomizationURL({
             ai: {

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -203,50 +203,7 @@ export function SearchContainer({
                     aria-controls={resultsId}
                 />
             ) : (
-                <Popover
-                    content={searchFrame}
-                    nativeButton={false}
-                    rootProps={{
-                        open: isSearchOpen,
-                        onOpenChange: (nextOpen, eventDetails) => {
-                            if (nextOpen) {
-                                open();
-                                return;
-                            }
-                            // Don't close if clicking on the search input itself
-                            if (
-                                eventDetails.reason === 'outside-press' &&
-                                searchInputRef.current?.contains(eventDetails.event.target as Node)
-                            ) {
-                                eventDetails.cancel();
-                                return;
-                            }
-                            close();
-                        },
-                    }}
-                    positionerProps={{
-                        align: 'start',
-                        sideOffset: 8,
-                        collisionPadding: {
-                            top: 16,
-                            right: 16,
-                            bottom: 32,
-                            left: 16,
-                        },
-                    }}
-                    popupProps={{
-                        initialFocus: false,
-                        // The input is its own trigger: restoring focus to it would re-fire
-                        // `onFocus` and reopen the popover.
-                        finalFocus: false,
-                        className: tcls(
-                            '@container flex flex-col overflow-hidden bg-tint-base has-[.empty]:hidden w-128 p-0 max-w-[min(var(--available-width),32rem)]',
-                            shouldFillHeight
-                                ? 'h-[min(32rem,var(--available-height))]'
-                                : 'max-h-[min(32rem,var(--available-height))]'
-                        ),
-                    }}
-                >
+                <>
                     <SearchInput
                         ref={searchInputRef}
                         aria-activedescendant={searchResultsActiveDescendant}
@@ -267,7 +224,56 @@ export function SearchContainer({
                             showing={Boolean(searchValue) && !fetching}
                         />
                     </SearchInput>
-                </Popover>
+                    {/* Anchored rather than triggered by the input: a trigger would give it button
+                        semantics and swallow the space bar. Opening is driven by `onFocus`. */}
+                    <Popover
+                        content={searchFrame}
+                        anchor={searchInputRef}
+                        rootProps={{
+                            open: isSearchOpen,
+                            onOpenChange: (nextOpen, eventDetails) => {
+                                if (nextOpen) {
+                                    open();
+                                    return;
+                                }
+                                // Without a trigger, the input counts as outside the popover, so
+                                // this is what keeps a click on it from closing the results.
+                                if (
+                                    eventDetails.reason === 'outside-press' &&
+                                    searchInputRef.current?.contains(
+                                        eventDetails.event.target as Node
+                                    )
+                                ) {
+                                    eventDetails.cancel();
+                                    return;
+                                }
+                                close();
+                            },
+                        }}
+                        positionerProps={{
+                            align: 'start',
+                            sideOffset: 8,
+                            collisionPadding: {
+                                top: 16,
+                                right: 16,
+                                bottom: 32,
+                                left: 16,
+                            },
+                        }}
+                        popupProps={{
+                            initialFocus: false,
+                            // Restoring focus to the input would re-fire `onFocus` and reopen the
+                            // popover.
+                            finalFocus: false,
+                            className: tcls(
+                                '@container flex flex-col overflow-hidden bg-tint-base has-[.empty]:hidden w-128 p-0 max-w-[min(var(--available-width),32rem)]',
+                                shouldFillHeight
+                                    ? 'h-[min(32rem,var(--available-height))]'
+                                    : 'max-h-[min(32rem,var(--available-height))]'
+                            ),
+                        }}
+                    />
+                </>
             )}
             {usesSideSheet ? (
                 <SideSheet

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -224,8 +224,8 @@ export function SearchContainer({
                             showing={Boolean(searchValue) && !fetching}
                         />
                     </SearchInput>
-                    {/* Anchored rather than triggered by the input: a trigger would give it button
-                        semantics and swallow the space bar. Opening is driven by `onFocus`. */}
+                    {/* Anchored, not triggered: a trigger gives the input button semantics and
+                        swallows the space bar. */}
                     <Popover
                         content={searchFrame}
                         anchor={searchInputRef}
@@ -236,8 +236,7 @@ export function SearchContainer({
                                     open();
                                     return;
                                 }
-                                // Without a trigger, the input counts as outside the popover, so
-                                // this is what keeps a click on it from closing the results.
+                                // Without a trigger, the input counts as outside the popover.
                                 if (
                                     eventDetails.reason === 'outside-press' &&
                                     searchInputRef.current?.contains(
@@ -262,8 +261,7 @@ export function SearchContainer({
                         }}
                         popupProps={{
                             initialFocus: false,
-                            // Restoring focus to the input would re-fire `onFocus` and reopen the
-                            // popover.
+                            // Restoring focus to the input would re-fire `onFocus` and reopen it.
                             finalFocus: false,
                             className: tcls(
                                 '@container flex flex-col overflow-hidden bg-tint-base has-[.empty]:hidden w-128 p-0 max-w-[min(var(--available-width),32rem)]',

--- a/packages/gitbook/src/components/primitives/Popover.tsx
+++ b/packages/gitbook/src/components/primitives/Popover.tsx
@@ -3,23 +3,30 @@ import { Popover as BasePopover } from '@base-ui/react/popover';
 import { tcls } from '@/lib/tailwind';
 
 export function Popover(props: {
-    children: React.ReactElement<Record<string, unknown>>;
+    // A trigger gets button semantics (role, keyboard activation), which are wrong for elements
+    // such as a text input: omit it, drive `rootProps.open` yourself and pass `anchor` instead.
+    children?: React.ReactElement<Record<string, unknown>>;
+    anchor?: BasePopover.Positioner.Props['anchor'];
     content?: string | React.ReactNode;
     rootProps?: Omit<BasePopover.Root.Props, 'children'>;
     nativeButton?: boolean;
-    positionerProps?: Omit<BasePopover.Positioner.Props, 'children' | 'className'> & {
+    positionerProps?: Omit<BasePopover.Positioner.Props, 'children' | 'className' | 'anchor'> & {
         className?: string;
     };
     popupProps?: Omit<BasePopover.Popup.Props, 'children' | 'className'> & { className?: string };
 }) {
-    const { children, content, rootProps, nativeButton, positionerProps, popupProps } = props;
+    const { children, anchor, content, rootProps, nativeButton, positionerProps, popupProps } =
+        props;
 
     return (
         <BasePopover.Root {...rootProps}>
-            <BasePopover.Trigger render={children} nativeButton={nativeButton} />
+            {children ? (
+                <BasePopover.Trigger render={children} nativeButton={nativeButton} />
+            ) : null}
             <BasePopover.Portal>
                 <BasePopover.Positioner
                     {...positionerProps}
+                    anchor={anchor}
                     className={tcls('z-50 data-anchor-hidden:hidden', positionerProps?.className)}
                     collisionPadding={positionerProps?.collisionPadding ?? 16}
                     sideOffset={positionerProps?.sideOffset ?? 4}

--- a/packages/gitbook/src/components/primitives/Popover.tsx
+++ b/packages/gitbook/src/components/primitives/Popover.tsx
@@ -3,26 +3,18 @@ import { Popover as BasePopover } from '@base-ui/react/popover';
 import { tcls } from '@/lib/tailwind';
 
 export function Popover(props: {
-    // A trigger gets button semantics (role, keyboard activation), which are wrong for elements
-    // such as a text input: omit it, drive `rootProps.open` yourself and pass `anchor` instead.
-    children?: React.ReactElement<Record<string, unknown>>;
-    anchor?: BasePopover.Positioner.Props['anchor'];
+    anchor: BasePopover.Positioner.Props['anchor'];
     content?: string | React.ReactNode;
     rootProps?: Omit<BasePopover.Root.Props, 'children'>;
-    nativeButton?: boolean;
     positionerProps?: Omit<BasePopover.Positioner.Props, 'children' | 'className' | 'anchor'> & {
         className?: string;
     };
     popupProps?: Omit<BasePopover.Popup.Props, 'children' | 'className'> & { className?: string };
 }) {
-    const { children, anchor, content, rootProps, nativeButton, positionerProps, popupProps } =
-        props;
+    const { anchor, content, rootProps, positionerProps, popupProps } = props;
 
     return (
         <BasePopover.Root {...rootProps}>
-            {children ? (
-                <BasePopover.Trigger render={children} nativeButton={nativeButton} />
-            ) : null}
             <BasePopover.Portal>
                 <BasePopover.Positioner
                     {...positionerProps}


### PR DESCRIPTION
The search bar has ignored the spacebar on every published site since #4499, making multi-word queries impossible — six customer reports on RND-12484. The Assistant input is unaffected.

### Cause

#4499 wrapped the search input in the `Popover` primitive with `nativeButton={false}`, which renders it as `<BasePopover.Trigger render={children}>`. `SearchInput` spreads the injected trigger props straight onto its `<input>`, so Base UI's `useButton` treated the text field as a non-native button — merging `role="button"` and calling `event.preventDefault()` on Space (`internals/use-button/useButton.mjs`).

Reproduced on the live site before changing anything: the space `keydown` reaches `document` with `defaultPrevented: true`, with a stack into `useButton`. The deployed input carries `role="button" tabindex="0" aria-haspopup="dialog" data-base-ui-click-trigger`.

Enter survived only by accident — `onInputKeyDown` calls `preventDefault()` first, so Base UI bails out at its earlier `if (event.defaultPrevented) return`. Radix injected `aria-haspopup="dialog"` on the same element but no button keyboard handling, so this is specific to the Base UI trigger.

### Fix

Stop making the input a trigger. The popover is already fully controlled (`open: isSearchOpen`, opened from `onFocus` and the ⌘K hotkey), so the trigger contributed nothing but button semantics. `SearchInput` and `Popover` are now siblings, with `anchor={searchInputRef}` on the positioner — Base UI's supported way to position a popup against an arbitrary element. `Popover`'s `children` becomes optional and it gains an `anchor` prop; `SearchContainer` is the primitive's only consumer.

Side effect, and an improvement: `role="button"`, `aria-haspopup="dialog"` and `tabindex="0"` disappear from the input, so `SearchInput`'s own `aria-haspopup="listbox"` and `aria-expanded` take effect again.

### One thing to know

The `outside-press` guard in `onOpenChange` is now load-bearing rather than defensive. Without a trigger element, Base UI no longer knows a click on the input is "inside", so that check is the only thing stopping a click on the input from closing the results. It's commented in place.

### Verified

Against `bun dev` in a real browser: multi-word typing works and the space is no longer prevented; popup geometry byte-identical to production (`left 368, top 59, width 512`); re-clicking the input keeps results open; Esc closes; ⌘K opens and focuses; outside click closes; `?q=` bootstrap and ArrowDown navigation intact; mobile side sheet unaffected; no console warnings.

The new e2e case types with `pressSequentially`. The existing search tests use `fill()`, which sets the value without dispatching key events — that's why this shipped undetected. Marked `screenshot: false` since it's behavioural, not visual.
