### PR TITLE
Stop suggesting previously asked questions in the GitBook Assistant

### DIFF
--- a/.changeset/assistant-recent-questions.md
+++ b/.changeset/assistant-recent-questions.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Stop showing previously asked questions as suggestions in the GitBook Assistant

--- a/packages/gitbook/src/components/AIChat/AIChatSuggestedQuestions.tsx
+++ b/packages/gitbook/src/components/AIChat/AIChatSuggestedQuestions.tsx
@@ -1,7 +1,5 @@
 import type { AIChatController } from '../AI';
 import { Button } from '../primitives';
-import { useRecentSearchQueries } from '../Search/recent-queries';
-import { useCurrentContent } from '@/components/hooks';
 import { tString, useLanguage } from '@/intl/client';
 
 export default function AIChatSuggestedQuestions(props: {
@@ -9,8 +7,6 @@ export default function AIChatSuggestedQuestions(props: {
     suggestions?: string[];
 }) {
     const language = useLanguage();
-    const { siteSpaceId } = useCurrentContent();
-    const recentQueries = useRecentSearchQueries(siteSpaceId ?? '');
     const { chatController, suggestions: configuredSuggestions } = props;
 
     const defaultSuggestions = [
@@ -18,22 +14,13 @@ export default function AIChatSuggestedQuestions(props: {
         tString(language, 'ai_chat_suggested_questions_read_next'),
         tString(language, 'ai_chat_suggested_questions_example'),
     ];
-    const baseSuggestions =
-        configuredSuggestions && configuredSuggestions.length > 0
-            ? configuredSuggestions
-            : defaultSuggestions;
-
-    const suggestions = [
-        ...recentQueries.filter((entry) => entry.action === 'ask').map((entry) => entry.query),
-        ...baseSuggestions,
-    ].reduce<string[]>((acc, suggestion) => {
-        if (acc.includes(suggestion)) {
-            return acc;
-        }
-
-        acc.push(suggestion);
-        return acc;
-    }, []);
+    const suggestions = Array.from(
+        new Set(
+            configuredSuggestions && configuredSuggestions.length > 0
+                ? configuredSuggestions
+                : defaultSuggestions
+        )
+    );
 
     return (
         <div


### PR DESCRIPTION
## Overview

- Stop mixing recent "ask" queries into the GitBook Assistant's suggested questions, so a one-off question a visitor typed no longer comes back as a recommendation the next time the Assistant is opened.
- The Assistant now only offers the site's configured suggestions, falling back to the three defaults when none are configured.
- Search is untouched: asked questions are still recorded in `localStorage` and still surface there as recent queries.

Fixes RND-12511.

## Demo

| Before | After |
| --- | --- |
| [![before](https://files.argos-ci.com/media/20307/d84b2c8a3bd0f4661d9911319b6f2bb8fd76c736b292c872d0d7bd76ddbae9ba.webp)](https://app.argos-ci.com/m/detn7uww9u7t59wcirvw) | [![after](https://files.argos-ci.com/media/20307/33f758db1ea292f51cb81d7092e0ff424e6cdf5034652ff15356fdb778dbfd46.webp)](https://app.argos-ci.com/m/emxeqw62ksgastfd3zjq) |

*— Authored by Claude*
