### PR TITLE
Prewarm Turbopuffer when published search opens

### DIFF
--- a/.changeset/prewarm-published-search.md
+++ b/.changeset/prewarm-published-search.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Prewarm published search caches when readers open the search interface.

--- a/bun.lock
+++ b/bun.lock
@@ -354,7 +354,7 @@
   },
   "catalog": {
     "@base-ui/react": "^1.7.0",
-    "@gitbook/api": "0.197.0",
+    "@gitbook/api": "0.198.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -726,7 +726,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.197.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-g+AQm2QbTPXc3aGV/HXPALK/GAu3INQBtEtZ+qOQ2VAjwn6sVGJvtFq+iWQOGplWO2xx9ucV0gLHuSXmCvf6Gg=="],
+    "@gitbook/api": ["@gitbook/api@0.198.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-ZGXqYip6YFsCM5rqlJ+n8/Esw1bMNK4whqiMoWMeQgMKEX5YXVQaBuVRxU1jDEI49kup+T56xPq3I9g6Wcayng=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
             "@base-ui/react": "^1.7.0",
-            "@gitbook/api": "0.197.0",
+            "@gitbook/api": "0.198.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search-prewarm/route.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search-prewarm/route.ts
@@ -1,9 +1,7 @@
-'use server';
-
 import { getSiteURLDataFromMiddleware } from '@/lib/middleware';
 import { getServerActionBaseContext } from '@/lib/server-actions';
 
-export async function prewarmPublishedSearch() {
+export async function POST() {
     const [context, siteURLData] = await Promise.all([
         getServerActionBaseContext(),
         getSiteURLDataFromMiddleware(),
@@ -11,4 +9,6 @@ export async function prewarmPublishedSearch() {
     const apiClient = await context.dataFetcher.api();
 
     await apiClient.orgs.prewarmSiteSearch(siteURLData.organization, siteURLData.site);
+
+    return new Response(null, { status: 204 });
 }

--- a/packages/gitbook/src/components/Embeddable/EmbeddableRootLayout.tsx
+++ b/packages/gitbook/src/components/Embeddable/EmbeddableRootLayout.tsx
@@ -57,6 +57,7 @@ export async function EmbeddableRootLayout({
                 externalLinksTarget={context.customization.externalLinks.target}
                 contextId={context.contextId}
                 proxyOrigin={context.site.proxy?.origin}
+                searchPrewarmURL={context.linker.toPathInSite('~gitbook/search-prewarm')}
             >
                 {/* Persist an explicit ?theme= override so it survives tab navigation. RND-11571 */}
                 <EmbeddableThemeSync forcedTheme={rememberedTheme} />

--- a/packages/gitbook/src/components/Search/prewarmSearch.ts
+++ b/packages/gitbook/src/components/Search/prewarmSearch.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { getSiteURLDataFromMiddleware } from '@/lib/middleware';
+import { getServerActionBaseContext } from '@/lib/server-actions';
+
+export async function prewarmPublishedSearch() {
+    const [context, siteURLData] = await Promise.all([
+        getServerActionBaseContext(),
+        getSiteURLDataFromMiddleware(),
+    ]);
+    const apiClient = await context.dataFetcher.api();
+
+    await apiClient.orgs.prewarmSiteSearch(siteURLData.organization, siteURLData.site);
+}

--- a/packages/gitbook/src/components/Search/search-prewarm.ts
+++ b/packages/gitbook/src/components/Search/search-prewarm.ts
@@ -1,0 +1,21 @@
+export interface SearchPrewarmer {
+    update(open: boolean): void;
+}
+
+export function createSearchPrewarmer(
+    initiallyOpen: boolean,
+    prewarmSiteSearch: () => Promise<unknown>
+): SearchPrewarmer {
+    let wasOpen = initiallyOpen;
+
+    return {
+        update(open) {
+            const shouldPrewarm = !wasOpen && open;
+            wasOpen = open;
+
+            if (shouldPrewarm) {
+                void prewarmSiteSearch().catch(() => undefined);
+            }
+        },
+    };
+}

--- a/packages/gitbook/src/components/Search/search-prewarm.ts
+++ b/packages/gitbook/src/components/Search/search-prewarm.ts
@@ -1,15 +1,12 @@
 export interface SearchPrewarmer {
-    update(open: boolean): void;
+    update(open: boolean, prewarmSiteSearch: () => Promise<unknown>): void;
 }
 
-export function createSearchPrewarmer(
-    initiallyOpen: boolean,
-    prewarmSiteSearch: () => Promise<unknown>
-): SearchPrewarmer {
+export function createSearchPrewarmer(initiallyOpen: boolean): SearchPrewarmer {
     let wasOpen = initiallyOpen;
 
     return {
-        update(open) {
+        update(open, prewarmSiteSearch) {
             const shouldPrewarm = !wasOpen && open;
             wasOpen = open;
 

--- a/packages/gitbook/src/components/Search/useSearch.tsx
+++ b/packages/gitbook/src/components/Search/useSearch.tsx
@@ -10,6 +10,7 @@ import {
 import React from 'react';
 
 import type { LinkProps } from '../primitives';
+import { useSearchPrewarm } from './useSearchPrewarm';
 
 export type SearchScope =
     /** Search all content on the site */
@@ -91,6 +92,8 @@ export function SearchContextProvider(props: React.PropsWithChildren): React.Rea
             open,
         };
     }, [rawState, open]);
+
+    useSearchPrewarm(Boolean(state?.open));
 
     const stateRef = React.useRef(state);
     React.useLayoutEffect(() => {

--- a/packages/gitbook/src/components/Search/useSearch.tsx
+++ b/packages/gitbook/src/components/Search/useSearch.tsx
@@ -69,8 +69,10 @@ export function shouldKeepSearchState(
     return values.q !== null || values.ask !== null || values.scope !== 'default';
 }
 
-export function SearchContextProvider(props: React.PropsWithChildren): React.ReactElement {
-    const { children } = props;
+export function SearchContextProvider(
+    props: React.PropsWithChildren<{ prewarmURL: string }>
+): React.ReactElement {
+    const { children, prewarmURL } = props;
 
     // URL-backed state
     const [rawState, setRawState] = useQueryStates(keyMap, {
@@ -93,7 +95,7 @@ export function SearchContextProvider(props: React.PropsWithChildren): React.Rea
         };
     }, [rawState, open]);
 
-    useSearchPrewarm(Boolean(state?.open));
+    useSearchPrewarm(Boolean(state?.open), prewarmURL);
 
     const stateRef = React.useRef(state);
     React.useLayoutEffect(() => {

--- a/packages/gitbook/src/components/Search/useSearchPrewarm.test.ts
+++ b/packages/gitbook/src/components/Search/useSearchPrewarm.test.ts
@@ -5,44 +5,44 @@ import { createSearchPrewarmer } from './search-prewarm';
 describe('createSearchPrewarmer', () => {
     it('does not prewarm while search remains closed', () => {
         const prewarmSiteSearch = mock(() => Promise.resolve());
-        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+        const prewarmer = createSearchPrewarmer(false);
 
-        prewarmer.update(false);
-        prewarmer.update(false);
+        prewarmer.update(false, prewarmSiteSearch);
+        prewarmer.update(false, prewarmSiteSearch);
 
         expect(prewarmSiteSearch).not.toHaveBeenCalled();
     });
 
     it('prewarms once when search opens and not again for updates while it remains open', () => {
         const prewarmSiteSearch = mock(() => Promise.resolve());
-        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+        const prewarmer = createSearchPrewarmer(false);
 
-        prewarmer.update(true);
-        prewarmer.update(true);
-        prewarmer.update(true);
+        prewarmer.update(true, prewarmSiteSearch);
+        prewarmer.update(true, prewarmSiteSearch);
+        prewarmer.update(true, prewarmSiteSearch);
 
         expect(prewarmSiteSearch).toHaveBeenCalledTimes(1);
     });
 
     it('prewarms again after search closes and reopens', () => {
         const prewarmSiteSearch = mock(() => Promise.resolve());
-        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+        const prewarmer = createSearchPrewarmer(false);
 
-        prewarmer.update(true);
-        prewarmer.update(false);
-        prewarmer.update(true);
+        prewarmer.update(true, prewarmSiteSearch);
+        prewarmer.update(false, prewarmSiteSearch);
+        prewarmer.update(true, prewarmSiteSearch);
 
         expect(prewarmSiteSearch).toHaveBeenCalledTimes(2);
     });
 
     it('does not surface a rejected prewarm request', async () => {
         const prewarmSiteSearch = mock(() => Promise.reject(new Error('Prewarm failed')));
-        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+        const prewarmer = createSearchPrewarmer(false);
 
-        expect(() => prewarmer.update(true)).not.toThrow();
+        expect(() => prewarmer.update(true, prewarmSiteSearch)).not.toThrow();
         await Promise.resolve();
-        prewarmer.update(false);
-        expect(() => prewarmer.update(true)).not.toThrow();
+        prewarmer.update(false, prewarmSiteSearch);
+        expect(() => prewarmer.update(true, prewarmSiteSearch)).not.toThrow();
         await Promise.resolve();
 
         expect(prewarmSiteSearch).toHaveBeenCalledTimes(2);
@@ -50,9 +50,9 @@ describe('createSearchPrewarmer', () => {
 
     it('does not prewarm when search is already open on initial render', () => {
         const prewarmSiteSearch = mock(() => Promise.resolve());
-        const prewarmer = createSearchPrewarmer(true, prewarmSiteSearch);
+        const prewarmer = createSearchPrewarmer(true);
 
-        prewarmer.update(true);
+        prewarmer.update(true, prewarmSiteSearch);
 
         expect(prewarmSiteSearch).not.toHaveBeenCalled();
     });

--- a/packages/gitbook/src/components/Search/useSearchPrewarm.test.ts
+++ b/packages/gitbook/src/components/Search/useSearchPrewarm.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { createSearchPrewarmer } from './search-prewarm';
+
+describe('createSearchPrewarmer', () => {
+    it('does not prewarm while search remains closed', () => {
+        const prewarmSiteSearch = mock(() => Promise.resolve());
+        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+
+        prewarmer.update(false);
+        prewarmer.update(false);
+
+        expect(prewarmSiteSearch).not.toHaveBeenCalled();
+    });
+
+    it('prewarms once when search opens and not again for updates while it remains open', () => {
+        const prewarmSiteSearch = mock(() => Promise.resolve());
+        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+
+        prewarmer.update(true);
+        prewarmer.update(true);
+        prewarmer.update(true);
+
+        expect(prewarmSiteSearch).toHaveBeenCalledTimes(1);
+    });
+
+    it('prewarms again after search closes and reopens', () => {
+        const prewarmSiteSearch = mock(() => Promise.resolve());
+        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+
+        prewarmer.update(true);
+        prewarmer.update(false);
+        prewarmer.update(true);
+
+        expect(prewarmSiteSearch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not surface a rejected prewarm request', async () => {
+        const prewarmSiteSearch = mock(() => Promise.reject(new Error('Prewarm failed')));
+        const prewarmer = createSearchPrewarmer(false, prewarmSiteSearch);
+
+        expect(() => prewarmer.update(true)).not.toThrow();
+        await Promise.resolve();
+        prewarmer.update(false);
+        expect(() => prewarmer.update(true)).not.toThrow();
+        await Promise.resolve();
+
+        expect(prewarmSiteSearch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not prewarm when search is already open on initial render', () => {
+        const prewarmSiteSearch = mock(() => Promise.resolve());
+        const prewarmer = createSearchPrewarmer(true, prewarmSiteSearch);
+
+        prewarmer.update(true);
+
+        expect(prewarmSiteSearch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/gitbook/src/components/Search/useSearchPrewarm.ts
+++ b/packages/gitbook/src/components/Search/useSearchPrewarm.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import React from 'react';
+
+import { prewarmPublishedSearch } from './prewarmSearch';
+import { createSearchPrewarmer, type SearchPrewarmer } from './search-prewarm';
+
+export function useSearchPrewarm(open: boolean) {
+    const prewarmerRef = React.useRef<SearchPrewarmer | null>(null);
+    if (prewarmerRef.current === null) {
+        prewarmerRef.current = createSearchPrewarmer(open, prewarmPublishedSearch);
+    }
+
+    React.useEffect(() => {
+        prewarmerRef.current?.update(open);
+    }, [open]);
+}

--- a/packages/gitbook/src/components/Search/useSearchPrewarm.ts
+++ b/packages/gitbook/src/components/Search/useSearchPrewarm.ts
@@ -2,16 +2,20 @@
 
 import React from 'react';
 
-import { prewarmPublishedSearch } from './prewarmSearch';
 import { createSearchPrewarmer, type SearchPrewarmer } from './search-prewarm';
 
-export function useSearchPrewarm(open: boolean) {
+export function useSearchPrewarm(open: boolean, prewarmURL: string) {
     const prewarmerRef = React.useRef<SearchPrewarmer | null>(null);
     if (prewarmerRef.current === null) {
-        prewarmerRef.current = createSearchPrewarmer(open, prewarmPublishedSearch);
+        prewarmerRef.current = createSearchPrewarmer(open);
     }
 
     React.useEffect(() => {
-        prewarmerRef.current?.update(open);
-    }, [open]);
+        prewarmerRef.current?.update(open, async () => {
+            const response = await fetch(prewarmURL, { method: 'POST' });
+            if (!response.ok) {
+                throw new Error(`Search prewarm request failed: ${response.status}`);
+            }
+        });
+    }, [open, prewarmURL]);
 }

--- a/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
+++ b/packages/gitbook/src/components/SiteLayout/SiteLayout.tsx
@@ -99,6 +99,7 @@ export async function SiteLayout(props: {
             defaultTheme={customization.themes.default}
             externalLinksTarget={customization.externalLinks.target}
             proxyOrigin={context.site.proxy?.origin}
+            searchPrewarmURL={context.linker.toPathInSite('~gitbook/search-prewarm')}
         >
             <AIContextProvider
                 aiMode={customization.ai?.mode}

--- a/packages/gitbook/src/components/SiteLayout/SiteLayoutClientContexts.tsx
+++ b/packages/gitbook/src/components/SiteLayout/SiteLayoutClientContexts.tsx
@@ -24,6 +24,7 @@ export function SiteLayoutClientContexts(props: {
     externalLinksTarget: SiteExternalLinksTarget;
     contextId: string | undefined;
     proxyOrigin: string | undefined;
+    searchPrewarmURL: string;
     children: React.ReactNode;
 }) {
     const {
@@ -34,6 +35,7 @@ export function SiteLayoutClientContexts(props: {
         externalLinksTarget,
         contextId,
         proxyOrigin,
+        searchPrewarmURL,
     } = props;
 
     useClearRouterCache(contextId);
@@ -67,7 +69,7 @@ export function SiteLayoutClientContexts(props: {
             <NuqsAdapter>
                 <SelectProvider>
                     <LinkContext.Provider value={linkContext}>
-                        <SearchContextProvider>
+                        <SearchContextProvider prewarmURL={searchPrewarmURL}>
                             <ReducedMotionProvider>{children}</ReducedMotionProvider>
                         </SearchContextProvider>
                     </LinkContext.Provider>


### PR DESCRIPTION
## Changes

- observe the centralized published-search open state and trigger one prewarm on each closed-to-open transition
- call the generated prewarmSiteSearch operation through the existing middleware-resolved organization, site, API base URL, and content or visitor authentication
- keep prewarming best-effort so it never blocks the dialog, input, or search requests
- update @gitbook/api to 0.198.0, the first release containing prewarmSiteSearch

Opening search now gives Turbopuffer an early cache-warming hint, reducing the likelihood that the first visitor query pays cold-namespace latency. This adds one best-effort API call per search opening. It does not block the dialog and does not execute an extra search.

## Testing

- bun test src/components/Search/useSearchPrewarm.test.ts — 5 passed
- bun run format — passed
- bun run lint — passed
- bun run typecheck from packages/gitbook — passed

## Links

- https://linear.app/gitbook-x/issue/RND-11915/prewarm-tpuf-cache-when-opening-the-gbo-search-dialog
- https://github.com/GitbookIO/gitbook-x/pull/25222