### PR TITLE
Stop expecting a cookies dialog in the faq.wanttopay.net e2e test

### DIFF
--- a/packages/gitbook/e2e/customers.spec.ts
+++ b/packages/gitbook/e2e/customers.spec.ts
@@ -396,7 +396,7 @@ const testCases: TestsCase[] = [
     {
         name: 'faq.wanttopay.net/wanttopay-app',
         contentBaseURL: 'https://faq.wanttopay.net',
-        tests: [{ name: 'Home', url: '/wanttopay-app', run: waitForCookiesDialog }],
+        tests: [{ name: 'Home', url: '/wanttopay-app' }],
     },
     {
         name: 'guide.prismlive.com',


### PR DESCRIPTION
## Overview

- `faq.wanttopay.net` no longer shows a cookies dialog, so `waitForCookiesDialog` sat through its 10s timeout on every run and then failed the case on a missing element.
- Drop `run` from that test case. The page is still loaded and checked like the other entries that don't pass a `run`.
- `waitForCookiesDialog` stays — plenty of other cases still rely on it.

Confirmed with a fresh browser profile (no stored consent): `faq.wanttopay.net/wanttopay-app` renders no `cookies-dialog` element at all, while `documentation.gravitee.io` still renders and shows one — so the helper itself is fine, the site simply dropped its banner.