### PR TITLE
Keep the section group menu open over the collapsed sidebar rail

### DIFF
--- a/.changeset/section-menu-sidebar-rail.md
+++ b/.changeset/section-menu-sidebar-rail.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the section group menu dismissing while the mouse is still inside it, when the collapsed sidebar rail overlaps the menu on no-sidebar pages.

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -58,15 +58,17 @@ export async function TableOfContents(props: {
                     'lg:mr-12',
                     'lg:z-0',
 
+                    // Keep the fixed rail below the z-30 header, so it doesn't steal
+                    // pointer events from the section tabs dropdown rendered in the header.
                     'layout-wide:no-sidebar:lg:fixed',
                     'layout-wide:no-sidebar:lg:max-3xl:w-12',
                     'layout-wide:no-sidebar:lg:left-5',
-                    'layout-wide:no-sidebar:lg:z-30',
+                    'layout-wide:no-sidebar:lg:z-29',
 
                     'layout-default:no-sidebar:lg:max-xl:fixed',
                     'layout-default:no-sidebar:lg:max-xl:w-12',
                     'layout-default:no-sidebar:lg:max-xl:left-5',
-                    'layout-default:no-sidebar:lg:max-xl:z-30',
+                    'layout-default:no-sidebar:lg:max-xl:z-29',
 
                     // Server-side static positioning
                     'lg:top-0',

--- a/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/gitbook/src/components/TableOfContents/TableOfContents.tsx
@@ -58,8 +58,6 @@ export async function TableOfContents(props: {
                     'lg:mr-12',
                     'lg:z-0',
 
-                    // Keep the fixed rail below the z-30 header, so it doesn't steal
-                    // pointer events from the section tabs dropdown rendered in the header.
                     'layout-wide:no-sidebar:lg:fixed',
                     'layout-wide:no-sidebar:lg:max-3xl:w-12',
                     'layout-wide:no-sidebar:lg:left-5',


### PR DESCRIPTION
Fixes [RND-12602](https://linear.app/gitbook-x/issue/RND-12602/section-group-menu-dismisses-before-mouse-leaves-menu): the invisible collapsed sidebar rail (z-30, same as the header) was stealing pointer events from section group dropdowns overlapping it, dismissing them while the mouse was still inside.