### PR TITLE
Scroll the table of contents to the active page on client-side navigation

### DIFF
--- a/.changeset/sidebar-active-item-scroll.md
+++ b/.changeset/sidebar-active-item-scroll.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Scroll the table of contents to the active page when navigating between pages, not only on the initial page load.

--- a/packages/gitbook/src/components/primitives/ScrollContainer.tsx
+++ b/packages/gitbook/src/components/primitives/ScrollContainer.tsx
@@ -4,6 +4,11 @@ import * as React from 'react';
 
 import { useScrollOverflow } from '../hooks/useScrollOverflow';
 import { Button, type ButtonProps } from './Button';
+import {
+    getScrollOffsetToCenter,
+    isElementVisibleInContainer,
+    resolveActiveItem,
+} from './scrollIntoContainer';
 import { tString, useLanguage } from '@/intl/client';
 import { tcls } from '@/lib/tailwind';
 
@@ -11,7 +16,7 @@ import { tcls } from '@/lib/tailwind';
  * A container that encapsulates a scrollable area with usability features.
  * - Faded edges when there is more content than the container can display.
  * - Buttons to advance the scroll position.
- * - Auto-scroll to the active item when it's initially active.
+ * - Auto-scroll to the active item, when it becomes active and isn't already visible.
  */
 export type ScrollContainerProps = {
     children: React.ReactNode;
@@ -61,23 +66,54 @@ export function ScrollContainer(props: ScrollContainerProps) {
 
     const { scrollPosition, scrollSize } = useScrollOverflow(orientation, containerRef);
 
+    // The active item is resolved from the DOM, so the effect below cannot depend on the
+    // element itself. `active` is usually a static selector, and the item it matches moves
+    // as the visitor navigates (client-side navigations keep this container mounted), so we
+    // track the resolved element and re-scroll whenever it points at a different item.
+    const [activeItem, setActiveItem] = React.useState<Element | null>(null);
+
     React.useEffect(() => {
         const container = containerRef.current;
         if (!container) {
             return;
         }
         if (!active) {
+            setActiveItem(null);
             return;
         }
-        const activeItem =
-            typeof active === 'string'
-                ? containerRef.current?.querySelector(active)
-                : active.current;
-        if (!activeItem || !container.contains(activeItem)) {
-            return;
-        }
-        scrollToElementInContainer(activeItem, container);
+
+        const trackActiveItem = () => {
+            setActiveItem(resolveActiveItem(active, container));
+        };
+
+        trackActiveItem();
+
+        // The active item can change without this container re-rendering: on a client-side
+        // navigation the items update their own active state, and the group holding the new
+        // active item may only expand (and render it) afterwards.
+        const observer = new MutationObserver(trackActiveItem);
+        observer.observe(container, {
+            subtree: true,
+            childList: true,
+            attributes: true,
+            attributeFilter: ['data-active', 'id'],
+        });
+
+        return () => observer.disconnect();
     }, [active]);
+
+    // Bring the active item into view whenever a different item becomes the active one, so
+    // the current page stays visible after a client-side navigation. Storing the element in
+    // state means React bails out while it stays the same, so repeated observer callbacks
+    // don't re-scroll and the visitor's own scroll position is left alone.
+    React.useEffect(() => {
+        const container = containerRef.current;
+        if (!container || !activeItem) {
+            return;
+        }
+
+        scrollElementIntoContainer(activeItem, container);
+    }, [activeItem]);
 
     const scrollFurther = () => {
         const container = containerRef.current;
@@ -192,23 +228,29 @@ export function ScrollContainer(props: ScrollContainerProps) {
 }
 
 /**
- * Scroll to an element in a container.
+ * Scroll an element into view inside a container, unless it is already fully visible.
  */
-function scrollToElementInContainer(element: Element, container: HTMLElement) {
-    const containerRect = container.getBoundingClientRect();
+function scrollElementIntoContainer(element: Element, container: HTMLElement) {
+    const containerBox = {
+        rect: container.getBoundingClientRect(),
+        clientHeight: container.clientHeight,
+        clientWidth: container.clientWidth,
+        scrollTop: container.scrollTop,
+        scrollLeft: container.scrollLeft,
+    };
     const rect = element.getBoundingClientRect();
 
-    return container.scrollTo({
-        top:
-            container.scrollTop +
-            (rect.top - containerRect.top) -
-            container.clientHeight / 2 +
-            rect.height / 2,
-        left:
-            container.scrollLeft +
-            (rect.left - containerRect.left) -
-            container.clientWidth / 2 +
-            rect.width / 2,
+    // Don't move the container when the element is already in view, so navigating to a
+    // nearby page doesn't shift the list under the visitor for no reason.
+    if (isElementVisibleInContainer(rect, containerBox)) {
+        return;
+    }
+
+    const { top, left } = getScrollOffsetToCenter(rect, containerBox);
+
+    container.scrollTo({
+        top,
+        left,
         // Use 'auto' to avoid additional scroll animations when scrolling to an element
         // as this may be called during layout/initialization when the page is not fully loaded.
         behavior: 'auto',

--- a/packages/gitbook/src/components/primitives/scrollIntoContainer.test.ts
+++ b/packages/gitbook/src/components/primitives/scrollIntoContainer.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+    getScrollOffsetToCenter,
+    isElementVisibleInContainer,
+    resolveActiveItem,
+} from './scrollIntoContainer';
+
+/**
+ * A vertical container 100px tall whose content overflows, positioned at the top of the
+ * viewport. Values mirror what `getBoundingClientRect()` / `clientHeight` would report.
+ */
+function container({ scrollTop = 0 }: { scrollTop?: number } = {}) {
+    return {
+        rect: { top: 0, left: 0 },
+        clientHeight: 100,
+        clientWidth: 100,
+        scrollTop,
+        scrollLeft: 0,
+    };
+}
+
+/** An item of the given height, positioned `top` pixels from the viewport origin. */
+function item({ top, height = 20 }: { top: number; height?: number }) {
+    return { top, left: 0, height, width: 20 };
+}
+
+describe('isElementVisibleInContainer', () => {
+    it('reports a fully visible item as visible', () => {
+        expect(isElementVisibleInContainer(item({ top: 40 }), container())).toBe(true);
+    });
+
+    it('reports an item below the visible region as not visible', () => {
+        // The case from the issue: the active item sits far below the container's
+        // visible region because the sidebar kept its previous scroll position.
+        expect(isElementVisibleInContainer(item({ top: 817 }), container())).toBe(false);
+    });
+
+    it('reports an item above the visible region as not visible', () => {
+        expect(isElementVisibleInContainer(item({ top: -30 }), container())).toBe(false);
+    });
+
+    it('reports an item clipped by the bottom edge as not visible', () => {
+        // Its top is inside the container but its bottom half is cut off.
+        expect(isElementVisibleInContainer(item({ top: 90, height: 20 }), container())).toBe(false);
+    });
+
+    it('treats an item flush with the edges as visible', () => {
+        expect(isElementVisibleInContainer(item({ top: 0 }), container())).toBe(true);
+        expect(isElementVisibleInContainer(item({ top: 80 }), container())).toBe(true);
+    });
+
+    it('measures against the container box, not the viewport', () => {
+        // A container offset down the page: an item at the viewport top is above it.
+        const offset = { ...container(), rect: { top: 200, left: 0 } };
+        expect(isElementVisibleInContainer(item({ top: 40 }), offset)).toBe(false);
+        expect(isElementVisibleInContainer(item({ top: 240 }), offset)).toBe(true);
+    });
+});
+
+describe('getScrollOffsetToCenter', () => {
+    it('centers an item that is below the visible region', () => {
+        // 0 (scrollTop) + 817 (relative top) - 50 (half container) + 10 (half item)
+        expect(getScrollOffsetToCenter(item({ top: 817 }), container())).toEqual({
+            top: 777,
+            left: -40,
+        });
+    });
+
+    it('accounts for the container current scroll position', () => {
+        expect(getScrollOffsetToCenter(item({ top: 817 }), container({ scrollTop: 200 }))).toEqual({
+            top: 977,
+            left: -40,
+        });
+    });
+});
+
+/** A stand-in for a DOM node, tracking which container it belongs to. */
+type Node = { name: string; contains: (other: Node) => boolean };
+
+/**
+ * A container holding `items`, of which the one named `activeName` carries `data-active`.
+ * `querySelector` mimics the DOM by returning the first match in document order.
+ */
+function tree(items: string[], activeName: string | null) {
+    const nodes = new Map(items.map((name) => [name, { name, contains: () => false }]));
+    const active = (activeName ? nodes.get(activeName) : null) ?? null;
+    const root: Node & { querySelector: (selector: string) => Node | null } = {
+        name: 'container',
+        contains: (other) => nodes.get(other.name) === other,
+        querySelector: (selector) => (selector === '[data-active=true]' ? active : null),
+    };
+    return { root, node: (name: string) => nodes.get(name) ?? null };
+}
+
+describe('resolveActiveItem', () => {
+    it('resolves the item matching a selector', () => {
+        const { root, node } = tree(['intro', 'setup'], 'setup');
+        expect(resolveActiveItem('[data-active=true]', root)).toBe(node('setup'));
+    });
+
+    it('resolves a different item once another page becomes active', () => {
+        // The regression: the sidebar stays mounted across a client-side navigation, so the
+        // only signal that it should scroll again is the selector matching another item.
+        const before = tree(['intro', 'setup'], 'intro');
+        const after = tree(['intro', 'setup'], 'setup');
+
+        const first = resolveActiveItem('[data-active=true]', before.root);
+        const second = resolveActiveItem('[data-active=true]', after.root);
+
+        expect(first).toBe(before.node('intro'));
+        expect(second).toBe(after.node('setup'));
+        expect(second).not.toBe(first);
+    });
+
+    it('returns null when no item is active', () => {
+        const { root } = tree(['intro', 'setup'], null);
+        expect(resolveActiveItem('[data-active=true]', root)).toBeNull();
+    });
+
+    it('resolves the item held by a ref', () => {
+        const { root, node } = tree(['intro'], null);
+        expect(resolveActiveItem({ current: node('intro') }, root)).toBe(node('intro'));
+        expect(resolveActiveItem({ current: null }, root)).toBeNull();
+    });
+
+    it('ignores an item that is not inside the container', () => {
+        // Scrolling to an item of another container would move this one to an arbitrary offset.
+        const { root } = tree(['intro'], null);
+        const foreign = { name: 'intro', contains: () => false };
+        expect(resolveActiveItem({ current: foreign }, root)).toBeNull();
+    });
+});

--- a/packages/gitbook/src/components/primitives/scrollIntoContainer.ts
+++ b/packages/gitbook/src/components/primitives/scrollIntoContainer.ts
@@ -1,0 +1,76 @@
+/**
+ * Geometry helpers for scrolling an item into view inside a scroll container.
+ *
+ * Kept free of React/DOM imports so the logic can be unit-tested directly.
+ */
+
+/** The subset of a `DOMRect` needed to position an element inside a container. */
+export type ElementBox = {
+    top: number;
+    left: number;
+    height: number;
+    width: number;
+};
+
+/** The subset of a scroll container's geometry needed to place one of its items. */
+export type ContainerBox = {
+    /** The container's own viewport-relative position, as returned by `getBoundingClientRect()`. */
+    rect: { top: number; left: number };
+    clientHeight: number;
+    clientWidth: number;
+    scrollTop: number;
+    scrollLeft: number;
+};
+
+/**
+ * Whether an element is fully within the visible region of its scroll container.
+ *
+ * Both boxes are viewport-relative, so the element's position is compared against the
+ * container's own box rather than the viewport.
+ */
+export function isElementVisibleInContainer(
+    element: Pick<ElementBox, 'top' | 'height'>,
+    container: Pick<ContainerBox, 'rect' | 'clientHeight'>
+): boolean {
+    const relativeTop = element.top - container.rect.top;
+    return relativeTop >= 0 && relativeTop + element.height <= container.clientHeight;
+}
+
+/**
+ * The scroll offset that centers an element within its scroll container.
+ */
+export function getScrollOffsetToCenter(
+    element: ElementBox,
+    container: ContainerBox
+): { top: number; left: number } {
+    return {
+        top:
+            container.scrollTop +
+            (element.top - container.rect.top) -
+            container.clientHeight / 2 +
+            element.height / 2,
+        left:
+            container.scrollLeft +
+            (element.left - container.rect.left) -
+            container.clientWidth / 2 +
+            element.width / 2,
+    };
+}
+
+/**
+ * Resolve the active item of a container from an `active` selector or ref.
+ *
+ * Returns null when nothing matches, or when the match lives outside the container — the
+ * caller tracks the returned element's identity to know when to scroll, so it must only
+ * ever be an item this container can actually scroll to.
+ */
+export function resolveActiveItem<T extends { contains: (other: T) => boolean }>(
+    active: string | { current: T | null },
+    container: T & { querySelector: (selector: string) => T | null }
+): T | null {
+    const item = typeof active === 'string' ? container.querySelector(active) : active.current;
+    if (!item || !container.contains(item)) {
+        return null;
+    }
+    return item;
+}


### PR DESCRIPTION
Fixes #4461

## What

The sidebar did not scroll the current page into view when navigating client-side. On a full page load the active page was scrolled into view correctly, but after clicking through to a page further down the table of contents the sidebar stayed at its previous offset, so the page you were reading was off-screen.

## How

`ScrollContainer`'s auto-scroll effect depended on the `active` prop:

```tsx
}, [active]);
```

`TableOfContents` passes `active="[data-active=true]"` — a constant selector string. The dependency was therefore identical on every render, so the effect only ever ran on mount. A full page load mounts the container (scroll worked); a client-side navigation keeps it mounted while the items update their own `data-active` attributes, so the effect never re-fired. `SiteSectionList` passes a dynamic `active={`#${currentSection.id}`}` and was not affected, which is why the bug was specific to the table of contents.

Rather than add a second scrolling mechanism, this retriggers the existing one: the resolved active element is tracked in state and the scroll effect is keyed on that element, so it re-runs exactly when the selector starts matching a different item.

A `MutationObserver` scoped to the container keeps that state in sync. It is needed because there is no React signal available here — the active item is identified by CSS selector, the items set their own `data-active`, and the container itself does not re-render on navigation. It also covers the case where the group holding the new active item expands (and renders it) only after the navigation. This follows existing usage in `useScrollOverflow.ts` and `TableOfContentsScript.tsx`, and avoids any `setTimeout` or arbitrary delay — the timing comes from React's own lifecycle.

Because the effect is keyed on the element's identity, React's `Object.is` bailout means repeated observer callbacks for the same active item do not re-scroll, so the visitor's own scroll position is left alone and there are no scroll loops.

Two further points:

- Scrolling is now skipped when the active item is already fully visible, so moving between neighbouring pages no longer shifts the list for no reason.
- The centering math is unchanged and still uses `behavior: 'auto'`; it moved to `scrollIntoContainer.ts` so it can be unit-tested without pulling in the component's dependency graph (the same split as `categorizeVariants.ts`). Only the sidebar's own scroll container is moved — the window is never scrolled.

No dependencies were added and group expansion state is untouched, so the fixes from #4391 and #4404 are unaffected.


## Visual verification

> The GitBook preview deployment is still awaiting maintainer approval, so these recordings use a local browser reproduction harness with the actual `ScrollContainer` implementation rather than the production GitBook site.

### Before

Client-side navigation changes the active page, but the sidebar keeps its previous scroll position. The newly active page remains outside the visible sidebar area.

[gitbook-4461-before.webm](https://github.com/user-attachments/assets/db7c2cdc-6b39-4c0a-935f-0c318bd2f945)

### After

With this change, the same client-side navigation automatically brings the newly active page into view inside the sidebar.

[gitbook-4461-after.webm](https://github.com/user-attachments/assets/b5fcaf13-060f-409d-919f-211d25aff020)

### Already-visible item

When navigating to an item that is already visible, the sidebar keeps its current position instead of scrolling unnecessarily.

[gitbook-4461-visible-item.webm](https://github.com/user-attachments/assets/ccee6155-5849-4a53-8bc7-9cdd2c9225c1)


## Testing

Tests actually run:

- `bun test src/components/primitives/scrollIntoContainer.test.ts` in `packages/gitbook` — 13 tests pass. They cover the visibility check (fully visible, above, below, clipped by the bottom edge, flush with the edges, measured against the container box rather than the viewport), the centering offsets, and `resolveActiveItem` — including the regression itself, that a navigation resolves a *different* element, plus items outside the container being ignored.
- `oxlint` on the changed files — no warnings.
- `oxfmt --check` on the changed files — correctly formatted.
- `tsc --noEmit` in `packages/gitbook` — no new errors (two errors in `AdaptiveVisitorContextProvider.tsx` and `imageFonts.ts` are present on an unmodified tree too).

These were focused checks, not a full CI-equivalent run of the workspace.

Manual verification was done in Chromium (Playwright) against a harness importing the real `scrollIntoContainer.ts` helpers and mounting both the old and new effect, rather than through `localhost:3000/url/...` — I do not have GitBook API credentials to run the dev server against a published site, so I could not verify against real content. All measurements below are read back from live layout:

| Scenario | Result |
| --- | --- |
| Client-side navigation to a deep page — old effect | `scrollTop` 0 → 0, active item at 1200px, not visible (reproduces the bug) |
| Client-side navigation to a deep page — new effect | `scrollTop` 1121, item at 79–119px of a 200px viewport, visible |
| Repeated deep → deep navigations | both scroll into view (`scrollTop` 721, then 1400) |
| Navigating to an already-visible item | `scrollTop` unchanged, **0** `scrollTo()` calls |
| Manual scroll to 400, then navigate | new active item brought into view (`scrollTop` 241) |
| Window scrolling | `window.scrollY` 0 → 0 while the container scrolled 0 → 1321 |
| Mount with a deep active item | scrolled into view — full-load behavior preserved |

Worth a maintainer's eye on real content: the `MutationObserver` scope, in case there are table-of-contents attribute updates I have not anticipated.