### PR TITLE
Fix published search scope fusion

### DIFF
--- a/.changeset/filter-published-search-scope.md
+++ b/.changeset/filter-published-search-scope.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Keep published search results within the selected site-space scope during local and remote result fusion.

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
@@ -156,6 +156,7 @@ function transformSitePageResult(args: {
         href: pageHref,
         pageId: pageItem.id,
         spaceId: spaceItem.id,
+        siteSpaceId: siteSpace?.id,
         score: pageItem.score,
         rank: pageItem.rank,
         resultType: pageItem.resultType,

--- a/packages/gitbook/src/components/Search/reciprocalRankFusion.test.ts
+++ b/packages/gitbook/src/components/Search/reciprocalRankFusion.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from 'bun:test';
 
-import { type MergedPageResult, getResultKey, reciprocalRankFusion } from './reciprocalRankFusion';
+import {
+    type MergedPageResult,
+    fuseSearchResults,
+    getResultKey,
+    reciprocalRankFusion,
+} from './reciprocalRankFusion';
 import type { OrderedComputedResult } from './search-types';
 import type { LocalPageResult } from './useLocalSearchResults';
 
-function localPage(id: string, title = id): LocalPageResult {
+function localPage(id: string, title = id, siteSpaceId = 'site-space-alpha'): LocalPageResult {
     return {
         type: 'local-page',
         id,
+        siteSpaceId,
         title,
         pathname: `/${id}`,
         description: `Local description for ${title}`,
@@ -15,12 +21,20 @@ function localPage(id: string, title = id): LocalPageResult {
     };
 }
 
-function remotePage(id: string, title = id, score = 0, rank = 1): OrderedComputedResult {
+function remotePage(
+    id: string,
+    title = id,
+    score = 0,
+    rank = 1,
+    spaceId = 'space-alpha',
+    siteSpaceId = 'site-space-alpha'
+): OrderedComputedResult {
     return {
         type: 'page',
         id: `remote-${id}`,
         pageId: id,
-        spaceId: 'space',
+        spaceId,
+        siteSpaceId,
         title,
         description: `Remote description for ${title}`,
         href: `/${id}`,
@@ -136,5 +150,90 @@ describe('reciprocalRankFusion', () => {
         expect(results.map(getResultKey).filter((key) => key === 'record:record-1')).toHaveLength(
             1
         );
+    });
+});
+
+describe('fuseSearchResults', () => {
+    it('filters every source to the current site space before fusion', () => {
+        const results = fuseSearchResults({
+            localResults: [
+                localPage('local-alpha', 'Alpha local result'),
+                localPage('remote-alpha-1', 'Beta local result', 'site-space-beta'),
+            ],
+            remoteResults: [
+                remotePage('remote-alpha-1', 'Alpha remote one', 10, 1),
+                remotePage(
+                    'local-alpha',
+                    'Beta remote result',
+                    9,
+                    2,
+                    'space-beta',
+                    'site-space-beta'
+                ),
+                remotePage('remote-alpha-2', 'Alpha remote two', 8, 3),
+            ],
+            query: 'result',
+            allowedSiteSpaceIds: ['site-space-alpha'],
+        });
+
+        expect(results.map(getResultKey)).toEqual([
+            'page:remote-alpha-1',
+            'page:remote-alpha-2',
+            'page:local-alpha',
+        ]);
+        expect(results[0]).not.toHaveProperty('pathname');
+        expect(results[2]?.type).toBe('local-page');
+    });
+
+    it('preserves cross-site-space results when the search is unrestricted', () => {
+        const results = fuseSearchResults({
+            localResults: [
+                localPage('local-alpha', 'Alpha local result'),
+                localPage('local-beta', 'Beta local result', 'site-space-beta'),
+            ],
+            remoteResults: [
+                remotePage('remote-alpha', 'Alpha remote result', 10, 1),
+                remotePage(
+                    'remote-beta',
+                    'Beta remote result',
+                    9,
+                    2,
+                    'space-beta',
+                    'site-space-beta'
+                ),
+            ],
+            query: 'result',
+        });
+
+        expect(results.map(getResultKey)).toEqual([
+            'page:remote-alpha',
+            'page:remote-beta',
+            'page:local-alpha',
+            'page:local-beta',
+        ]);
+    });
+
+    it('preserves every allowed site space in an intentionally multi-space search', () => {
+        const results = fuseSearchResults({
+            localResults: [
+                localPage('local-alpha'),
+                localPage('local-beta', 'local-beta', 'site-space-beta'),
+                localPage('local-gamma', 'local-gamma', 'site-space-gamma'),
+            ],
+            remoteResults: [
+                remotePage('remote-alpha'),
+                remotePage('remote-beta', 'remote-beta', 0, 2, 'space-beta', 'site-space-beta'),
+                remotePage('remote-gamma', 'remote-gamma', 0, 3, 'space-gamma', 'site-space-gamma'),
+            ],
+            query: 'page',
+            allowedSiteSpaceIds: ['site-space-alpha', 'site-space-beta'],
+        });
+
+        expect(results.map(getResultKey)).toEqual([
+            'page:remote-alpha',
+            'page:remote-beta',
+            'page:local-alpha',
+            'page:local-beta',
+        ]);
     });
 });

--- a/packages/gitbook/src/components/Search/reciprocalRankFusion.ts
+++ b/packages/gitbook/src/components/Search/reciprocalRankFusion.ts
@@ -102,6 +102,32 @@ export function getResultKey(
 
 type RRFResult = LocalPageResult | OrderedComputedResult | MergedPageResult;
 
+/** Filter page candidates at the final assembly boundary, immediately before ranking and fusion. */
+export function fuseSearchResults(args: {
+    localResults: LocalPageResult[];
+    remoteResults: OrderedComputedResult[];
+    query: string;
+    allowedSiteSpaceIds?: string[];
+}): RRFResult[] {
+    const { localResults, remoteResults, query, allowedSiteSpaceIds } = args;
+
+    if (!allowedSiteSpaceIds) {
+        return reciprocalRankFusion(localResults, remoteResults, query);
+    }
+
+    const allowed = new Set(allowedSiteSpaceIds);
+
+    return reciprocalRankFusion(
+        localResults.filter((result) => allowed.has(result.siteSpaceId)),
+        remoteResults.filter(
+            (result) =>
+                result.type === 'record' ||
+                (result.siteSpaceId !== undefined && allowed.has(result.siteSpaceId))
+        ),
+        query
+    );
+}
+
 function mergeLocalPageWithRemotePage(
     localResult: LocalPageResult,
     remoteResult: ComputedPageResult

--- a/packages/gitbook/src/components/Search/search-types.ts
+++ b/packages/gitbook/src/components/Search/search-types.ts
@@ -20,6 +20,8 @@ export type ComputedPageResult = BaseComputedResult & {
     type: 'page';
     pageId: string;
     spaceId: string;
+    /** Site-space owning this result, used to enforce the client-side search scope. */
+    siteSpaceId?: string;
     /** Page-level description for a page-root search destination. */
     description: string;
     /** Canonical one-based relevance position assigned by the search backend. */

--- a/packages/gitbook/src/components/Search/useLocalSearchResults.tsx
+++ b/packages/gitbook/src/components/Search/useLocalSearchResults.tsx
@@ -24,6 +24,7 @@ interface IndexPage {
 export interface LocalPageResult {
     type: 'local-page';
     id: string;
+    siteSpaceId: string;
     title: string;
     pathname: string;
     icon?: string;
@@ -242,6 +243,7 @@ export function useLocalSearchResults(props: {
                     results.push({
                         type: 'local-page',
                         id: doc.id,
+                        siteSpaceId: doc.siteSpaceId,
                         title: doc.title,
                         pathname: extra?.pathname ?? '',
                         icon: extra?.icon,

--- a/packages/gitbook/src/components/Search/useSearchResults.ts
+++ b/packages/gitbook/src/components/Search/useSearchResults.ts
@@ -10,7 +10,7 @@ import {
 } from './empty-search-results';
 import { computeFilterSiteSpaceIds } from './filter';
 import { useRecentSearchQueries } from './recent-queries';
-import { type MergedPageResult, reciprocalRankFusion } from './reciprocalRankFusion';
+import { type MergedPageResult, fuseSearchResults } from './reciprocalRankFusion';
 import { computeRemoteSearchScope } from './remote-scope';
 import type { OrderedComputedResult, SearchSiteContentScope } from './search-types';
 import { streamRecommendedQuestions } from './server-actions';
@@ -298,8 +298,22 @@ export function useSearchResults(props: {
             });
         }
 
-        return reciprocalRankFusion(localResults, remoteState.results, query);
-    }, [localResults, remoteState.results, query, withAI, siteSpaceId, suggestions, recentQueries]);
+        return fuseSearchResults({
+            localResults,
+            remoteResults: remoteState.results,
+            query,
+            allowedSiteSpaceIds: filterSiteSpaceIds,
+        });
+    }, [
+        localResults,
+        remoteState.results,
+        query,
+        filterSiteSpaceIds,
+        withAI,
+        siteSpaceId,
+        suggestions,
+        recentQueries,
+    ]);
 
     return {
         results,


### PR DESCRIPTION
## Changes

- carry site-space ownership through local and remote published-search candidates
- filter restricted searches at the final assembly boundary before pinning, deduplication, and reciprocal-rank fusion
- preserve unrestricted and intentionally multi-space result fusion

## Testing

- `cd packages/gitbook && bun test src/components/Search/reciprocalRankFusion.test.ts src/components/Search/filter.test.ts src/components/Search/remote-scope.test.ts`
- `bun run format`
- `bun run lint`
- `bun run typecheck --filter gitbook`