### PR TITLE
Match the Docs Embed widget to the page it is embedded in

### DIFF
--- a/.changeset/embed-script-color-scheme.md
+++ b/.changeset/embed-script-color-scheme.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the Docs Embed widget rendering with a dark surface when the visitor's OS is in dark mode, even on a light page or a site published with a light theme. The embed script now accepts `?theme=light|dark` to force a scheme.

--- a/.changeset/embed-widget-color-scheme.md
+++ b/.changeset/embed-widget-color-scheme.md
@@ -1,0 +1,5 @@
+---
+"@gitbook/embed": patch
+---
+
+Make the Docs Embed widget match the page it is embedded in rather than the visitor's OS: a widget on a light page stays light even when the visitor's system is in dark mode, and the widget's own chrome and the docs inside it always render in the same scheme. Sites published with a single theme impose it on the widget too, since they render in it regardless. The standalone script takes `?theme=light` on its URL, and calling `init` twice now updates the options instead of throwing.

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -21,13 +21,25 @@ You can find the embed script from your docs site settings, or you can copy the 
 
 ```html
 <script src="https://docs.company.com/~gitbook/embed/script.js"></script>
+```
+
+The script initializes the widget itself, so there is nothing to call. To pin the embed to one color
+scheme, put it on the script URL — it has to be known before the widget renders:
+
+```html
+<script src="https://docs.company.com/~gitbook/embed/script.js?theme=light"></script>
+```
+
+To authenticate the visitor, call `init` with their token. Keep tokens out of the script URL: it is
+publicly cacheable and ends up in server logs.
+
+```html
+<script src="https://docs.company.com/~gitbook/embed/script.js"></script>
 <script>
-// Initialize with Authenticated Access (optional)
-window.GitBook('init', 
+window.GitBook('init',
     { siteURL: 'https://docs.company.com' },
     { visitor: { token: 'your-jwt-token' } }
 );
-window.GitBook('show');
 </script>
 ```
 
