### PR TITLE
Allow search to target any section

### DIFF
--- a/.changeset/isolate-preview-embed.md
+++ b/.changeset/isolate-preview-embed.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Keep embed demos and frames on the deployment that served them.

--- a/.changeset/search-any-section.md
+++ b/.changeset/search-any-section.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Allow published search to be scoped to any visible site section.

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/demo/route.ts
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/demo/route.ts
@@ -117,7 +117,7 @@ export async function GET(
         <button type="button" class="control" onclick="window.GitBook('open')">Open</button>
         <button type="button" class="control" onclick="window.GitBook('close')">Close</button>
     </body>
-    <script src="${context.linker.toAbsoluteURL(context.linker.toPathInSite('~gitbook/embed/script.js'))}"></script>
+    <script src="${context.linker.toPathInSite('~gitbook/embed/script.js')}"></script>
     <script>
         const useCustomTrigger = new URLSearchParams(window.location.search).get('trigger') === 'custom';
         window.GitBook('configure', {

--- a/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/script.js/route.ts
+++ b/packages/gitbook/src/app/sites/static/[mode]/[siteURL]/[siteData]/~gitbook/embed/script.js/route.ts
@@ -18,7 +18,7 @@ export async function GET(
 ) {
     const { context } = await getEmbeddableStaticContext(await params);
     const initOptions: CreateGitBookOptions = {
-        siteURL: context.linker.toAbsoluteURL(context.linker.toPathInSite('')),
+        siteURL: context.linker.toPathInSite(''),
     };
 
     // The theme this site pins its embeds to, if it has one. The widget paints the panel around the
@@ -41,7 +41,12 @@ export async function GET(
 
   const searchParams = getScriptSearchParams()
   const token = searchParams.get('jwt_token');
-  const initOptions = { ...${JSON.stringify(initOptions)}, ...(window.gitbookSettings || {}) };
+  const initOptions = {
+    ...${JSON.stringify(initOptions)},
+    // Preview deployments must keep the iframe on the deployment that served this script.
+    siteURL: new URL(${JSON.stringify(initOptions.siteURL)}, window.location.origin).toString(),
+    ...(window.gitbookSettings || {}),
+  };
   const initFrameOptions = {};
   const theme = searchParams.get('theme');
   // The site's own theme first: it renders in that one whatever the embedder asks for.

--- a/packages/gitbook/src/components/Search/SearchScopeControl.tsx
+++ b/packages/gitbook/src/components/Search/SearchScopeControl.tsx
@@ -1,14 +1,21 @@
 'use client';
 
-import type { SiteSection } from '@gitbook/api';
-
-import { Button, DropdownMenu, DropdownMenuItem, ToggleChevron } from '../primitives';
+import {
+    Button,
+    DropdownMenu,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownSubMenu,
+    ToggleChevron,
+} from '../primitives';
+import { findSearchSection, type SearchSection, type SearchSectionItem } from './search-props';
 import { useSearchState, useSetSearchState } from './useSearch';
 import { t, tString, useLanguage } from '@/intl/client';
 
 interface SearchScopeControlProps {
     spaceTitle: string;
-    section?: Pick<SiteSection, 'title' | 'icon'>;
+    section?: SearchSection;
+    sections: SearchSectionItem[];
     withVariants: boolean;
     withSiteVariants: boolean;
     withSections: boolean;
@@ -19,7 +26,7 @@ interface SearchScopeControlProps {
  * Only visible when the space is in a collection.
  */
 export function SearchScopeControl(props: SearchScopeControlProps) {
-    const { withVariants, withSections } = props;
+    const { section, sections, withVariants, withSections } = props;
 
     const state = useSearchState();
 
@@ -30,6 +37,12 @@ export function SearchScopeControl(props: SearchScopeControlProps) {
     // Whether to include all variants in the search
     const sectionScopeIsExtended = ['default', 'all'].includes(state.scope);
     const variantScopeIsExtended = ['extended', 'all'].includes(state.scope);
+    const independentlySelectedSection = state.section
+        ? findSearchSection(sections, state.section)
+        : undefined;
+    const hasIndependentlySelectedSection = Boolean(
+        independentlySelectedSection && independentlySelectedSection.id !== section?.id
+    );
 
     return (
         <div className="flex items-center">
@@ -38,7 +51,9 @@ export function SearchScopeControl(props: SearchScopeControlProps) {
                 <SearchScopeSectionControl isExtended={sectionScopeIsExtended} {...props} />
             ) : null}
 
-            {withVariants && (!withSections || !sectionScopeIsExtended) ? (
+            {withVariants &&
+            !hasIndependentlySelectedSection &&
+            (!withSections || !sectionScopeIsExtended) ? (
                 <SearchScopeVariantControl isExtended={variantScopeIsExtended} {...props} />
             ) : null}
         </div>
@@ -51,10 +66,16 @@ function SearchScopeTitle() {
 }
 
 function SearchScopeSectionControl(props: SearchScopeControlProps & { isExtended: boolean }) {
-    const { isExtended, section } = props;
+    const { isExtended, section, sections } = props;
 
     const language = useLanguage();
     const setSearchState = useSetSearchState();
+    const state = useSearchState();
+    const independentlySelectedSection = state?.section
+        ? findSearchSection(sections, state.section)
+        : undefined;
+    const selectedSection = independentlySelectedSection ?? section;
+    const searchesAllSections = isExtended && !independentlySelectedSection;
 
     return (
         <DropdownMenu
@@ -63,11 +84,13 @@ function SearchScopeSectionControl(props: SearchScopeControlProps & { isExtended
                     variant="blank"
                     size="small"
                     className="text-tint-strong"
-                    icon={isExtended ? undefined : section?.icon}
+                    icon={searchesAllSections ? undefined : selectedSection?.icon}
                     label={tString(
                         language,
-                        isExtended ? 'search_scope_section_all' : 'search_scope_section_current',
-                        section?.title ?? ''
+                        searchesAllSections
+                            ? 'search_scope_section_all'
+                            : 'search_scope_section_current',
+                        selectedSection?.title ?? ''
                     )}
                     trailing={<ToggleChevron />}
                 />
@@ -76,9 +99,11 @@ function SearchScopeSectionControl(props: SearchScopeControlProps & { isExtended
             <DropdownMenuItem
                 leadingIcon="infinity"
                 className="gap-3"
-                active={isExtended}
+                active={searchesAllSections}
                 onClick={() =>
-                    setSearchState((prev) => (prev ? { ...prev, scope: 'default' } : null))
+                    setSearchState((prev) =>
+                        prev ? { ...prev, scope: 'default', section: null } : null
+                    )
                 }
             >
                 <div className="flex flex-col">
@@ -90,24 +115,60 @@ function SearchScopeSectionControl(props: SearchScopeControlProps & { isExtended
                     </span>
                 </div>
             </DropdownMenuItem>
-            <DropdownMenuItem
-                leadingIcon={section?.icon ?? 'crosshairs'}
-                className="gap-3"
-                active={!isExtended}
-                onClick={() =>
-                    setSearchState((prev) => (prev ? { ...prev, scope: 'current' } : null))
-                }
-            >
-                <div className="flex flex-col">
-                    <span className="text-tint-strong">
-                        {t(language, 'search_scope_section_current', section?.title ?? '')}
-                    </span>
-                    <span className="text-xs text-tint-subtle">
-                        {t(language, 'search_scope_section_current_description')}
-                    </span>
-                </div>
-            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            {sections.map((item) => (
+                <SearchSectionMenuItem
+                    key={item.id}
+                    item={item}
+                    currentSectionId={section?.id}
+                    selectedSectionId={searchesAllSections ? undefined : selectedSection?.id}
+                />
+            ))}
         </DropdownMenu>
+    );
+}
+
+function SearchSectionMenuItem(props: {
+    item: SearchSectionItem;
+    currentSectionId?: string;
+    selectedSectionId?: string;
+}) {
+    const { item, currentSectionId, selectedSectionId } = props;
+    const setSearchState = useSetSearchState();
+
+    if (item.object === 'site-section-group') {
+        return (
+            <DropdownSubMenu label={item.title}>
+                {item.children.map((child) => (
+                    <SearchSectionMenuItem
+                        key={child.id}
+                        item={child}
+                        currentSectionId={currentSectionId}
+                        selectedSectionId={selectedSectionId}
+                    />
+                ))}
+            </DropdownSubMenu>
+        );
+    }
+
+    return (
+        <DropdownMenuItem
+            leadingIcon={item.icon ?? 'crosshairs'}
+            active={item.id === selectedSectionId}
+            onClick={() =>
+                setSearchState((prev) =>
+                    prev
+                        ? {
+                              ...prev,
+                              scope: item.id === currentSectionId ? 'current' : 'extended',
+                              section: item.id === currentSectionId ? null : item.id,
+                          }
+                        : null
+                )
+            }
+        >
+            <span className="text-tint-strong">{item.title}</span>
+        </DropdownMenuItem>
     );
 }
 

--- a/packages/gitbook/src/components/Search/filter.test.ts
+++ b/packages/gitbook/src/components/Search/filter.test.ts
@@ -25,4 +25,12 @@ describe('computeFilterSiteSpaceIds', () => {
         const r = computeFilterSiteSpaceIds('default', currentId, ids, false);
         expect(r).toEqual([currentId]);
     });
+
+    it('filters to an independently selected section', () => {
+        const r = computeFilterSiteSpaceIds('extended', currentId, ids, true, [
+            'space-other-a',
+            'space-other-b',
+        ]);
+        expect(r).toEqual(['space-other-a', 'space-other-b']);
+    });
 });

--- a/packages/gitbook/src/components/Search/filter.ts
+++ b/packages/gitbook/src/components/Search/filter.ts
@@ -8,14 +8,20 @@ import type { SearchScope } from './useSearch';
  * results consistent with remote ones, we also restrict "default" to the
  * current `siteSpaceId` when `withSections` is false. Otherwise (sections
  * present), local "default" stays unfiltered to match the broader section UI.
+ * An explicitly selected section takes precedence over these legacy scopes.
  */
 
 export function computeFilterSiteSpaceIds(
     scope: SearchScope,
     siteSpaceId: string,
     siteSpaceIds: string[],
-    withSections?: boolean
+    withSections?: boolean,
+    selectedSectionSiteSpaceIds?: string[]
 ) {
+    if (selectedSectionSiteSpaceIds) {
+        return selectedSectionSiteSpaceIds;
+    }
+
     switch (scope) {
         case 'current':
             return [siteSpaceId];

--- a/packages/gitbook/src/components/Search/remote-scope.test.ts
+++ b/packages/gitbook/src/components/Search/remote-scope.test.ts
@@ -14,4 +14,18 @@ describe('computeRemoteSearchScope', () => {
             siteSpaceId: 'snyk-discover',
         });
     });
+
+    it('requests only the site spaces belonging to an independently selected section', () => {
+        expect(
+            computeRemoteSearchScope(
+                'extended',
+                'snyk-discover',
+                ['snyk-discover', 'snyk-developer-tools'],
+                ['snyk-api-v1', 'snyk-api-v2']
+            )
+        ).toEqual({
+            mode: 'specific',
+            siteSpaceIds: ['snyk-api-v1', 'snyk-api-v2'],
+        });
+    });
 });

--- a/packages/gitbook/src/components/Search/remote-scope.ts
+++ b/packages/gitbook/src/components/Search/remote-scope.ts
@@ -3,12 +3,17 @@ import assertNever from 'assert-never';
 import type { SearchSiteContentScope } from './search-types';
 import type { SearchScope } from './useSearch';
 
-/** Map the UI scope to one backend request so every returned rank is globally comparable. */
+/** Map the UI scope (and any explicit section selection) to one globally ranked request. */
 export function computeRemoteSearchScope(
     scope: SearchScope,
     siteSpaceId: string,
-    siteSpaceIds: string[]
+    siteSpaceIds: string[],
+    selectedSectionSiteSpaceIds?: string[]
 ): SearchSiteContentScope {
+    if (selectedSectionSiteSpaceIds) {
+        return { mode: 'specific', siteSpaceIds: selectedSectionSiteSpaceIds };
+    }
+
     switch (scope) {
         case 'all':
             return { mode: 'all' };

--- a/packages/gitbook/src/components/Search/search-props.test.ts
+++ b/packages/gitbook/src/components/Search/search-props.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+
+import { findSearchSection, type SearchSectionItem } from './search-props';
+
+describe('findSearchSection', () => {
+    const sections: SearchSectionItem[] = [
+        {
+            id: 'guides',
+            object: 'site-section-group',
+            title: 'Guides',
+            children: [
+                {
+                    id: 'getting-started',
+                    object: 'site-section',
+                    title: 'Getting started',
+                    siteSpaceIds: ['getting-started-v1'],
+                },
+            ],
+        },
+    ];
+
+    it('finds sections nested in groups', () => {
+        expect(findSearchSection(sections, 'getting-started')).toEqual({
+            id: 'getting-started',
+            object: 'site-section',
+            title: 'Getting started',
+            siteSpaceIds: ['getting-started-v1'],
+        });
+    });
+
+    it('returns undefined for an unknown section', () => {
+        expect(findSearchSection(sections, 'api-reference')).toBeUndefined();
+    });
+});

--- a/packages/gitbook/src/components/Search/search-props.ts
+++ b/packages/gitbook/src/components/Search/search-props.ts
@@ -1,14 +1,27 @@
-import type { SiteSection, SiteSpace } from '@gitbook/api';
+import type { SiteExternalLink, SiteSection, SiteSectionGroup, SiteSpace } from '@gitbook/api';
 
-import { encodeClientSiteSections } from '../SiteSections';
 import type { GitBookSiteContext } from '@/lib/context';
+import { getLocalizedTitle } from '@/lib/sites';
+
+export type SearchSection = Pick<SiteSection, 'id' | 'icon' | 'object'> & {
+    title: string;
+    siteSpaceIds: string[];
+};
+
+export type SearchSectionGroup = Pick<SiteSectionGroup, 'id' | 'icon' | 'object'> & {
+    title: string;
+    children: SearchSectionItem[];
+};
+
+export type SearchSectionItem = SearchSection | SearchSectionGroup;
 
 export interface SearchBaseProps {
     asEmbeddable?: boolean;
     siteSpace: SiteSpace;
     siteSpaces: readonly SiteSpace[];
     withSections: boolean;
-    section?: Pick<SiteSection, 'title' | 'icon'>;
+    section?: SearchSection;
+    sections: SearchSectionItem[];
     withVariants: boolean;
     withSiteVariants: boolean;
     indexURL: string;
@@ -17,15 +30,18 @@ export interface SearchBaseProps {
 
 export function getSearchBaseProps(context: GitBookSiteContext): SearchBaseProps {
     const { siteSpace, visibleSections, visibleSiteSpaces } = context;
+    const sections = visibleSections ? encodeSearchSections(context, visibleSections.list) : [];
+    const section = visibleSections
+        ? findSearchSection(sections, visibleSections.current.id)
+        : undefined;
 
     return {
         searchURL: context.linker.toPathInSpace('~gitbook/search'),
-        section: visibleSections
-            ? encodeClientSiteSections(context, visibleSections).current
-            : undefined,
+        section,
+        sections,
         siteSpace,
         siteSpaces: visibleSiteSpaces,
-        withSections: Boolean(visibleSections && visibleSections.list.length > 1),
+        withSections: countSearchSections(sections) > 1,
         withSiteVariants:
             visibleSections?.list.some(
                 (section) => section.object === 'site-section' && section.siteSpaces.length > 1
@@ -33,4 +49,84 @@ export function getSearchBaseProps(context: GitBookSiteContext): SearchBaseProps
         indexURL: context.linker.toPathInSite('~gitbook/site-index'),
         withVariants: visibleSiteSpaces.length > 1,
     };
+}
+
+function encodeSearchSections(
+    context: GitBookSiteContext,
+    items: (SiteSection | SiteSectionGroup | SiteExternalLink)[]
+): SearchSectionItem[] {
+    const sections: SearchSectionItem[] = [];
+
+    for (const item of items) {
+        switch (item.object) {
+            case 'site-section':
+                const languageCompatibleSiteSpaces = item.siteSpaces.filter(
+                    (candidate) =>
+                        !context.siteSpace.space.language ||
+                        !candidate.space.language ||
+                        candidate.space.language === context.siteSpace.space.language
+                );
+                const defaultLanguage = item.siteSpaces.find((candidate) => candidate.default)
+                    ?.space.language;
+                const fallbackSiteSpaces = defaultLanguage
+                    ? item.siteSpaces.filter(
+                          (candidate) =>
+                              !candidate.space.language ||
+                              candidate.space.language === defaultLanguage
+                      )
+                    : item.siteSpaces;
+                sections.push({
+                    id: item.id,
+                    icon: item.icon,
+                    object: item.object,
+                    title: getLocalizedTitle(item, context.locale),
+                    siteSpaceIds: (languageCompatibleSiteSpaces.length > 0
+                        ? languageCompatibleSiteSpaces
+                        : fallbackSiteSpaces
+                    ).map((candidate) => candidate.id),
+                });
+                break;
+            case 'site-section-group':
+                sections.push({
+                    id: item.id,
+                    icon: item.icon,
+                    object: item.object,
+                    title: getLocalizedTitle(item, context.locale),
+                    children: encodeSearchSections(context, item.children),
+                });
+                break;
+            case 'site-external-link':
+                break;
+        }
+    }
+
+    return sections;
+}
+
+export function findSearchSection(
+    items: SearchSectionItem[],
+    sectionId: string
+): SearchSection | undefined {
+    for (const item of items) {
+        if (item.object === 'site-section') {
+            if (item.id === sectionId) {
+                return item;
+            }
+        } else {
+            const section = findSearchSection(item.children, sectionId);
+            if (section) {
+                return section;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+function countSearchSections(items: SearchSectionItem[]): number {
+    return items.reduce(
+        (count, item) =>
+            count + (item.object === 'site-section' ? 1 : countSearchSections(item.children)),
+        0
+    );
 }

--- a/packages/gitbook/src/components/Search/useSearch.tsx
+++ b/packages/gitbook/src/components/Search/useSearch.tsx
@@ -26,6 +26,8 @@ export interface SearchState {
     query: string | null;
     ask: string | null;
     scope: SearchScope;
+    /** A section selected independently from the page currently being viewed. */
+    section?: string | null;
 
     // Local UI state
     open: boolean;
@@ -36,6 +38,7 @@ const keyMap = {
     q: parseAsString,
     ask: parseAsString,
     scope: parseAsStringLiteral(['all', 'default', 'extended', 'current']).withDefault('default'),
+    section: parseAsString,
     global: parseAsBoolean, // Legacy support for global=true
 };
 
@@ -88,6 +91,7 @@ export function SearchContextProvider(props: React.PropsWithChildren): React.Rea
             query: normalized.q,
             ask: normalized.ask,
             scope: normalized.scope,
+            section: normalized.section,
             open,
         };
     }, [rawState, open]);
@@ -107,7 +111,7 @@ export function SearchContextProvider(props: React.PropsWithChildren): React.Rea
 
             if (update === null) {
                 setIsOpen(false);
-                return setRawState({ q: null, ask: null, scope: 'default' });
+                return setRawState({ q: null, ask: null, scope: 'default', section: null });
             }
 
             setIsOpen(update.open);
@@ -115,6 +119,10 @@ export function SearchContextProvider(props: React.PropsWithChildren): React.Rea
                 q: update.query,
                 ask: update.ask,
                 scope: update.scope,
+                section:
+                    update.section === undefined
+                        ? (stateRef.current?.section ?? null)
+                        : update.section,
             });
         },
         [setRawState]
@@ -160,6 +168,9 @@ export function useSearchLink(): (
             params.query ? searchParams.set('q', params.query) : searchParams.delete('q');
             params.ask ? searchParams.set('ask', params.ask) : searchParams.delete('ask');
             params.scope ? searchParams.set('scope', params.scope) : searchParams.delete('scope');
+            params.section
+                ? searchParams.set('section', params.section)
+                : searchParams.delete('section');
             return {
                 href: `?${searchParams.toString()}`,
                 prefetch: false,
@@ -170,6 +181,7 @@ export function useSearchLink(): (
                         query: params.query !== undefined ? params.query : null,
                         ask: params.ask !== undefined ? params.ask : null,
                         scope: params.scope !== undefined ? params.scope : 'default',
+                        section: params.section,
                         open: params.open !== undefined ? params.open : false,
                     }));
                     callback?.();

--- a/packages/gitbook/src/components/Search/useSearchController.tsx
+++ b/packages/gitbook/src/components/Search/useSearchController.tsx
@@ -13,7 +13,7 @@ import {
     useLastSearchQuery,
 } from './last-query';
 import { addRecentSearchQuery } from './recent-queries';
-import type { SearchBaseProps } from './search-props';
+import { findSearchSection, type SearchBaseProps } from './search-props';
 import type { SearchResultsRef } from './SearchResults';
 import { useSearchState, useSetSearchState } from './useSearch';
 import { useSearchResults } from './useSearchResults';
@@ -124,6 +124,7 @@ export function useSearchController(
         asEmbeddable,
         siteSpace,
         section,
+        sections,
         withVariants,
         withSiteVariants,
         withSections,
@@ -241,6 +242,7 @@ export function useSearchController(
         siteSpaces,
         language: siteSpace.space.language,
     });
+    const selectedSection = state?.section ? findSearchSection(sections, state.section) : undefined;
 
     const { results, fetching, error, abort } = useSearchResults({
         asEmbeddable,
@@ -249,6 +251,7 @@ export function useSearchController(
         query: normalizedQuery,
         siteSpaceId: siteSpace.id,
         siteSpaceIds,
+        selectedSectionSiteSpaceIds: selectedSection?.siteSpaceIds,
         scope: state?.scope ?? 'default',
         suggestions: config.suggestions,
         searchURL,
@@ -329,6 +332,7 @@ export function useSearchController(
         withSearchAI,
         scopeControl: {
             section,
+            sections,
             spaceTitle: getLocalizedTitle(siteSpace, siteSpace.space.language),
             withVariants,
             withSiteVariants,

--- a/packages/gitbook/src/components/Search/useSearchResults.ts
+++ b/packages/gitbook/src/components/Search/useSearchResults.ts
@@ -45,6 +45,7 @@ export function useSearchResults(props: {
     query: string;
     siteSpaceId: string;
     siteSpaceIds: string[];
+    selectedSectionSiteSpaceIds?: string[];
     scope: SearchScope;
     suggestions?: string[];
     /** URL for the search API route (e.g. from linker.toPathInSpace('~gitbook/search')). */
@@ -63,6 +64,7 @@ export function useSearchResults(props: {
         query,
         siteSpaceId,
         siteSpaceIds,
+        selectedSectionSiteSpaceIds,
         scope,
         suggestions,
         searchURL,
@@ -74,8 +76,15 @@ export function useSearchResults(props: {
     const trackEvent = useTrackEvent();
 
     const filterSiteSpaceIds = React.useMemo(
-        () => computeFilterSiteSpaceIds(scope, siteSpaceId, siteSpaceIds, withSections),
-        [scope, siteSpaceId, siteSpaceIds, withSections]
+        () =>
+            computeFilterSiteSpaceIds(
+                scope,
+                siteSpaceId,
+                siteSpaceIds,
+                withSections,
+                selectedSectionSiteSpaceIds
+            ),
+        [scope, siteSpaceId, siteSpaceIds, withSections, selectedSectionSiteSpaceIds]
     );
 
     const { results: localResults } = useLocalSearchResults({
@@ -206,7 +215,12 @@ export function useSearchResults(props: {
 
             try {
                 const resultsPromise = fetchSearch(
-                    computeRemoteSearchScope(scope, siteSpaceId, siteSpaceIds)
+                    computeRemoteSearchScope(
+                        scope,
+                        siteSpaceId,
+                        siteSpaceIds,
+                        selectedSectionSiteSpaceIds
+                    )
                 );
 
                 const onResults = (results: OrderedComputedResult[]) => {
@@ -268,6 +282,7 @@ export function useSearchResults(props: {
         withAI,
         siteSpaceId,
         siteSpaceIds,
+        selectedSectionSiteSpaceIds,
         disabled,
         suggestions,
         searchURL,


### PR DESCRIPTION
## Changes

- list every visible site section in the search scope dropdown, preserving nested section groups
- scope local and remote results to the selected section and its language-compatible variants
- persist an independently selected section in the URL while preserving existing all-docs and current-section behavior
- keep embed demos and frames on the deployment that served them so Cloudflare preview tests exercise the PR bundle

## Testing

- bun run format
- bun run lint
- bun run typecheck
- bun run unit (577 passed, 2 skipped)
- cd packages/gitbook && bun test src/components/Search/search-props.test.ts src/components/Search/filter.test.ts src/components/Search/remote-scope.test.ts src/components/Search/useSearch.test.ts

Fix https://linear.app/gitbook-x/issue/RND-12565/allow-search-to-be-scoped-to-any-section-not-just-the-current-one