### PR TITLE
Fix large OpenAPI payload section not being scrollable (RND-12291)

### DIFF
--- a/.changeset/openapi-webhook-payload-scroll.md
+++ b/.changeset/openapi-webhook-payload-scroll.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix OpenAPI webhook payload and schema example panels being clipped instead of scrollable.

--- a/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
+++ b/packages/gitbook/src/components/DocumentView/OpenAPI/style.css
@@ -585,12 +585,18 @@ button.openapi-mcp {
     @apply bg-transparent!
 }
 
+.openapi-panel {
+    @apply flex flex-col;
+}
+
 .openapi-panel-heading {
-    @apply font-medium px-4 py-2 text-xs uppercase;
+    @apply font-medium px-4 py-2 text-xs uppercase shrink-0;
 }
 
 .openapi-panel-body {
-    @apply relative;
+    /* Mirrors .openapi-section-body: the sticky preview column caps the height, so the body must be
+       able to shrink for the code block's own overflow-auto to kick in instead of being clipped. */
+    @apply relative flex flex-col shrink min-h-0 overflow-clip [overflow-clip-margin:0.75rem];
 }
 
 .openapi-panel-footer,


### PR DESCRIPTION
Long payloads in the OpenAPI **webhook** panel were clipped with no way to scroll — the rest of the JSON was simply unreachable. Reported on [docs.360dialog.com/partner/partner-api/api-reference/webhooks](https://docs.360dialog.com/partner/partner-api/api-reference/webhooks).

### Root cause

The webhook payload sits in the same sticky, height-capped preview column as an operation's response example, but it uses a hand-rolled `.openapi-panel` wrapper instead of `StaticSection`. That wrapper broke the flex + `min-height: 0` chain the height cap needs to propagate down to the code block:

- `.openapi-panel` was `display: block` (children never height-constrained)
- `.openapi-panel-body` was only `relative` — no flex, no `min-h-0`

So the `<pre>` grew to its full natural height and `.openapi-panel`'s `overflow: hidden` just clipped it, leaving nothing to scroll. Operations are unaffected because `StaticSection` renders `.openapi-section` / `.openapi-section-body`, which are already `flex flex-col min-h-0 overflow-clip`.

### Fix

CSS only — align `.openapi-panel` with what `.openapi-section` already does. The same wrapper is used by the single-schema view (`OpenAPISchemas`), so that case is fixed too.

### Measured

On the reported page at 1440×900, before → after:

| | before | after |
|---|---|---|
| clipped panels (46 total) | 21 | **0** |
| "Channel Created" `pre` (client / scroll) | 1060 / 1060 — clipped | 713 / 1060 — **scrolls** |
| short payloads | 200 / 200 | unchanged |

Operation pages measure identically to production (no regression), and below `lg` the payload keeps its existing `max-h-96` scroll.
