### PR TITLE
Stop preloading zoom-modal images at render time

### DIFF
--- a/.changeset/light-parts-repeat.md
+++ b/.changeset/light-parts-repeat.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Stop preloading the zoom-modal variant of every zoomable image at render time; it downloaded each image twice during the initial page load. The modal image still loads on hover or click.

--- a/packages/gitbook/src/components/utils/ZoomImage.tsx
+++ b/packages/gitbook/src/components/utils/ZoomImage.tsx
@@ -74,12 +74,8 @@ export function ZoomImage(
         };
     }, [imgRef, width]);
 
-    // Preload the image that will be displayed in the modal
-    if (zoomable) {
-        ReactDOM.preload(src, {
-            as: 'image',
-        });
-    }
+    // The modal image is loaded on demand (hover or click) by `preloadImage`; preloading it at
+    // render time would download every zoomable image twice during the initial page load.
     const preloadImage = React.useCallback(
         (onLoad?: () => void) => {
             const image = new Image();


### PR DESCRIPTION
`ZoomImage` called `ReactDOM.preload(src, { as: 'image' })` on every render, downloading the zoom-modal variant of every zoomable image during the initial page load — a second copy of each image (the preloaded fallback `src` never matches the srcset candidate the inline `<img>` picks), paid by every visitor for a zoom most of them never open. On `gitbook.com/docs` production, Chrome flags 7 of 10 image preloads as unused (~40 KB); pages heavy in zoomable images pay proportionally more.

The on-demand path already covers the modal: `onMouseEnter` pre-warms the image and `onClick` loads it before opening (`preloadImage(onLoad)`). Only change in behavior: on touch devices the first zoom waits for the image download instead of having it pre-fetched — already handled by the existing load-then-open callback.

After the fix a page emits a single image preload (the `fetchPriority="high"` cover/logo), verified locally. No Lighthouse score impact expected — this removes wasted visitor bandwidth and the "preloaded but not used" console warnings.
