### PR TITLE
Remove CODEOWNERS file for API data cache functions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# Changes to the API data cache functions can invalidate all existing data cache
-# causing a massive amount of revalidation, impacting our API.
-packages/gitbook/src/lib/data/api.ts   @SamyPesse


### PR DESCRIPTION
Eliminate the CODEOWNERS file associated with API data cache functions to streamline ownership management.