### PR TITLE
Compute the AI chat time greeting after mount to avoid a hydration mismatch

### DIFF
--- a/.changeset/khaki-buses-invent.md
+++ b/.changeset/khaki-buses-invent.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix a hydration mismatch on every page load caused by the AI chat time-based greeting being computed in the server timezone.

--- a/packages/gitbook/src/components/AIChat/AIChat.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChat.tsx
@@ -23,7 +23,7 @@ import {
     EmbeddableFrameSubtitle,
     EmbeddableFrameTitle,
 } from '../Embeddable/EmbeddableFrame';
-import { useNow } from '../hooks';
+import { useIsMounted, useNow } from '../hooks';
 import { useTrackEvent } from '../Insights';
 import { Button } from '../primitives';
 import { ScrollContainer } from '../primitives/ScrollContainer';
@@ -224,13 +224,17 @@ export function AIChatBody(props: {
 
     const isEmpty = !chat.messages.length;
 
+    const isMounted = useIsMounted();
     const timeGreeting = React.useMemo(() => {
+        // The server clock runs in another timezone than the visitor's, so computing the
+        // greeting during SSR mismatches on hydration and regenerates the whole chat tree.
+        if (!isMounted) return '';
         const hour = new Date(now).getHours();
         if (hour < 6) return tString(language, 'ai_chat_assistant_greeting_night');
         if (hour < 12) return tString(language, 'ai_chat_assistant_greeting_morning');
         if (hour < 18) return tString(language, 'ai_chat_assistant_greeting_afternoon');
         return tString(language, 'ai_chat_assistant_greeting_evening');
-    }, [now, language]);
+    }, [isMounted, now, language]);
 
     return (
         <>


### PR DESCRIPTION
Every page load in production throws React #418: the AI chat greeting ("Good morning/afternoon/…") is computed from `getHours()` during SSR in the **server's** timezone (UTC), then recomputed client-side in the visitor's timezone. Whenever the two clocks fall in different greeting buckets — most of the day for most of the world — the text mismatches and React regenerates the whole chat side-sheet client-side on every load.

It never reproduced in dev because the dev server shares the machine's timezone. Reproduced by pointing a `timezoneId: 'UTC'` browser at a local dev server: React names `AIChatBody` with `+ Good morning / - Good afternoon`.

Fix: only compute the greeting after mount (`useIsMounted`), rendering an empty title during SSR/hydration. No visible impact: the chat sheet is closed at load, and in the embed the existing blur-in animation covers the first frame.

Verified with the same UTC-browser repro: 0 hydration errors after the fix.