@@ -464,19 +476,24 @@ visitor: {
 
 Available in: Standalone script (via `init`), NPM package (via `getFrameURL()`), React components (as prop)
 
-Override the embed's color scheme. When omitted, the embed follows the iframe's CSS `color-scheme`, which lets it inherit the parent page or browser preference.
+Override the embed's color scheme.
+
+When omitted, the standalone widget follows the page it is embedded in — its `color-scheme`, falling back to the visitor's OS preference only when that page declares support for both. With the NPM package or the React components you own the iframe, so the embed follows the visitor's OS preference unless you pass this.
 
 **Note**: This is not a configuration option but rather a parameter when initializing the frame or creating the frame URL.
 
-**Standalone script**: Pass as the second argument to `GitBook('init', options, frameOptions)`
+**Standalone script**: `?theme=light` on the script URL
 **NPM package**: Pass to `getFrameURL({ colorScheme: 'dark' })`
 **React components**: Pass as the `colorScheme` prop on `<GitBookFrame>`
 
 - **Type**: `'light' | 'dark'`
 
-```javascript
-colorScheme: 'dark'
+```html
+<script src="https://docs.company.com/~gitbook/embed/script.js?theme=light"></script>
 ```
+
+Sites published with a single theme always render in that theme, so `colorScheme` has no effect on
+them — the widget follows the site instead, to keep its chrome and the docs inside it consistent.
 
 ### `button`
 

--- a/packages/embed/src/client/createGitBook.ts
+++ b/packages/embed/src/client/createGitBook.ts
@@ -10,7 +10,9 @@ export type CreateGitBookOptions = {
 export type GetFrameURLOptions = {
     /**
      * Override the color scheme used by the embedded docs.
-     * When omitted, the embed follows the iframe's CSS `color-scheme`.
+     * When omitted, the standalone widget follows the page it is embedded in, and only falls back
+     * to the visitor's OS preference when that page supports both schemes. Building the iframe
+     * yourself, the embed follows the visitor's OS preference unless you pass this.
      */
     colorScheme?: 'light' | 'dark';
 

--- a/packages/embed/src/react/GitBookFrame.tsx
+++ b/packages/embed/src/react/GitBookFrame.tsx
@@ -79,7 +79,6 @@ export function GitBookFrame(props: GitBookFrameProps) {
             height="100%"
             allow="clipboard-write"
             className={className}
-            style={colorScheme ? { colorScheme } : undefined}
         />
     );
 }

--- a/packages/embed/src/standalone/index.ts
+++ b/packages/embed/src/standalone/index.ts
@@ -55,6 +55,7 @@ let widgetIframe: HTMLIFrameElement | undefined;
 let _client: GitBookClient | undefined;
 let _frame: GitBookFrameClient | undefined;
 let frameOptions: GetFrameURLOptions | undefined;
+let frameConfigured = false;
 let frameConfiguration: GitBookEmbeddableConfiguration & StandaloneConfiguration = {
     button: {
         label: 'Ask',
@@ -85,6 +86,47 @@ widgetWindow.classList.add('hidden');
 document.body.appendChild(widgetButton);
 document.body.appendChild(widgetWindow);
 
+/**
+ * The one scheme everything follows: the widget's chrome, the frame's URL and the docs inside it.
+ * Either it was configured, or we match the page we are embedded in (RND-12558).
+ */
+function resolveColorScheme(): 'light' | 'dark' {
+    const configured = frameOptions?.colorScheme;
+    // Callers are plain JS, so anything else — a typo, a `system` — falls back to the page rather
+    // than reaching the CSS and the frame's URL, where the two would disagree.
+    return configured === 'light' || configured === 'dark' ? configured : hostColorScheme();
+}
+
+/**
+ * The scheme the embedding page renders in, which is not the visitor's OS preference: a page that
+ * never opted into dark stays light however the OS is set.
+ *
+ * Resolving a `light-dark()` is the only way to read it. A page's *used* color scheme isn't exposed
+ * anywhere — the CSSOM gives computed values, and a `<meta name="color-scheme">` (the common way to
+ * declare it) never even reaches those.
+ */
+function hostColorScheme(): 'light' | 'dark' {
+    const probe = document.createElement('div');
+    // The first `color` is the fallback where `light-dark()` is unsupported: without it the probe
+    // would inherit the page's own text colour and a white one would read as dark.
+    probe.style.cssText =
+        'display:none;color:rgb(0,0,0);color:light-dark(rgb(0,0,0), rgb(255,255,255))';
+    document.body.appendChild(probe);
+    const used = getComputedStyle(probe).color;
+    probe.remove();
+
+    return used === 'rgb(255, 255, 255)' ? 'dark' : 'light';
+}
+
+/** Mirror the resolved scheme onto the widget's own chrome, and hand it back for the frame's URL. */
+function applyColorScheme(): 'light' | 'dark' {
+    const colorScheme = resolveColorScheme();
+    for (const element of [widgetButton, widgetWindow]) {
+        element.dataset.colorScheme = colorScheme;
+    }
+    return colorScheme;
+}
+
 function getClient() {
     if (!_client) {
         throw new Error(
@@ -102,12 +144,8 @@ function getIframe() {
         widgetIframe = document.createElement('iframe');
         widgetIframe.id = 'gitbook-widget-iframe';
         widgetIframe.allow = 'clipboard-write';
-        if (frameOptions?.colorScheme) {
-            widgetIframe.style.colorScheme = frameOptions.colorScheme;
-        }
-        widgetIframe.src = client.getFrameURL({
-            ...frameOptions,
-        });
+        // One read for both, so the docs can't come back in a different scheme than the panel.
+        widgetIframe.src = client.getFrameURL({ ...frameOptions, colorScheme: applyColorScheme() });
         widgetWindow.appendChild(widgetIframe);
 
         _frame = client.createFrame(widgetIframe);
@@ -121,19 +159,47 @@ function getIframe() {
 
 const GitBook = (...args: StandaloneCalls) => {
     switch (args[0]) {
-        case 'init':
-            if (_client) {
-                throw new Error(
-                    'GitBook client already initialized. Call GitBook("unload") first.'
-                );
-            }
+        case 'init': {
+            // `~gitbook/embed/script.js` already calls `init`, so an integrator following the docs
+            // ends up calling it a second time. Merge instead of throwing: throwing here dropped
+            // every call queued after it (RND-12558).
             _client = createGitBook(args[1]);
-            frameOptions = args[2];
+            frameOptions = {
+                ...frameOptions,
+                ...args[2],
+                // First scheme wins: `script.js` passes the site's own theme when it has one, and
+                // that is not the integrator's to override.
+                colorScheme: frameOptions?.colorScheme ?? args[2]?.colorScheme,
+            };
+            const colorScheme = applyColorScheme();
+
+            // Rebuild the frame only if the new options change its URL — reloading it on the
+            // loader's `init` plus the integrator's would throw away a chat for nothing.
+            const frameURL = _client.getFrameURL({ ...frameOptions, colorScheme });
+            if (widgetIframe && widgetIframe.src !== frameURL) {
+                const wasOpen = !widgetWindow.classList.contains('hidden');
+                widgetIframe.remove();
+                widgetIframe = undefined;
+                _frame = undefined;
+                if (wasOpen) {
+                    // The new frame starts from the site's defaults, so anything the host
+                    // configured has to be sent again.
+                    const { frame } = getIframe();
+                    if (frameConfigured) {
+                        frame.configure(frameConfiguration);
+                    }
+                }
+            }
             break;
+        }
         case 'unload':
             _client = undefined;
             _frame = undefined;
             widgetIframe?.remove();
+            widgetIframe = undefined;
+            frameOptions = undefined;
+            frameConfigured = false;
+            applyColorScheme();
             widgetWindow.classList.add('hidden');
             break;
         case 'show':
@@ -192,6 +258,7 @@ const GitBook = (...args: StandaloneCalls) => {
                 }
             }
 
+            frameConfigured = true;
             getIframe().frame.configure({
                 ...frameConfiguration,
             });
@@ -214,4 +281,11 @@ const precalls = (window.GitBook as GitBookStandalone | undefined)?.q ?? [];
 
 // @ts-expect-error - GitBook is not defined in the global scope
 window.GitBook = GitBook;
-precalls.forEach((call) => GitBook(...call));
+// Replay each queued call on its own, so one that throws doesn't drop the rest.
+precalls.forEach((call) => {
+    try {
+        GitBook(...call);
+    } catch (error) {
+        console.error('[gitbook:embed]', error);
+    }
+});

--- a/packages/embed/src/standalone/index.ts
+++ b/packages/embed/src/standalone/index.ts
@@ -153,6 +153,10 @@ function getIframe() {
             widgetWindow.classList.add('hidden');
             widgetButton.classList.remove('open');
         });
+        // A new frame starts from the site's own defaults, so replay whatever the host configured.
+        if (frameConfigured) {
+            _frame.configure(frameConfiguration);
+        }
     }
     return { iframe: widgetIframe, frame: _frame };
 }
@@ -161,14 +165,15 @@ const GitBook = (...args: StandaloneCalls) => {
     switch (args[0]) {
         case 'init': {
             // `~gitbook/embed/script.js` already calls `init`, so an integrator following the docs
-            // ends up calling it a second time. Merge instead of throwing: throwing here dropped
-            // every call queued after it (RND-12558).
+            // ends up calling it a second time. Take the new options instead of throwing: throwing
+            // here dropped every call queued behind it (RND-12558).
             _client = createGitBook(args[1]);
             frameOptions = {
-                ...frameOptions,
+                // Replace rather than merge: a call that leaves out `visitor` — a logout, another
+                // site — must not keep the token from the last one.
                 ...args[2],
-                // First scheme wins: `script.js` passes the site's own theme when it has one, and
-                // that is not the integrator's to override.
+                // Except the scheme, where the first one wins: `script.js` passes the site's own
+                // theme when it pins one, and that is not the integrator's to override.
                 colorScheme: frameOptions?.colorScheme ?? args[2]?.colorScheme,
             };
             const colorScheme = applyColorScheme();
@@ -182,12 +187,7 @@ const GitBook = (...args: StandaloneCalls) => {
                 widgetIframe = undefined;
                 _frame = undefined;
                 if (wasOpen) {
-                    // The new frame starts from the site's defaults, so anything the host
-                    // configured has to be sent again.
-                    const { frame } = getIframe();
-                    if (frameConfigured) {
-                        frame.configure(frameConfiguration);
-                    }
+                    getIframe();
                 }
             }
             break;

--- a/packages/embed/src/standalone/style.css
+++ b/packages/embed/src/standalone/style.css
@@ -33,7 +33,8 @@
  * iframe. `data-color-scheme` carries that one resolved scheme — see `resolveColorScheme()` — and
  * is always set, so the declaration below only shows before the widget initializes (RND-12558).
  * The colours are declared here rather than on `:root` because `light-dark()` resolves against the
- * color-scheme of the element that declares them. The plain values above stay as the fallback. */
+ * color-scheme of the element that declares them. The bundler lowers it to a variable toggle, so
+ * browsers without `light-dark()` still get both schemes. */
 #gitbook-widget-button,
 #gitbook-widget-window {
     color-scheme: light;

--- a/packages/embed/src/standalone/style.css
+++ b/packages/embed/src/standalone/style.css
@@ -29,14 +29,29 @@
     --gitbook-widget-easing-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --gitbook-widget-text-color: #FFFFFF;
-        --gitbook-widget-border-color: #202020;
-        --gitbook-widget-background-translucent: rgba(15, 15, 15, 0.9);
-        --gitbook-widget-background-translucent-hover: rgba(20, 20, 20, 0.9);
-        --gitbook-widget-background-solid: #f0f0f0;
-    }
+/* The widget owns the panel's surface, so it renders in the same scheme as the docs inside the
+ * iframe. `data-color-scheme` carries that one resolved scheme — see `resolveColorScheme()` — and
+ * is always set, so the declaration below only shows before the widget initializes (RND-12558).
+ * The colours are declared here rather than on `:root` because `light-dark()` resolves against the
+ * color-scheme of the element that declares them. The plain values above stay as the fallback. */
+#gitbook-widget-button,
+#gitbook-widget-window {
+    color-scheme: light;
+
+    --gitbook-widget-text-color: light-dark(#656973, #FFFFFF);
+    --gitbook-widget-border-color: light-dark(#e5e5e5, #202020);
+    --gitbook-widget-background-translucent: light-dark(rgba(255, 255, 255, 0.9), rgba(15, 15, 15, 0.9));
+    --gitbook-widget-background-translucent-hover: light-dark(rgba(250, 250, 250, 0.9), rgba(20, 20, 20, 0.9));
+    --gitbook-widget-background-solid: light-dark(#FFFFFF, #0f0f0f);
+    --gitbook-widget-background-solid-hover: light-dark(#FBFBFB, #141414);
+}
+#gitbook-widget-button[data-color-scheme="light"],
+#gitbook-widget-window[data-color-scheme="light"] {
+    color-scheme: light;
+}
+#gitbook-widget-button[data-color-scheme="dark"],
+#gitbook-widget-window[data-color-scheme="dark"] {
+    color-scheme: dark;
 }
 
 * {

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/script.js/route.ts
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/script.js/route.ts
@@ -5,7 +5,7 @@ import type { CreateGitBookOptions } from '@gitbook/embed';
 import type { RouteLayoutParams } from '@/app/utils';
 import { getAssetURL } from '@/lib/assets';
 import { buildVersion } from '@/lib/build';
-import { getEmbeddableStaticContext } from '@/lib/embeddable';
+import { getEmbeddableStaticContext, resolveEmbeddableTheme } from '@/lib/embeddable';
 
 export const dynamic = 'force-static';
 
@@ -20,6 +20,10 @@ export async function GET(
     const initOptions: CreateGitBookOptions = {
         siteURL: context.linker.toAbsoluteURL(context.linker.toPathInSite('')),
     };
+
+    // The theme this site pins its embeds to, if it has one. The widget paints the panel around the
+    // iframe, so it has to render in the same scheme as the docs inside it (RND-12558).
+    const siteColorScheme = resolveEmbeddableTheme(context.customization).forcedTheme;
 
     return new Response(
         `
@@ -37,8 +41,18 @@ export async function GET(
 
   const searchParams = getScriptSearchParams()
   const token = searchParams.get('jwt_token');
-  const initOptions = window.gitbookSettings || ${JSON.stringify(initOptions)};
-  const initFrameOptions = token ? { visitor: { token } } : undefined;
+  const initOptions = { ...${JSON.stringify(initOptions)}, ...(window.gitbookSettings || {}) };
+  const initFrameOptions = {};
+  const theme = searchParams.get('theme');
+  // The site's own theme first: it renders in that one whatever the embedder asks for.
+  const colorScheme =
+    ${JSON.stringify(siteColorScheme ?? null)} || (theme === 'light' || theme === 'dark' ? theme : null);
+  if (colorScheme) {
+    initFrameOptions.colorScheme = colorScheme;
+  }
+  if (token) {
+    initFrameOptions.visitor = { token };
+  }
 
   if (typeof gb === "function") {
     gb('init', initOptions, initFrameOptions);

--- a/packages/gitbook/src/components/Embeddable/EmbeddableRootLayout.tsx
+++ b/packages/gitbook/src/components/Embeddable/EmbeddableRootLayout.tsx
@@ -38,10 +38,10 @@ export async function EmbeddableRootLayout({
 }: React.PropsWithChildren<EmbeddableRootLayoutProps>) {
     const theme = resolveEmbeddableTheme(context.customization, forcedTheme);
 
-    // Only remember a theme the visitor explicitly requested via `?theme=`, and only on
-    // multi-theme sites that actually honor the override. Single-theme sites ignore it (and would
-    // otherwise persist their own default on every plain visit — see PR #4380 review). RND-11571
-    const rememberedTheme = context.customization.themes.toggeable ? forcedTheme : null;
+    // Only remember a theme that was explicitly requested via `?theme=` *and* honored — a site
+    // pinned to one theme ignores the request, and would otherwise persist its own default on every
+    // plain visit (see PR #4380 review). RND-11571
+    const rememberedTheme = theme.forcedTheme === forcedTheme ? forcedTheme : null;
 
     return (
         <CustomizationRootLayout

--- a/packages/gitbook/src/lib/embeddable.test.ts
+++ b/packages/gitbook/src/lib/embeddable.test.ts
@@ -182,3 +182,20 @@ describe('resolveEmbeddableTheme', () => {
         });
     });
 });
+
+describe('resolveEmbeddableTheme with a single system theme', () => {
+    it('accepts an explicit override, since the site pins no theme', () => {
+        // The widget outside the iframe follows the embedding page for these sites, so the docs
+        // have to honor the scheme it asks for or the two disagree (RND-12558).
+        expect(
+            resolveEmbeddableTheme(
+                { themes: { toggeable: false, default: CustomizationDefaultThemeMode.System } },
+                CustomizationDefaultThemeMode.Light
+            )
+        ).toEqual({
+            htmlTheme: CustomizationDefaultThemeMode.Light,
+            defaultTheme: CustomizationDefaultThemeMode.Light,
+            forcedTheme: CustomizationDefaultThemeMode.Light,
+        });
+    });
+});

--- a/packages/gitbook/src/lib/embeddable.ts
+++ b/packages/gitbook/src/lib/embeddable.ts
@@ -58,13 +58,17 @@ export function resolveEmbeddableTheme(
     customization: Pick<SiteCustomizationSettings, 'themes'>,
     forcedTheme?: CustomizationDefaultThemeMode | null
 ) {
-    if (!customization.themes.toggeable) {
-        const mode = customization.themes.default;
+    const mode = customization.themes.default;
+    // A site published in one concrete theme renders in it whatever the embedder asks for: its
+    // content only exists for that theme. `System` pins nothing, so an override applies there —
+    // and it has to, or the widget outside would follow the page while the docs follow the OS
+    // (RND-12558). Unforced `System` also lets next-themes resolve prefers-color-scheme pre-paint,
+    // avoiding a flash (RND-11643).
+    if (!customization.themes.toggeable && mode !== CustomizationDefaultThemeMode.System) {
         return {
             htmlTheme: mode,
             defaultTheme: mode,
-            // Only force concrete light/dark; System stays unforced so next-themes resolves prefers-color-scheme pre-paint (avoids the flash). A theme saved while the toggle was previously on still wins — see the PR's "Known limitation". RND-11643
-            forcedTheme: mode === CustomizationDefaultThemeMode.System ? undefined : mode,
+            forcedTheme: mode,
         };
     }
 

--- a/packages/gitbook/src/lib/embeddable.ts
+++ b/packages/gitbook/src/lib/embeddable.ts
@@ -48,9 +48,11 @@ export async function getEmbeddableDynamicContext(params: RouteLayoutParams) {
 export { getEmbeddableLinker } from './embeddable-linker';
 
 /**
- * Resolve theme behavior for docs embeds.
- * Embeds should follow the parent frame's color-scheme by default,
- * while still allowing an explicit override for multi-theme sites.
+ * Resolve the theme the embed renders in: the site's own when it publishes a single theme, an
+ * explicit `?theme=` override when it publishes both, and otherwise the visitor's OS.
+ *
+ * `forcedTheme` is also what the embed is pinned to whatever the embedder asks for, which is what
+ * the widget outside the iframe has to follow (RND-12558).
  */
 export function resolveEmbeddableTheme(
     customization: Pick<SiteCustomizationSettings, 'themes'>,


### PR DESCRIPTION
## Overview

- The Docs Embed widget now renders in the same color scheme as the docs inside it, and follows the page it is embedded in rather than the visitor's OS. A widget on a light page stays light for a visitor whose system is in dark mode.
- The widget paints the panel's surface around the iframe, and that surface was keyed off `prefers-color-scheme` alone — so a dark-mode visitor got a near-black panel behind light docs. RND-12558; reported on a site published with a light theme, where no configuration could fix it.
- Sites published with a single theme now impose it on the widget too, since the docs render in that theme whatever the embedder asks for. Nothing can force a light-only site's embed into dark, where its images have no dark variant.
- One resolution, in one place: the site's own theme, then the configured `colorScheme`, then the embedding page. It reaches the widget's chrome as `data-color-scheme` and the docs as `?theme=`.
- The embed script accepts `?theme=light|dark` on its URL, so the scheme can be set without an inline script. Visitor tokens stay on `init` — the script URL is publicly cacheable and ends up in server logs.
- A second `init` updates the options instead of throwing. The script initializes the widget itself, so an integrator following the API reference always makes a second call, and throwing there dropped every call queued behind it.
- Removed `iframe.style.colorScheme`: an iframe's `color-scheme` reaches nothing in the embedded document — neither its `prefers-color-scheme` nor its used scheme. Verified in Chromium.
- Fixed the widget's high-contrast dark background, which was `#f0f0f0` (white text on near-white).

The embedding page's scheme is read by resolving a `light-dark()` on a throwaway element. That is the only thing that reflects a document's *used* scheme: a `<meta name="color-scheme">`, the common way to declare one, never reaches the computed property.

Verified with 42 Playwright cases across both real sites (a single-theme one and a multi-theme one), both OS settings, `<meta>` and CSS declarations, every configuration channel including invalid values, plus `configure` and Authenticated Access regressions. Every case asserts that the chrome and the docs agree.

Known trade-off: the scheme resolves when the widget initializes, so changing the OS setting mid-session no longer re-themes an open panel until reload — re-theming it would mean reloading the frame and discarding the chat.

## Demo

Visitor's OS in dark mode, on a light-only page — the reported bug, and after:

| Before | After |
| --- | --- |
| [![before](https://files.argos-ci.com/media/20307/eb3beeea7adaac3b2fa0c6f6647780b15303f003a664b47785361e957a9a92e7.webp)](https://app.argos-ci.com/m/hd6uhhk793gjxncsuipg) | [![after](https://files.argos-ci.com/media/20307/46ef47a6c0eb6d94a7abef1019b7133987f24487ebeb6e3dfe1495c3e6323f82.webp)](https://app.argos-ci.com/m/uik23h5ipi8m2idhnxxw) |

The same visitor on a page that does declare support for dark, before and after — the widget follows the page there, so this one is unchanged:

| Before | After |
| --- | --- |
| [![before](https://files.argos-ci.com/media/20307/21246d5205dd802e93cc571a6da93afb0fc1a6935cf833e24abe24833d567568.webp)](https://app.argos-ci.com/m/9sxa3bd5j72c2abplaoc) | [![after](https://files.argos-ci.com/media/20307/08f20fee2a49c6faa0174b73f0448bb33bfe724824c08ea55eb50c3f653b4257.webp)](https://app.argos-ci.com/m/h4ir7qk6wqtcxmcppg8s) |

*— Authored by Claude*
