### PR TITLE
Fix the gap between columns in large section group dropdowns

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Let a section group dropdown scroll when it is taller than the screen

--- a/.changeset/tidy-spoons-repeat.md
+++ b/.changeset/tidy-spoons-repeat.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Remove the gap between the columns of a section group dropdown holding a large group

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -21,6 +21,8 @@ const SCREEN_OFFSET = 16; // 1rem
 const POPUP_OFFSET = 4;
 const OPEN_DELAY_MS = 200;
 const MOTION = 'duration-300 ease-[cubic-bezier(0.83,0,0.17,1)]';
+// Bounds the scrolling content too: the popup settles at `height: auto`, so `h-full` doesn't.
+const MAX_POPUP_HEIGHT = 'max-h-[calc(100vh-8rem)]';
 const MAX_ITEMS_PER_COLUMN = 10; // number of items per column
 const GROUP_MASONRY_THRESHOLD = 3; // if a section group has more than this many child groups, it will be shown in a masonry grid
 const COLUMN_WIDTH = '18rem';
@@ -109,6 +111,7 @@ export function SiteSectionTabs(props: {
                                         <NavigationMenu.Content
                                             className={tcls(
                                                 'h-full w-[calc(100vw-2rem)] overflow-y-auto overflow-x-hidden md:w-max md:max-w-(--available-width)',
+                                                MAX_POPUP_HEIGHT,
                                                 `transition-[opacity,translate] ${MOTION}`,
                                                 'data-ending-style:opacity-0 data-starting-style:opacity-0',
                                                 'data-starting-style:data-[activation-direction=left]:-translate-x-1/2 data-ending-style:data-[activation-direction=left]:translate-x-1/2',
@@ -159,7 +162,8 @@ export function SiteSectionTabs(props: {
                 >
                     <NavigationMenu.Popup
                         className={tcls(
-                            'relative h-(--popup-height) max-h-[calc(100vh-8rem)] w-(--popup-width) origin-(--transform-origin) overflow-hidden circular-corners:rounded-3xl rounded-corners:rounded-xl border border-tint bg-tint-base shadow-lg outline-hidden',
+                            'relative h-(--popup-height) w-(--popup-width) origin-(--transform-origin) overflow-hidden circular-corners:rounded-3xl rounded-corners:rounded-xl border border-tint bg-tint-base shadow-lg outline-hidden',
+                            MAX_POPUP_HEIGHT,
                             // `scale` rather than `transform`: that is what `scale-95` sets.
                             `transition-[opacity,scale,width,height] ${MOTION}`,
                             // The size vars reset on close, so animating them out collapses the
@@ -222,7 +226,11 @@ function SectionGroupTileList(props: {
     const hasSections = sections.length > 0;
     const hasGroups = groups.length > 0;
     const isMasonryLayout = groups.length > GROUP_MASONRY_THRESHOLD;
-    const masonryColumnCount = Math.min(Math.ceil(groups.length / 2), MAX_MASONRY_COLUMNS);
+    const masonryRows = groups.reduce((total, group) => total + 1 + group.children.length, 0); // title + sections
+    const masonryColumnCount = Math.min(
+        Math.max(Math.ceil(groups.length / 2), Math.ceil(masonryRows / MAX_ITEMS_PER_COLUMN)),
+        MAX_MASONRY_COLUMNS
+    );
 
     return (
         <div className="flex w-full flex-col md:flex-row">
@@ -277,6 +285,8 @@ function SectionGroupTileList(props: {
                                 key={group.id}
                                 child={group}
                                 currentSection={currentSection}
+                                isMasonry={isMasonryLayout}
+                                invertIcon={hasSections}
                             />
                         ))}
                     </ul>
@@ -293,8 +303,10 @@ function SectionGroupTile(props: {
     child: ClientSiteSection | ClientSiteSectionGroup;
     currentSection: ClientSiteSection;
     invertIcon?: boolean;
+    /** Whether the tile is a top-level group of the dropdown's masonry layout. */
+    isMasonry?: boolean;
 }) {
-    const { child, currentSection, invertIcon } = props;
+    const { child, currentSection, invertIcon, isMasonry } = props;
 
     if (child.object === 'site-section') {
         const { url, icon, title, description } = child;
@@ -341,18 +353,32 @@ function SectionGroupTile(props: {
     // Handle nested section group
     const { title, icon, children } = child;
 
+    // Multi-column sizes every column to the widest, so a wide group spans instead of stretching them all.
+    const spansMasonry = Boolean(isMasonry) && children.length > MAX_ITEMS_PER_COLUMN;
+
     return (
-        <li className="flex w-full min-w-0 shrink-0 break-inside-avoid flex-col gap-1 md:w-auto">
-            <div className="mb-1 mt-2 flex min-w-0 gap-2 px-2.5 text-xs font-semibold text-tint-subtle">
+        <li
+            className={tcls(
+                'flex w-full min-w-0 shrink-0 break-inside-avoid flex-col gap-1 md:w-auto',
+                spansMasonry ? 'md:[column-span:all]' : ''
+            )}
+        >
+            <div className="mb-1 mt-2 flex min-w-0 gap-2 px-2.5 font-heading text-xs font-semibold text-tint-subtle">
                 {icon && (
                     <SectionIcon className="mt-0.5" isActive={false} icon={icon as IconName} />
                 )}
                 <span className="min-w-0 flex-1 whitespace-normal">{title}</span>
             </div>
             <ul
-                className="flex w-full grid-flow-row flex-col gap-x-2 gap-y-0.5 md:grid"
+                className={tcls(
+                    'flex w-full grid-flow-row flex-col gap-x-2 gap-y-0.5 md:grid',
+                    // Reuse the masonry's gap and columns, to stay aligned with the groups around it.
+                    spansMasonry ? 'md:gap-x-[var(--site-section-column-gap)]' : ''
+                )}
                 style={{
-                    gridTemplateColumns: `repeat(${Math.ceil(children.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, auto))`,
+                    gridTemplateColumns: spansMasonry
+                        ? 'repeat(var(--masonry-columns), minmax(0, 1fr))'
+                        : `repeat(${Math.ceil(children.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, auto))`,
                 }}
             >
                 {children.map((nestedChild) => (
@@ -360,7 +386,7 @@ function SectionGroupTile(props: {
                         key={nestedChild.id}
                         child={nestedChild}
                         currentSection={currentSection}
-                        invertIcon={true}
+                        invertIcon={invertIcon}
                     />
                 ))}
             </ul>


### PR DESCRIPTION
## Overview

- A section group with more than 10 sections renders an internal multi-track grid, twice the width of a normal tile column. CSS multi-column sizes every column to the widest one, so that single group stretched the whole dropdown and left a ~300px gap beside the narrower groups.
- Such a group now spans the masonry with `column-span: all` and lays its sections out on the masonry's own columns, so every column stays one tile wide and the popup shrinks to fit. Zoom's "Docs" goes from 1226px to 952px; Thales' "Product Docs" from 1224px to 952px.
- The masonry column count now also counts the sections inside each group, not just the number of groups, so a content-heavy dropdown gets the columns it needs. It can only grow relative to the old formula, so no dropdown gets narrower than before.
- Separately, the popup clipped its content instead of scrolling it. Base UI resets `--popup-height` to `auto` once the open animation settles, and the `h-full` chain down to the scroll container then resolved against an auto height, so the scroller grew to the full content height and had nothing left to scroll. The scrolling content now carries the same max-height as the popup.
- Group titles use the site's heading font, and the section icon chips are only inverted when the panel behind them is tinted — previously they were white-on-white in dropdowns without a sections column.

Verified against every published site in the e2e suite plus Ansys and Zoom. Three dropdowns use the masonry layout: Zoom "Docs" and Thales "Product Docs" both had the gap and are fixed; Ansys "Documentation" has no oversized group and is pixel-identical (4 columns, same 6/4/4/2 split). Checked at 1440px, at a clamped 880px where the columns still line up exactly, below `md` where the dropdown stacks, and in dark mode.

## Demo

**Zoom — "Docs"** · 1226px → 952px

| Before | After |
| --- | --- |
| [![zoom.png](https://files.argos-ci.com/media/20307/a12b9b1ed6968a7325ffc7daf0c8c81b26292b0d8d9f62be9b8d4287b6526e5d.webp)](https://app.argos-ci.com/m/fl7rt46xvhciksulisx6) | [![zoom.png](https://files.argos-ci.com/media/20307/6beb1229126cb416e73fc4dc200a8b7ece5ba08fe0b35f95d96713c767261f15.webp)](https://app.argos-ci.com/m/8pcn2xmxxsqnzq33lgey) |

**Thales — "Product Docs"** · 1224px → 952px

| Before | After |
| --- | --- |
| [![thales.png](https://files.argos-ci.com/media/20307/7c04a574bc979845990513cd333c59f8a951622d65ecc010d29d52a9f281d8e3.webp)](https://app.argos-ci.com/m/awe1kp1tvw6ixigbo8n6) | [![thales.png](https://files.argos-ci.com/media/20307/db8b2898de352ccb4f1bdad896b3b95e3084d2af8c320c25e1739cc308c61d69.webp)](https://app.argos-ci.com/m/bkralryynbc1zrm64ipv) |

**Ansys — "Documentation"** · unchanged, no oversized group

| Before | After |
| --- | --- |
| [![ansys.png](https://files.argos-ci.com/media/20307/09e3c27704c672f544cba72cc06ce4ea02750935bf62a90461bf67a1e9f9af33.webp)](https://app.argos-ci.com/m/gno822wx7cvey6dmqzwy) | [![ansys.png](https://files.argos-ci.com/media/20307/6cc9f83fea49d37c4db3dd3c8cee350c2bfce8c2dd93fd874c3e0d6305040e78.webp)](https://app.argos-ci.com/m/wi76s2ooha9y56tdf5am) |

*— Authored by Claude*
