### PR TITLE
Chunk oversized visitor authentication cookies

### DIFF
--- a/.changeset/chunk-visitor-auth-cookie.md
+++ b/.changeset/chunk-visitor-auth-cookie.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Chunk oversized visitor auth cookies to fix an infinite redirect loop when the visitor token exceeds the browser cookie size limit.

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -1656,6 +1656,71 @@ const testCases: TestsCase[] = [
         ],
     },
     {
+        name: 'Visitor Auth - Space (oversized token)',
+        contentBaseURL: 'https://gitbook.gitbook.io/gbo-va-space/',
+        // Our Cloudflare stack still folds multiple Set-Cookie headers into one,
+        // breaking chunked cookies (variant of opennextjs-cloudflare#501).
+        skip: process.env.ARGOS_BUILD_NAME === 'v2-cloudflare',
+        tests: [
+            {
+                name: 'Oversized token is chunked into cookies and survives navigation',
+                url: () => {
+                    const privateKey = '70b844d0-c519-4532-8586-5970ce48c537';
+                    const token = jwt.sign(
+                        {
+                            name: 'gitbook-open-tests',
+                            // Inflate the token above the ~4KB browser cookie limit,
+                            // like an IdP issuing many group claims would.
+                            groups: Array.from(
+                                { length: 60 },
+                                (_, index) => `group-${index}-${'x'.repeat(80)}`
+                            ),
+                        },
+                        privateKey,
+                        {
+                            expiresIn: '24h',
+                        }
+                    );
+                    return `first?jwt_token=${token}`;
+                },
+                run: async (page) => {
+                    await expect(
+                        page.getByRole('heading', { level: 1, name: 'first' })
+                    ).toBeVisible();
+
+                    // The token must be persisted as a chunk-count marker plus chunk cookies.
+                    const cookies = await page.context().cookies();
+                    // Next.js percent-encodes cookie values, so the raw value is `chunks%3A2`.
+                    const marker = cookies.find(
+                        (cookie) =>
+                            cookie.name.startsWith(VISITOR_TOKEN_COOKIE) &&
+                            /^chunks(:|%3A)\d+$/.test(cookie.value)
+                    );
+                    expect(marker).toBeDefined();
+                    const chunks = cookies.filter((cookie) =>
+                        cookie.name.startsWith(`${marker?.name}-`)
+                    );
+                    expect(chunks.length).toBeGreaterThanOrEqual(2);
+
+                    // Navigating without the token must authenticate from the chunked cookie.
+                    // `first` is the space's default page, so the post-sign-in redirect
+                    // canonicalizes to the space root: derive `second` from that base.
+                    const secondURL = new URL(page.url());
+                    const basePathname = secondURL.pathname
+                        .replace(/\/first\/?$/, '')
+                        .replace(/\/$/, '');
+                    secondURL.pathname = `${basePathname}/second`;
+                    secondURL.search = '';
+                    await page.goto(secondURL.toString());
+                    await expect(
+                        page.getByRole('heading', { level: 1, name: 'second' })
+                    ).toBeVisible();
+                },
+                screenshot: false,
+            },
+        ],
+    },
+    {
         name: 'Visitor Auth - Collection',
         contentBaseURL: 'https://gitbook.gitbook.io/gbo-va-collection/',
         tests: [

--- a/packages/gitbook/src/lib/api-token-cookie.test.ts
+++ b/packages/gitbook/src/lib/api-token-cookie.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
-import {
-    MAX_API_TOKEN_COOKIE_LENGTH,
-    getAPITokenFromCookies,
-    getAPITokenResponseCookies,
-} from './api-token-cookie';
+import { getAPITokenFromCookies, getAPITokenResponseCookies } from './api-token-cookie';
+import { MAX_CHUNKED_COOKIE_LENGTH } from './chunked-cookies';
 
 const cookieName = 'gitbook-api-token~test';
 const options = {
@@ -40,10 +37,10 @@ describe('API token cookies', () => {
             getAPITokenResponseCookies({
                 cookies: [],
                 cookieName,
-                apiToken: 'a'.repeat(MAX_API_TOKEN_COOKIE_LENGTH + 1),
+                apiToken: 'a'.repeat(MAX_CHUNKED_COOKIE_LENGTH + 1),
                 options,
             })
-        ).toThrow(`API token exceeds the ${MAX_API_TOKEN_COOKIE_LENGTH}-character cookie limit`);
+        ).toThrow(`API token exceeds the ${MAX_CHUNKED_COOKIE_LENGTH}-character cookie limit`);
     });
 
     it('reads legacy single-cookie tokens', () => {

--- a/packages/gitbook/src/lib/api-token-cookie.ts
+++ b/packages/gitbook/src/lib/api-token-cookie.ts
@@ -1,13 +1,12 @@
+import {
+    MAX_CHUNKED_COOKIE_LENGTH,
+    type RequestCookie,
+    getChunkedCookieValue,
+    getChunkedResponseCookies,
+} from './chunked-cookies';
 import type { ResponseCookie, ResponseCookies } from './visitors';
 
-const COOKIE_CHUNK_SIZE = 4_000;
-const MAX_COOKIE_CHUNKS = 3;
-export const MAX_API_TOKEN_COOKIE_LENGTH = COOKIE_CHUNK_SIZE * MAX_COOKIE_CHUNKS;
-
-type RequestCookie = Pick<ResponseCookie, 'name' | 'value'>;
-
 /**
- *
  * Retrieves the API token from the provided cookies, handling both single-cookie and chunked representations.
  * We need to split the token into multiple cookies if it exceeds the size limit of a single cookie (4,000 characters).
  * Some sites go over that limit which then cause an infinite redirect loop.
@@ -16,51 +15,7 @@ export function getAPITokenFromCookies(
     cookies: readonly RequestCookie[],
     cookieName: string
 ): string | undefined {
-    const cookie = cookies.find(({ name }) => name === cookieName);
-    if (!cookie) {
-        return undefined;
-    }
-
-    const chunkCount = parseChunkCount(cookie.value);
-    // A base cookie without a recognized chunk marker is always a token value.
-    if (chunkCount === undefined) {
-        return cookie.value;
-    }
-
-    if (chunkCount > MAX_COOKIE_CHUNKS) {
-        return undefined;
-    }
-
-    const chunks = new Map<number, string>();
-    const chunkNamePrefix = `${cookieName}-`;
-    for (const { name, value } of cookies) {
-        if (!name.startsWith(chunkNamePrefix)) {
-            continue;
-        }
-
-        const indexValue = name.slice(chunkNamePrefix.length);
-        const index = Number(indexValue);
-        if (/^\d+$/.test(indexValue) && Number.isSafeInteger(index) && index >= 0) {
-            chunks.set(index, value);
-        }
-    }
-
-    // We don't have all the chunks, so we can't reconstruct the token.
-    // We consider this a missing token
-    if (chunks.size < chunkCount) {
-        return undefined;
-    }
-
-    const tokenChunks: string[] = [];
-    for (let index = 0; index < chunkCount; index++) {
-        const chunk = chunks.get(index);
-        if (chunk === undefined) {
-            return undefined;
-        }
-        tokenChunks.push(chunk);
-    }
-
-    return tokenChunks.join('');
+    return getChunkedCookieValue(cookies, cookieName);
 }
 
 export function getAPITokenResponseCookies(input: {
@@ -70,67 +25,14 @@ export function getAPITokenResponseCookies(input: {
     options: NonNullable<ResponseCookie['options']>;
 }): ResponseCookies {
     const { cookies, cookieName, apiToken, options } = input;
-    if (apiToken.length > MAX_API_TOKEN_COOKIE_LENGTH) {
+    if (apiToken.length > MAX_CHUNKED_COOKIE_LENGTH) {
         throw new APITokenCookieTooLargeError();
     }
-
-    const chunks = splitIntoCookieChunks(apiToken);
-    const previousChunkCount = getPreviousChunkCount(cookies, cookieName);
-    const responseCookies: ResponseCookies =
-        chunks.length === 1
-            ? [{ name: cookieName, value: apiToken, options }]
-            : [
-                  { name: cookieName, value: `chunks:${chunks.length}`, options },
-                  ...chunks.map((value, index) => ({
-                      name: `${cookieName}-${index}`,
-                      value,
-                      options,
-                  })),
-              ];
-
-    const firstChunkToExpire = chunks.length === 1 ? 0 : chunks.length;
-    for (let index = firstChunkToExpire; index < previousChunkCount; index++) {
-        responseCookies.push({
-            name: `${cookieName}-${index}`,
-            value: '',
-            options: { ...options, maxAge: 0 },
-        });
-    }
-
-    return responseCookies;
-}
-
-function splitIntoCookieChunks(value: string): string[] {
-    if (value.length <= COOKIE_CHUNK_SIZE) {
-        return [value];
-    }
-
-    const chunks: string[] = [];
-    for (let start = 0; start < value.length; start += COOKIE_CHUNK_SIZE) {
-        chunks.push(value.slice(start, start + COOKIE_CHUNK_SIZE));
-    }
-    return chunks;
-}
-
-function getPreviousChunkCount(cookies: readonly RequestCookie[], cookieName: string): number {
-    const cookie = cookies.find(({ name }) => name === cookieName);
-    const chunkCount = cookie ? parseChunkCount(cookie.value) : undefined;
-    return chunkCount && chunkCount <= MAX_COOKIE_CHUNKS ? chunkCount : 0;
-}
-
-function parseChunkCount(value: string): number | undefined {
-    // This regex matches the format "chunks:N" where N is a number between 2 and 9 or any number with two or more digits.
-    const match = /^chunks:([2-9]|[1-9]\d+)$/.exec(value);
-    if (!match) {
-        return undefined;
-    }
-
-    const count = Number(match[1]);
-    return Number.isSafeInteger(count) ? count : undefined;
+    return getChunkedResponseCookies({ cookies, cookieName, value: apiToken, options });
 }
 
 export class APITokenCookieTooLargeError extends Error {
     constructor() {
-        super(`API token exceeds the ${MAX_API_TOKEN_COOKIE_LENGTH}-character cookie limit`);
+        super(`API token exceeds the ${MAX_CHUNKED_COOKIE_LENGTH}-character cookie limit`);
     }
 }

--- a/packages/gitbook/src/lib/chunked-cookies.ts
+++ b/packages/gitbook/src/lib/chunked-cookies.ts
@@ -1,0 +1,140 @@
+import type { ResponseCookie, ResponseCookies } from './visitors';
+
+const COOKIE_CHUNK_SIZE = 4_000;
+const MAX_COOKIE_CHUNKS = 3;
+export const MAX_CHUNKED_COOKIE_LENGTH = COOKIE_CHUNK_SIZE * MAX_COOKIE_CHUNKS;
+
+export type RequestCookie = Pick<ResponseCookie, 'name' | 'value'>;
+
+/**
+ * Retrieves a cookie value from the provided cookies, handling both single-cookie and chunked representations.
+ * We need to split a value into multiple cookies if it exceeds the size limit of a single cookie (4,000 characters),
+ * as browsers silently drop oversized Set-Cookie headers, which causes infinite auth redirect loops.
+ */
+export function getChunkedCookieValue(
+    cookies: readonly RequestCookie[],
+    cookieName: string
+): string | undefined {
+    const cookie = cookies.find(({ name }) => name === cookieName);
+    if (!cookie) {
+        return undefined;
+    }
+
+    const chunkCount = parseChunkCount(cookie.value);
+    // A base cookie without a recognized chunk marker is always a plain value.
+    if (chunkCount === undefined) {
+        return cookie.value;
+    }
+
+    if (chunkCount > MAX_COOKIE_CHUNKS) {
+        return undefined;
+    }
+
+    const chunks = new Map<number, string>();
+    const chunkNamePrefix = `${cookieName}-`;
+    for (const { name, value } of cookies) {
+        if (!name.startsWith(chunkNamePrefix)) {
+            continue;
+        }
+
+        const indexValue = name.slice(chunkNamePrefix.length);
+        const index = Number(indexValue);
+        if (/^\d+$/.test(indexValue) && Number.isSafeInteger(index) && index >= 0) {
+            chunks.set(index, value);
+        }
+    }
+
+    // We don't have all the chunks, so we can't reconstruct the value.
+    // We consider this a missing value.
+    if (chunks.size < chunkCount) {
+        return undefined;
+    }
+
+    const valueChunks: string[] = [];
+    for (let index = 0; index < chunkCount; index++) {
+        const chunk = chunks.get(index);
+        if (chunk === undefined) {
+            return undefined;
+        }
+        valueChunks.push(chunk);
+    }
+
+    return valueChunks.join('');
+}
+
+/**
+ * Build the response cookies to store a value, chunking it when it exceeds the
+ * single-cookie size limit, and expiring stale chunks left by a previous larger value.
+ * Throws `ChunkedCookieTooLargeError` if the value exceeds the maximum chunked size.
+ */
+export function getChunkedResponseCookies(input: {
+    cookies: readonly RequestCookie[];
+    cookieName: string;
+    value: string;
+    options: NonNullable<ResponseCookie['options']>;
+}): ResponseCookies {
+    const { cookies, cookieName, value, options } = input;
+    if (value.length > MAX_CHUNKED_COOKIE_LENGTH) {
+        throw new ChunkedCookieTooLargeError();
+    }
+
+    const chunks = splitIntoCookieChunks(value);
+    const previousChunkCount = getPreviousChunkCount(cookies, cookieName);
+    const responseCookies: ResponseCookies =
+        chunks.length === 1
+            ? [{ name: cookieName, value, options }]
+            : [
+                  { name: cookieName, value: `chunks:${chunks.length}`, options },
+                  ...chunks.map((chunk, index) => ({
+                      name: `${cookieName}-${index}`,
+                      value: chunk,
+                      options,
+                  })),
+              ];
+
+    const firstChunkToExpire = chunks.length === 1 ? 0 : chunks.length;
+    for (let index = firstChunkToExpire; index < previousChunkCount; index++) {
+        responseCookies.push({
+            name: `${cookieName}-${index}`,
+            value: '',
+            options: { ...options, maxAge: 0 },
+        });
+    }
+
+    return responseCookies;
+}
+
+function splitIntoCookieChunks(value: string): string[] {
+    if (value.length <= COOKIE_CHUNK_SIZE) {
+        return [value];
+    }
+
+    const chunks: string[] = [];
+    for (let start = 0; start < value.length; start += COOKIE_CHUNK_SIZE) {
+        chunks.push(value.slice(start, start + COOKIE_CHUNK_SIZE));
+    }
+    return chunks;
+}
+
+function getPreviousChunkCount(cookies: readonly RequestCookie[], cookieName: string): number {
+    const cookie = cookies.find(({ name }) => name === cookieName);
+    const chunkCount = cookie ? parseChunkCount(cookie.value) : undefined;
+    return chunkCount && chunkCount <= MAX_COOKIE_CHUNKS ? chunkCount : 0;
+}
+
+function parseChunkCount(value: string): number | undefined {
+    // This regex matches the format "chunks:N" where N is a number between 2 and 9 or any number with two or more digits.
+    const match = /^chunks:([2-9]|[1-9]\d+)$/.exec(value);
+    if (!match) {
+        return undefined;
+    }
+
+    const count = Number(match[1]);
+    return Number.isSafeInteger(count) ? count : undefined;
+}
+
+export class ChunkedCookieTooLargeError extends Error {
+    constructor() {
+        super(`Cookie value exceeds the ${MAX_CHUNKED_COOKIE_LENGTH}-character cookie limit`);
+    }
+}

--- a/packages/gitbook/src/lib/visitors.test.ts
+++ b/packages/gitbook/src/lib/visitors.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'bun:test';
 import type { JwtPayload } from 'jwt-decode';
 
 import {
+    type ResponseCookies,
+    getResponseCookiesForVisitorAuth,
     getVisitorAuthCookieMaxAge,
     getVisitorAuthCookieName,
     getVisitorAuthCookieValue,
@@ -221,6 +223,78 @@ describe('getVisitorAuthToken', () => {
                 token: 'token-in-query',
             });
         });
+    });
+});
+
+// The chunking mechanics themselves are covered in api-token-cookie.test.ts;
+// these tests cover the wiring into the visitor auth cookie.
+describe('getResponseCookiesForVisitorAuth chunking', () => {
+    const base64url = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url');
+
+    // Build a decodable JWT of an arbitrary length by padding the signature part.
+    const makeJwt = (length = 200) => {
+        const jwt = `${base64url({ alg: 'none' })}.${base64url({ exp: 2_000_000_000 })}.`;
+        return jwt.padEnd(length, 's');
+    };
+
+    const write = (basePath: string, token: string, previous: ResponseCookies = []) =>
+        getResponseCookiesForVisitorAuth(basePath, { source: 'url', token }, previous);
+
+    const read = (cookies: ResponseCookies, urlPath = '/') =>
+        getVisitorToken({
+            cookies,
+            headers: new Headers(),
+            url: new URL(`https://example.com${urlPath}`),
+        });
+
+    it('keeps small tokens in a single cookie', () => {
+        const token = makeJwt();
+        const cookies = write('/', token);
+
+        expect(cookies).toHaveLength(1);
+        expect(cookies[0]?.value).toBe(getVisitorAuthCookieValue('/', token));
+        expect(read(cookies)).toEqual({ source: 'visitor-auth-cookie', basePath: '/', token });
+    });
+
+    it('round-trips an oversized token through chunked cookies', () => {
+        const token = makeJwt(9_000);
+        const cookies = write('/', token);
+
+        expect(cookies).toHaveLength(4); // chunk-count marker + 3 chunks
+        for (const cookie of cookies) {
+            expect(cookie.options).toMatchObject({ httpOnly: true });
+            expect(cookie.options?.maxAge).toBeGreaterThan(0);
+        }
+        expect(read(cookies)).toEqual({ source: 'visitor-auth-cookie', basePath: '/', token });
+    });
+
+    it('treats a missing chunk as no token', () => {
+        const cookies = write('/', makeJwt(9_000));
+        const chunkName = `${getVisitorAuthCookieName('/')}-1`;
+        expect(cookies.some(({ name }) => name === chunkName)).toBe(true);
+
+        expect(read(cookies.filter(({ name }) => name !== chunkName))).toBeUndefined();
+    });
+
+    it('expires stale chunks when a smaller token is written', () => {
+        const cookies = write('/', makeJwt(), write('/', makeJwt(9_000)));
+
+        const staleChunks = cookies.filter(({ options }) => options?.maxAge === 0);
+        expect(staleChunks.map(({ name }) => name)).toEqual(
+            [0, 1, 2].map((index) => `${getVisitorAuthCookieName('/')}-${index}`)
+        );
+    });
+
+    it('scopes chunked cookies to the base path', () => {
+        const token = makeJwt(9_000);
+        const cookies = write('/hello/', token);
+
+        expect(read(cookies, '/hello/world')).toEqual({
+            source: 'visitor-auth-cookie',
+            basePath: '/hello/',
+            token,
+        });
+        expect(read(cookies, '/other/page')).toBeUndefined();
     });
 });
 

