### PR TITLE
Make keyboard shortcuts work on non-QWERTY layouts

### DIFF
--- a/.changeset/hotkeys-usekey.md
+++ b/.changeset/hotkeys-usekey.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Upgrade react-hotkeys-hook to v5 and use its native `useKey` option so keyboard shortcuts match the produced key on non-QWERTY layouts.

--- a/bun.lock
+++ b/bun.lock
@@ -171,7 +171,7 @@
         "quick-lru": "^7.0.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "react-hotkeys-hook": "^4.4.1",
+        "react-hotkeys-hook": "^5.3.3",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.1",
@@ -2862,7 +2862,7 @@
 
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
-    "react-hotkeys-hook": ["react-hotkeys-hook@4.5.1", "", { "peerDependencies": { "react": ">=16.8.1", "react-dom": ">=16.8.1" } }, "sha512-scAEJOh3Irm0g95NIn6+tQVf/OICCjsQsC9NBHfQws/Vxw4sfq1tDQut5fhTEvPraXhu/sHxRd9lOtxzyYuNAg=="],
+    "react-hotkeys-hook": ["react-hotkeys-hook@5.3.3", "", { "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-aswgyWUnE25hmhzHTfKDmKzsaSE5DJ4LKaU/o6rQSXkDd/1Bh9TfAFQbHkf6fLy11HvlYkp+cDDarGdhmCDhoQ=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 

--- a/packages/gitbook/package.json
+++ b/packages/gitbook/package.json
@@ -62,7 +62,7 @@
         "quick-lru": "^7.0.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "react-hotkeys-hook": "^4.4.1",
+        "react-hotkeys-hook": "^5.3.3",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.1",

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -63,7 +63,9 @@ export function AIChat() {
         () => {
             chatController.close();
         },
-        []
+        {
+            useKey: true,
+        }
     );
 
     // Track the view of the AI chat

--- a/packages/gitbook/src/components/AIChat/AIChatInput.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatInput.tsx
@@ -77,9 +77,9 @@ export function AIChatInput(props: {
         },
         {
             enableOnFormTags: true,
-            // Match the logical character so Dvorak ⌘-C (physical "I" key) copies
+            // Match the produced key so Dvorak ⌘-C (physical "I" key) copies
             // instead of focusing the Assistant input. RND-11340.
-            ignoreEventWhen: (e) => e.key.toLowerCase() !== 'i',
+            useKey: true,
         }
     );
 

--- a/packages/gitbook/src/components/Search/SearchContainer.tsx
+++ b/packages/gitbook/src/components/Search/SearchContainer.tsx
@@ -75,10 +75,9 @@ export function SearchContainer({
         },
         {
             enableOnFormTags: true,
-            // Match the logical character typed, not the physical key position, so
-            // non-QWERTY layouts don't trigger the shortcut by position (e.g. on
-            // Dvorak the physical "K"/"I" keys produce other characters). RND-11340.
-            ignoreEventWhen: (e) => e.key.toLowerCase() !== 'k',
+            // Match the produced key, not the physical key position, so non-QWERTY
+            // layouts don't trigger the shortcut by position. RND-11340.
+            useKey: true,
         }
     );
 
@@ -94,9 +93,9 @@ export function SearchContainer({
         },
         {
             enableOnFormTags: true,
-            // Match the logical character so Dvorak ⌘-C (physical "I" key) copies
+            // Match the produced key so Dvorak ⌘-C (physical "I" key) copies
             // instead of opening the Assistant. RND-11340.
-            ignoreEventWhen: (e) => e.key.toLowerCase() !== 'i',
+            useKey: true,
         }
     );
 


### PR DESCRIPTION
Fixes https://github.com/GitbookIO/gitbook/issues/4008

Upgrades `react-hotkeys-hook` from v4 to v5 and sets its native `useKey: true` option on the ⌘K / ⌘I / Esc hotkeys, so shortcuts match the character the keypress produces rather than the physical key position. This replaces the manual `ignoreEventWhen` workaround (RND-11340) with the library's supported path - e.g. on Dvorak, ⌘C copies text instead of opening the assistant, and ⌘K matches the key that actually types "k".

The v4→v5 breaking changes (`splitKey`/`combinationKey` renames, `HotkeysProvider` scope rename, default code-based matching) don't affect us: these three hooks are the only call sites and all now set `useKey`.

Tested locally with a Dvorak layout.

Credit to @verhovsky for the original fix in #4273 - this applies the same approach along with the required library upgrade (`useKey` was introduced in v5).