### PR TITLE
Show the light/dark toggle on laptop-width screens

### DIFF
--- a/.changeset/dark-mode-toggle-laptop.md
+++ b/.changeset/dark-mode-toggle-laptop.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Show the theme toggle in the footer whenever the outline column that hosts the other toggle isn't pinned open, so it stays reachable on laptop-sized screens in wide layouts and while the AI chat is open.

--- a/packages/gitbook/src/components/Footer/Footer.tsx
+++ b/packages/gitbook/src/components/Footer/Footer.tsx
@@ -30,8 +30,11 @@ export function Footer(props: { context: GitBookSiteContext }) {
             data-gb-site-footer
             className={tcls(
                 'border-tint-subtle border-t',
-                // If the footer only contains a mode toggle, we only show it on smaller screens
-                mobileOnly ? 'xl:hidden' : null
+                // If the footer only contains a mode toggle, we only show it where the outline
+                // column — which carries its own toggle — isn't pinned open.
+                mobileOnly
+                    ? 'layout-default:xl:chat-closed:hidden layout-default:3xl:hidden layout-wide:3xl:chat-closed:hidden page-api-block:page-has-outline:min-[96rem]:hidden'
+                    : null
             )}
         >
             <div className="lg:chat-open:pr-(--ai-chat-width) transition-[padding] duration-300 motion-reduce:transition-none">
@@ -96,7 +99,9 @@ export function Footer(props: { context: GitBookSiteContext }) {
                         {
                             // Theme Toggle
                             customization.themes.toggeable ? (
-                                <div className="-col-start-2 row-start-1 flex items-start @xs:justify-end xl:hidden">
+                                // Hidden where the outline column is pinned open (see PageAside),
+                                // since that column carries its own toggle.
+                                <div className="page-api-block:page-has-outline:min-[96rem]:hidden -col-start-2 row-start-1 flex items-start @xs:justify-end layout-default:xl:chat-closed:hidden layout-default:3xl:hidden layout-wide:3xl:chat-closed:hidden">
                                     <React.Suspense fallback={null}>
                                         <ThemeToggler />
                                     </React.Suspense>


### PR DESCRIPTION
## Overview

- Keeps the light/dark toggle reachable on laptop-width screens: the footer toggle was hidden from `xl` (1280px) up, on the assumption that the page outline column — which hosts the only other toggle — is always pinned open at that width.
- That assumption only holds for `layout-default` with the AI chat closed. The outline actually pins at 1280px (default layout, chat closed), 1920px (wide layout, or default layout with the chat open) and 1536px (API pages with an outline), so **between 1280px and 1919px no toggle rendered at all** in wide layouts or with the chat open.
- On pages without headings the "On this page" button is hidden too (`page-no-outline:hidden`), so on those pages there was no way to reach the toggle at all — which is what the reporter hit on the portal home page. Zooming to 90% on a 1728px screen yields a 1920px viewport, which is why that "fixed" it.
- The footer toggle now hides only where the outline column is actually pinned open, mirroring the conditions in `PageAside`. Below those widths it shows, as it always did; above them there's still exactly one toggle, never two.

Verified against `cortex-docs.paloaltonetworks.com` at 1024/1280/1440/1920px, in both layouts and with the AI chat open and closed — exactly one toggle is visible at every width, where previously there were none in the 1280–1919px band.

Fixes RND-12434.

## Demo

Portal home page (wide layout) at 1440px — before, no toggle anywhere in the footer:

[![before](https://files.argos-ci.com/media/20307/0c304835ab863949e4f29936cfe6d364caab27817c33e2fa2d555558a8e48f9f.webp)](https://app.argos-ci.com/m/2g2b4bh1st2bdlx2ri97)

After, toggle back in the footer:

[![after](https://files.argos-ci.com/media/20307/7e4e9f0284d5571f482062a8eb5de48e5554cb15dbaa8cf897e0edd813b5ec3c.webp)](https://app.argos-ci.com/m/a4nckz7arf4tvntfqrla)

*— Authored by Claude*