--- a/packages/gitbook/src/lib/visitors.ts
+++ b/packages/gitbook/src/lib/visitors.ts
@@ -5,6 +5,12 @@ import hash from 'object-hash';
 
 import type { SiteVisitorPayload } from '@gitbook/api';
 
+import {
+    MAX_CHUNKED_COOKIE_LENGTH,
+    getChunkedCookieValue,
+    getChunkedResponseCookies,
+} from './chunked-cookies';
+
 const VISITOR_AUTH_PARAM = 'jwt_token';
 const VISITOR_PARAM_PREFIX = 'visitor.';
 export const VISITOR_TOKEN_COOKIE = 'gitbook-visitor-token';
@@ -303,7 +309,8 @@ function getResponseCookieForVisitorParams(
  */
 export function getResponseCookiesForVisitorAuth(
     basePath: string,
-    visitorTokenLookup: VisitorTokenLookup
+    visitorTokenLookup: VisitorTokenLookup,
+    requestCookies: RequestCookies = []
 ): ResponseCookies {
     if (!visitorTokenLookup) {
         return [];
@@ -328,18 +335,29 @@ export function getResponseCookiesForVisitorAuth(
         (visitorTokenLookup?.source === 'visitor-auth-cookie' &&
             visitorTokenLookup.basePath === basePath)
     ) {
-        return [
-            {
-                name: getVisitorAuthCookieName(basePath),
-                value: getVisitorAuthCookieValue(basePath, visitorTokenLookup.token),
-                options: {
-                    httpOnly: true,
-                    sameSite: process.env.NODE_ENV === 'production' ? 'none' : undefined,
-                    secure: process.env.NODE_ENV === 'production',
-                    maxAge: getVisitorAuthCookieMaxAge(decoded),
-                },
-            },
-        ];
+        const name = getVisitorAuthCookieName(basePath);
+        const value = getVisitorAuthCookieValue(basePath, visitorTokenLookup.token);
+        const options = {
+            httpOnly: true,
+            sameSite: process.env.NODE_ENV === 'production' ? ('none' as const) : undefined,
+            secure: process.env.NODE_ENV === 'production',
+            maxAge: getVisitorAuthCookieMaxAge(decoded),
+        };
+
+        // Chunk the cookie when the value exceeds the single-cookie size limit,
+        // as browsers silently drop oversized Set-Cookie headers which causes
+        // an infinite auth redirect loop.
+        if (value.length > MAX_CHUNKED_COOKIE_LENGTH) {
+            // Too large even for chunking: fall back to a single cookie (best effort).
+            return [{ name, value, options }];
+        }
+
+        return getChunkedResponseCookies({
+            cookies: requestCookies,
+            cookieName: name,
+            value,
+            options,
+        });
     }
 
     return [];
@@ -469,15 +487,21 @@ function findVisitorAuthCookieForBasePath(
     cookies: RequestCookies,
     basePath: string
 ): VisitorAuthCookieValue | undefined {
-    return cookies.reduce<VisitorAuthCookieValue | undefined>((acc, cookie) => {
-        if (cookie.name === getVisitorAuthCookieName(basePath)) {
-            const value = JSON.parse(cookie.value) as VisitorAuthCookieValue;
-            if (value.basePath === basePath) {
-                acc = value;
-            }
+    const cookieValue = getChunkedCookieValue(cookies, getVisitorAuthCookieName(basePath));
+    if (cookieValue === undefined) {
+        return undefined;
+    }
+
+    try {
+        const value = JSON.parse(cookieValue) as VisitorAuthCookieValue;
+        if (value.basePath === basePath) {
+            return value;
         }
-        return acc;
-    }, undefined);
+    } catch {
+        // An unparsable cookie is treated as a missing token; the visitor re-authenticates.
+    }
+
+    return undefined;
 }
 
 /**

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -20,11 +20,8 @@ import {
     serveProxyAnalyticsEvent,
     trackServerInsightsEvents,
 } from './lib/tracking';
-import {
-    MAX_API_TOKEN_COOKIE_LENGTH,
-    getAPITokenFromCookies,
-    getAPITokenResponseCookies,
-} from '@/lib/api-token-cookie';
+import { getAPITokenFromCookies, getAPITokenResponseCookies } from '@/lib/api-token-cookie';
+import { MAX_CHUNKED_COOKIE_LENGTH } from '@/lib/chunked-cookies';
 import type { SiteURLData } from '@/lib/context';
 import { getContentSecurityPolicy } from '@/lib/csp';
 import { validateSerializedCustomization } from '@/lib/customization';
@@ -319,7 +316,8 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
             cookies.push(
                 ...getResponseCookiesForVisitorAuth(
                     getVisitorAuthBasePath(siteRequestURL, siteURLData),
-                    visitorToken
+                    visitorToken,
+                    request.cookies.getAll()
                 )
             );
         }
@@ -672,7 +670,7 @@ async function serveWithQueryAPIToken(input: {
     // If found, we redirect to the same URL but with the token in the cookie
     const queryAPIToken = requestURL.searchParams.get('token');
     if (queryAPIToken) {
-        if (queryAPIToken.length > MAX_API_TOKEN_COOKIE_LENGTH) {
+        if (queryAPIToken.length > MAX_CHUNKED_COOKIE_LENGTH) {
             return new Response('API token is too large', {
                 status: 400,
                 headers: { 'content-type': 'text/plain' },


### PR DESCRIPTION
Sites issuing large visitor JWTs (an Entra site with approx. 60 group claims triggered this) end up with a visitor auth cookie over the 4KB browser limit. 

The browser drops the `Set-Cookie` silently, so after a successful sign-in every request arrives without a token and gets redirected back to the IdP. 

#4421 fixed the same failure for API token cookies by splitting them into 4,000-char chunks. This PR moves that logic into `lib/chunked-cookies.ts` unchanged and applies it to the visitor auth cookie. `api-token-cookie.ts` now uses the shared helper.

Existing single cookies still parse, so no need to sign-in again after deploy. A missing chunk reads as no token and the visitor re-authenticates, and writing a smaller token expires leftover chunk cookies from a previous bigger one.