### PR TITLE
Keep section group dropdown columns readable when space is tight

### DIFF
--- a/.changeset/olive-melons-repeat.md
+++ b/.changeset/olive-melons-repeat.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Drop a column instead of shrinking them all when a section group dropdown runs out of room

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -284,7 +284,7 @@ function SectionGroupTileList(props: {
                 className={tcls(
                     'p-3',
                     isMasonryLayout
-                        ? 'w-full max-md:space-y-8 md:w-max md:max-w-[min(100%,var(--masonry-max-width))] md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[column-width:var(--site-section-column-min-width)] md:[&>li]:mb-4'
+                        ? 'w-full max-md:space-y-8 md:max-w-[var(--masonry-max-width)] md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[column-width:var(--site-section-column-min-width)] md:[&>li]:mb-4'
                         : 'flex w-full flex-col justify-start space-y-8 md:w-max md:flex-row md:items-start md:gap-[var(--site-section-column-gap)] md:space-y-0'
                 )}
                 style={
@@ -292,7 +292,8 @@ function SectionGroupTileList(props: {
                         ? ({
                               '--masonry-columns': String(masonryColumnCount),
                               // Tiles fill their column here, so the list carries the width cap
-                              // they would otherwise have given it.
+                              // they would otherwise have given it. Kept free of percentages, or
+                              // it stops capping what the list asks the panel around it for.
                               '--masonry-max-width': `calc(${masonryColumnCount} * ${COLUMN_WIDTH} + ${masonryColumnCount - 1} * ${COLUMN_GAP} + ${COLUMN_PADDING})`,
                               '--site-section-tile-max-width': 'none',
                           } as React.CSSProperties)

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -27,9 +27,10 @@ const MAX_ITEMS_PER_COLUMN = 10; // number of items per column
 const GROUP_MASONRY_THRESHOLD = 3; // if a section group has more than this many child groups, it will be shown in a masonry grid
 const COLUMN_WIDTH = '18rem';
 // Floor for a column, so a dropdown squeezed by the sections panel or the screen drops a column
-// instead of shrinking them all. Stays under COLUMN_WIDTH, or it would widen roomy dropdowns.
-const COLUMN_MIN_WIDTH = '14rem';
+// instead of shrinking them all.
+const COLUMN_MIN_WIDTH = '16rem';
 const COLUMN_GAP = '2rem';
+const COLUMN_PADDING = '1.5rem'; // the p-3 on the lists holding the columns
 const MAX_MASONRY_COLUMNS = 4;
 
 /**
@@ -63,6 +64,8 @@ export function SiteSectionTabs(props: {
                     '--site-section-column-width': COLUMN_WIDTH,
                     '--site-section-column-min-width': COLUMN_MIN_WIDTH,
                     '--site-section-column-gap': COLUMN_GAP,
+                    // Lifted so the masonry can drop it and let a tile fill a column instead.
+                    '--site-section-tile-max-width': COLUMN_WIDTH,
                 } as React.CSSProperties
             }
             delay={OPEN_DELAY_MS}
@@ -281,13 +284,17 @@ function SectionGroupTileList(props: {
                 className={tcls(
                     'p-3',
                     isMasonryLayout
-                        ? 'w-full max-md:space-y-8 md:w-max md:max-w-full md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[column-width:var(--site-section-column-min-width)] md:[&>li]:mb-4'
+                        ? 'w-full max-md:space-y-8 md:w-max md:max-w-[min(100%,var(--masonry-max-width))] md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[column-width:var(--site-section-column-min-width)] md:[&>li]:mb-4'
                         : 'flex w-full flex-col justify-start space-y-8 md:w-max md:flex-row md:items-start md:gap-[var(--site-section-column-gap)] md:space-y-0'
                 )}
                 style={
                     isMasonryLayout
                         ? ({
                               '--masonry-columns': String(masonryColumnCount),
+                              // Tiles fill their column here, so the list carries the width cap
+                              // they would otherwise have given it.
+                              '--masonry-max-width': `calc(${masonryColumnCount} * ${COLUMN_WIDTH} + ${masonryColumnCount - 1} * ${COLUMN_GAP} + ${COLUMN_PADDING})`,
+                              '--site-section-tile-max-width': 'none',
                           } as React.CSSProperties)
                         : undefined
                 }
@@ -338,7 +345,7 @@ function SectionGroupTile(props: {
         const { url, icon, title, description } = child;
         const isActive = child.id === currentSection.id;
         return (
-            <li className="group/section-tile flex w-full min-w-0 shrink-0 grow md:max-w-[var(--site-section-column-width)]">
+            <li className="group/section-tile flex w-full min-w-0 shrink-0 grow md:max-w-[var(--site-section-tile-max-width)]">
                 <Link
                     href={url}
                     className={tcls(

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -117,7 +117,7 @@ export function SiteSectionTabs(props: {
                                         />
                                         <NavigationMenu.Content
                                             className={tcls(
-                                                'h-full w-[calc(100vw-2rem)] overflow-y-auto overflow-x-hidden md:w-max md:max-w-(--available-width)',
+                                                'h-full w-full overflow-y-auto overflow-x-hidden md:w-max md:max-w-(--available-width)',
                                                 MAX_POPUP_HEIGHT,
                                                 `transition-[opacity,translate] ${MOTION}`,
                                                 'data-ending-style:opacity-0 data-starting-style:opacity-0',
@@ -170,6 +170,9 @@ export function SiteSectionTabs(props: {
                     <NavigationMenu.Popup
                         className={tcls(
                             'relative h-(--popup-height) w-(--popup-width) origin-(--transform-origin) overflow-hidden circular-corners:rounded-3xl rounded-corners:rounded-xl border border-tint bg-tint-base shadow-lg outline-hidden',
+                            // Sized here rather than on the content, so the border doesn't push the
+                            // content off-centre and eat the padding down one side.
+                            'max-md:w-[calc(100vw-2rem)]',
                             MAX_POPUP_HEIGHT,
                             // `scale` rather than `transform`: that is what `scale-95` sets.
                             `transition-[opacity,scale,width,height] ${MOTION}`,

--- a/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
+++ b/packages/gitbook/src/components/SiteSections/SiteSectionTabs.tsx
@@ -26,6 +26,9 @@ const MAX_POPUP_HEIGHT = 'max-h-[calc(100vh-8rem)]';
 const MAX_ITEMS_PER_COLUMN = 10; // number of items per column
 const GROUP_MASONRY_THRESHOLD = 3; // if a section group has more than this many child groups, it will be shown in a masonry grid
 const COLUMN_WIDTH = '18rem';
+// Floor for a column, so a dropdown squeezed by the sections panel or the screen drops a column
+// instead of shrinking them all. Stays under COLUMN_WIDTH, or it would widen roomy dropdowns.
+const COLUMN_MIN_WIDTH = '14rem';
 const COLUMN_GAP = '2rem';
 const MAX_MASONRY_COLUMNS = 4;
 
@@ -58,6 +61,7 @@ export function SiteSectionTabs(props: {
             style={
                 {
                     '--site-section-column-width': COLUMN_WIDTH,
+                    '--site-section-column-min-width': COLUMN_MIN_WIDTH,
                     '--site-section-column-gap': COLUMN_GAP,
                 } as React.CSSProperties
             }
@@ -277,7 +281,7 @@ function SectionGroupTileList(props: {
                 className={tcls(
                     'p-3',
                     isMasonryLayout
-                        ? 'w-full max-md:space-y-8 md:w-max md:max-w-full md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[&>li]:mb-4'
+                        ? 'w-full max-md:space-y-8 md:w-max md:max-w-full md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[column-width:var(--site-section-column-min-width)] md:[&>li]:mb-4'
                         : 'flex w-full flex-col justify-start space-y-8 md:w-max md:flex-row md:items-start md:gap-[var(--site-section-column-gap)] md:space-y-0'
                 )}
                 style={
@@ -393,15 +397,20 @@ function SectionGroupTile(props: {
             </div>
             <ul
                 className={tcls(
-                    'flex w-full grid-flow-row flex-col gap-x-2 gap-y-0.5 md:grid',
-                    // Reuse the masonry's gap and columns, to stay aligned with the groups around it.
-                    spansMasonry ? 'md:gap-x-[var(--site-section-column-gap)]' : ''
+                    'flex w-full flex-col gap-x-2 gap-y-0.5',
+                    spansMasonry
+                        ? // Same track sizing as the masonry it spans, so its sections line up with the
+                          // groups around it however many columns the width allows.
+                          'md:block md:gap-x-[var(--site-section-column-gap)] md:[column-count:var(--masonry-columns)] md:[column-width:var(--site-section-column-min-width)] md:[&>li]:mb-0.5 md:[&>li]:break-inside-avoid'
+                        : 'grid-flow-row md:grid'
                 )}
-                style={{
-                    gridTemplateColumns: spansMasonry
-                        ? 'repeat(var(--masonry-columns), minmax(0, 1fr))'
-                        : `repeat(${Math.ceil(children.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, auto))`,
-                }}
+                style={
+                    spansMasonry
+                        ? undefined
+                        : {
+                              gridTemplateColumns: `repeat(${Math.ceil(children.length / MAX_ITEMS_PER_COLUMN)}, minmax(0, auto))`,
+                          }
+                }
             >
                 {children.map((nestedChild) => (
                     <SectionGroupTile


### PR DESCRIPTION
## Overview

- The masonry only set `column-count`, so a dropdown squeezed by the loose sections panel or by a narrow screen split whatever width was left into the same number of columns. At 1024px that was 140px columns; at 800px, 84px columns wrapping two words per line, with a spanning group overflowing its band by up to 46px.
- Pair the count with a `column-width` floor of `14rem`. Multi-column then uses as many columns as the width actually allows, so columns never fall below that floor. The floor sits under the `18rem` tile width, so any dropdown with room to spare keeps exactly the width and column count it has today.
- A spanning group now lays its sections out in a nested multi-column with the same count and floor, instead of a grid of a fixed track count. Both resolve the same used count from the same width, so its sections stay aligned with the groups around it at every width — and they now read down a column rather than across a row.

### On the container query

I tried that first, and it can't work here: `container-type: inline-size` implies inline-size containment, and the groups panel is `w-max` inside a shrink-to-fit popup. Making it a container collapses it — measured 1272px → 0.

`column-width` gets at the same thing without the containment. It resolves against the groups panel's own content box, so a leading or trailing sections panel is already discounted exactly as a container query would, and it adapts continuously rather than at breakpoints.

## Demo

Zoom "Docs" at a 1024px viewport, where the loose sections panel takes ~310px of the popup:

| Before | After |
| --- | --- |
| [![zoom.png](https://files.argos-ci.com/media/20307/b4afee5f97db5e98260b37eb90739c9e9664697b0c00b34ed84441f5406e6317.webp)](https://app.argos-ci.com/m/nb11wuagz8uu714m67w5) | [![zoom.png](https://files.argos-ci.com/media/20307/49ea7acdecfdb354ca213e6c639ba120930d63628b8f4fcad4cfc507f6074683.webp)](https://app.argos-ci.com/m/t9a2xzel4blkwc13ig4m) |

Ansys "Documentation", same viewport:

| Before | After |
| --- | --- |
| [![ansys.png](https://files.argos-ci.com/media/20307/517baae632ed0c1632d86242c0787260ab369cf4cfafd77a12c824a21024472e.webp)](https://app.argos-ci.com/m/rzw7d8jv8s8amr156jse) | [![ansys.png](https://files.argos-ci.com/media/20307/a23718a12c4ae54477c5c4efa7713ed71b72d44970222609f6b2bba0d95e9103.webp)](https://app.argos-ci.com/m/dfc2xz9cjn82w9mzzbgv) |

Measured across widths — column width in px, used column count in brackets:

| | 1600 | 1280 | 1024 | 900 | 800 |
| --- | --- | --- | --- | --- | --- |
| Zoom — before | 284 (4) | 204 (4) | 140 (4) | 109 (4) | 84 (4) |
| Zoom — after | 284 (4) | 282 (3) | 312 (2) | 250 (2) | 431 (1) |
| Ansys — before | 266 (4) | 204 (4) | 140 (4) | 109 (4) | 84 (4) |
| Ansys — after | 266 (4) | 283 (3) | 312 (2) | 250 (2) | 431 (1) |
| Thales — before | 288 (3) | 288 (3) | 288 (3) | 260 (3) | 227 (3) |
| Thales — after | 288 (3) | 288 (3) | 288 (3) | 260 (3) | 227 (3) |

Widest sizes are unchanged, Thales is unchanged at every width (it never gets squeezed below the floor), and the horizontal overflow Zoom had at 900/800px is gone. Below `md` the dropdown still stacks into a single column.

*— Authored by Claude*
