### PR TITLE
Hide the section tabs scroll button when all tabs already fit

### DIFF
--- a/.changeset/section-tabs-phantom-scroll.md
+++ b/.changeset/section-tabs-phantom-scroll.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Stop the section tabs in the header from showing a scroll button and faded edge when all tabs already fit.

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -79,9 +79,9 @@ export function SiteSectionTabs(props: {
             >
                 <NavigationMenu.List
                     className={tcls(
-                        '-mx-3 flex grow gap-2 bg-transparent',
-                        'pl-4 sm:pl-6 md:pl-8',
-                        !children ? 'pr-4 sm:pr-6 md:pr-8' : 'pr-4'
+                        'flex grow gap-2 bg-transparent',
+                        'pl-1 sm:pl-3 md:pl-5',
+                        !children ? 'pr-1 sm:pr-3 md:pr-5' : 'pr-1'
                     )}
                     aria-label="Sections"
                     data-gb-sections


### PR DESCRIPTION
## Overview

- The header's section tabs offset each tab's own `0.75rem` padding with `-mx-3` while keeping the full container padding. A negative *end* margin counts as scrollable overflow, so the row reported a permanent 12px of scroll: the right edge stayed faded and hovering the tabs revealed a scroll button that scrolled nowhere (RND-12536).
- **Why it started now:** the `-mx-3` has been there since #3655 (Sept 2025) but was inert. Radix's `NavigationMenu.List` wrapped the `<ul>` in an indicator-track `<div>`, so the list was never the scroller's flex item and `grow` did nothing — the outdent stayed hundreds of pixels inside the scrollport. #4499 swapped in Base UI, which renders the list element directly, so `grow` began stretching it to fill the scrollport and the outdent started landing 12px past the edge. Verified by re-inserting a Radix-shaped wrapper on the live page: overflow drops from 12px to 0.
- Folded the offset into the padding (`pl-1 sm:pl-3 md:pl-5` / `pr-1 sm:pr-3 md:pr-5`) — what this list used before the `ScrollContainer` refactor. When the tabs fit, insets are pixel-identical at every breakpoint and `scrollWidth` now equals `clientWidth`.

Two intended consequences, both of which restore behaviour the phantom overflow was masking:

- On rows that genuinely overflow, the gap between the last tab and the edge at full scroll goes 16px → 4px, matching the leading gap (the asymmetry predates #4499).
- On sites with multiple translations, the divider between the tabs and the language dropdown is gated on the row being scrollable, so it was permanently visible; it now appears only when the tabs actually scroll.

## Demo

Hovering the section tabs on [apryse.gitbook.io/apryse-docs/web](https://apryse.gitbook.io/apryse-docs/web) at 1400px, where all six tabs fit.

**Before** — a scroll button appears at the right edge, with nothing to scroll to:

[![section-tabs.png](https://files.argos-ci.com/media/20307/eac8ad9f3e2f975deec40f5852db8e83ca04274afb71b501ec0d688564fd1374.webp)](https://app.argos-ci.com/m/akxtsq8yrafvbttmi5hz)

**After** — no scroll button, no faded edge:

[![section-tabs.png](https://files.argos-ci.com/media/20307/ee10bdd3e440747cb393e388024ebaecdc281247f210a55962c87ebb8255e45b.webp)](https://app.argos-ci.com/m/37f4f6s21do17811h8kd)

*— Authored by Claude*
