### PR TITLE
Show loose sections in a section group dropdown as secondary links unless the group starts with one

### DIFF
--- a/.changeset/section-tabs-loose-section-order.md
+++ b/.changeset/section-tabs-loose-section-order.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Show loose sections in a section group dropdown as secondary links unless the group starts with one

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -225,6 +225,8 @@ function SectionGroupTileList(props: {
 
     const hasSections = sections.length > 0;
     const hasGroups = groups.length > 0;
+    // Loose sections only lead when the structure opens with one, otherwise they read as secondary links and trail the groups.
+    const sectionsLead = items[0]?.object === 'site-section';
     const isMasonryLayout = groups.length > GROUP_MASONRY_THRESHOLD;
     const masonryRows = groups.reduce((total, group) => total + 1 + group.children.length, 0); // title + sections
     const masonryColumnCount = Math.min(
@@ -232,65 +234,85 @@ function SectionGroupTileList(props: {
         MAX_MASONRY_COLUMNS
     );
 
+    // Whichever panel comes second is recessed: it carries the divider, the background and inverted tile icons.
+    const sectionsRecessed = hasGroups && !sectionsLead;
+    const groupsRecessed = hasSections && sectionsLead;
+    const RECESSED_PANEL = 'border-tint-subtle bg-tint-subtle max-md:border-t md:border-l';
+
+    // Non-grouped sections. The wrapper spans the dropdown's height, so the list itself can stay content-sized.
+    const sectionsPanel = hasSections ? (
+        <div
+            className={tcls(
+                'w-full shrink-0 md:w-max',
+                hasGroups ? (sectionsRecessed ? RECESSED_PANEL : 'bg-tint-base') : ''
+            )}
+        >
+            <ul
+                className="flex w-full grid-flow-row flex-col gap-x-2 gap-y-0.5 p-3 md:grid md:w-max"
+                style={{
+                    gridTemplateColumns: `repeat(${Math.ceil(sections.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, 1fr))`,
+                }}
+            >
+                {sections.map((section) => (
+                    <SectionGroupTile
+                        key={section.id}
+                        child={section}
+                        currentSection={currentSection}
+                        invertIcon={sectionsRecessed}
+                    />
+                ))}
+            </ul>
+        </div>
+    ) : null;
+
+    // Grouped sections
+    const groupsPanel = hasGroups ? (
+        <div
+            className={tcls(
+                'w-full md:w-max md:min-w-0 md:max-w-full',
+                groupsRecessed ? RECESSED_PANEL : ''
+            )}
+        >
+            <ul
+                className={tcls(
+                    'p-3',
+                    isMasonryLayout
+                        ? 'w-full max-md:space-y-8 md:w-max md:max-w-full md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[&>li]:mb-4'
+                        : 'flex w-full flex-col justify-start space-y-8 md:w-max md:flex-row md:items-start md:gap-[var(--site-section-column-gap)] md:space-y-0'
+                )}
+                style={
+                    isMasonryLayout
+                        ? ({
+                              '--masonry-columns': String(masonryColumnCount),
+                          } as React.CSSProperties)
+                        : undefined
+                }
+            >
+                {groups.map((group) => (
+                    <SectionGroupTile
+                        key={group.id}
+                        child={group}
+                        currentSection={currentSection}
+                        isMasonry={isMasonryLayout}
+                        invertIcon={groupsRecessed}
+                    />
+                ))}
+            </ul>
+        </div>
+    ) : null;
+
     return (
         <div className="flex w-full flex-col md:flex-row">
-            {/* Non-grouped sections */}
-            {hasSections && (
-                <ul
-                    className={tcls(
-                        'flex w-full shrink-0 grid-flow-row flex-col gap-x-2 gap-y-0.5 self-stretch p-3 md:sticky md:top-0 md:grid md:w-max md:self-start',
-                        hasGroups ? 'bg-tint-base' : ''
-                    )}
-                    style={{
-                        gridTemplateColumns: `repeat(${Math.ceil(sections.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, 1fr))`,
-                    }}
-                >
-                    {sections.map((section) => (
-                        <SectionGroupTile
-                            key={section.id}
-                            child={section}
-                            currentSection={currentSection}
-                        />
-                    ))}
-                </ul>
-            )}
-
-            {/* Grouped sections */}
-            {hasGroups && (
-                <div
-                    className={tcls(
-                        'w-full md:w-max md:min-w-0 md:max-w-full',
-                        hasSections
-                            ? 'border-tint-subtle bg-tint-subtle max-md:border-t md:border-l'
-                            : ''
-                    )}
-                >
-                    <ul
-                        className={tcls(
-                            'p-3',
-                            isMasonryLayout
-                                ? 'w-full max-md:space-y-8 md:w-max md:max-w-full md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[&>li]:mb-4'
-                                : 'flex w-full flex-col justify-start space-y-8 md:w-max md:flex-row md:items-start md:gap-[var(--site-section-column-gap)] md:space-y-0'
-                        )}
-                        style={
-                            isMasonryLayout
-                                ? ({
-                                      '--masonry-columns': String(masonryColumnCount),
-                                  } as React.CSSProperties)
-                                : undefined
-                        }
-                    >
-                        {groups.map((group) => (
-                            <SectionGroupTile
-                                key={group.id}
-                                child={group}
-                                currentSection={currentSection}
-                                isMasonry={isMasonryLayout}
-                                invertIcon={hasSections}
-                            />
-                        ))}
-                    </ul>
-                </div>
+            {sectionsLead ? (
+                <>
+                    {sectionsPanel}
+                    {groupsPanel}
+                </>
+            ) : (
+                <>
+                    {groupsPanel}
+                    {sectionsPanel}
+                </>
             )}
         </div>
     );


### PR DESCRIPTION
## Overview

- Section group dropdowns rendered loose sections before the nested groups unconditionally, which reads as a primary list. They now lead only when the group's structure actually opens with a loose section, and otherwise trail the groups as secondary links.
- The panel that comes second is the recessed one, so the divider, `bg-tint-subtle` and inverted tile icons follow the order instead of always landing on the groups.
- The loose sections now sit in a wrapper that spans the dropdown's height, so the recessed background reaches the bottom rather than stopping after the last link. The list keeps its own content height — stretching the grid itself spreads its rows (measured: a 44px row gap becomes 136px).
- That wrapper replaces `md:self-start`, which was both suppressing the row spreading and, as a side effect, making `md:sticky` a no-op. Dropped the sticky rather than start pinning a panel that has never actually pinned.

## Demo

Group whose structure starts with a group, so the loose sections (SDK Reference → Probe SDK) trail:

**Before** — loose sections lead, and their panel stops after the last link:

[![before](https://files.argos-ci.com/media/20307/c0b2bb40d0da2645701e272d219142da31555d030e848facb42f2ee5438d1698.webp)](https://app.argos-ci.com/m/vochq2tflvqp37v78sqf)

**After** — they trail the groups, and the panel spans the dropdown:

[![after](https://files.argos-ci.com/media/20307/48d4108303ce88bd6c717aff934831ea3bbb991ba26b2bc2c26850d9c52b4da4.webp)](https://app.argos-ci.com/m/4t62kkbhe6qbx5by2sqx)

*— Authored by Claude*
