### PR TITLE
Evaluate <if> blocks when serving markdown pages

### DIFF
--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -430,6 +430,7 @@ const getRevisionPageMarkdown = cache(
                         {
                             format: 'markdown',
                             'format.markdown.refs': 'stable',
+                            evaluated: 'deterministic-only',
                             metadata: false,
                         },
                         {


### PR DESCRIPTION
  This PR aims to resolve in-page `<if>` blocks in the markdown version of a page instead of emitting them raw. This is the last change needed to fully add support for the new `visitor.type` property.