### PR TITLE
Stop expecting the cookies dialog on faq.wanttopay.net

### DIFF
--- a/packages/gitbook/e2e/customers.spec.ts
+++ b/packages/gitbook/e2e/customers.spec.ts
@@ -396,7 +396,8 @@ const testCases: TestsCase[] = [
     {
         name: 'faq.wanttopay.net/wanttopay-app',
         contentBaseURL: 'https://faq.wanttopay.net',
-        tests: [{ name: 'Home', url: '/wanttopay-app', run: waitForCookiesDialog }],
+        // The site no longer shows the cookies dialog (customer disabled cookie tracking).
+        tests: [{ name: 'Home', url: '/wanttopay-app' }],
     },
     {
         name: 'guide.prismlive.com',


### PR DESCRIPTION
The customer disabled cookie tracking, so the cookies dialog no longer renders on their site and the customer e2e test failed on every run since 2026-08-25; drop the stale assertion, keep the screenshot coverage.