### PR TITLE
Fix embed search suggested questions not opening the assistant

### DIFF
--- a/.changeset/embed-search-suggestions.md
+++ b/.changeset/embed-search-suggestions.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix suggested question clicks in the embed search not opening the assistant.

--- a/packages/gitbook/src/components/Search/useSearch.tsx
+++ b/packages/gitbook/src/components/Search/useSearch.tsx
@@ -163,16 +163,16 @@ export function useSearchLink(): (
             return {
                 href: `?${searchParams.toString()}`,
                 prefetch: false,
-                onClick: (event) => {
+                onClick: async (event) => {
                     event.preventDefault();
-                    callback?.();
-                    setSearchState((prev) => ({
+                    await setSearchState((prev) => ({
                         ...prev,
                         query: params.query !== undefined ? params.query : null,
                         ask: params.ask !== undefined ? params.ask : null,
                         scope: params.scope !== undefined ? params.scope : 'default',
                         open: params.open !== undefined ? params.open : false,
                     }));
+                    callback?.();
                 },
             };
         },

--- a/packages/gitbook/src/components/Search/useSearchController.tsx
+++ b/packages/gitbook/src/components/Search/useSearchController.tsx
@@ -271,7 +271,7 @@ export function useSearchController(
     }, [abort, siteSpace.id]);
 
     const askInAssistant = React.useCallback(
-        (assistantIndex = 0) => {
+        async (assistantIndex = 0) => {
             const assistant = assistants[assistantIndex];
             if (!assistant || !normalizedQuery) {
                 return;
@@ -282,13 +282,13 @@ export function useSearchController(
             }
 
             abort();
-            assistant.open(normalizedQuery);
-            setSearchState({
+            await setSearchState({
                 ask: normalizedQuery,
                 query: null,
                 scope: state?.scope ?? 'default',
                 open: assistant.mode === 'search',
             });
+            assistant.open(normalizedQuery);
         },
         [abort, assistants, normalizedQuery, setSearchState, siteSpace.id, state?.scope]
     );


### PR DESCRIPTION
Clicking a suggested question on the embed's search tab posted the message but never switched to the assistant: the click's `?ask=` URL write flushes after the assistant navigation and clobbers it - same pre-existing race as RND-12435. The click now awaits the URL write before opening the assistant.