### PR TITLE
Wait for integrations to register before showing the cookie banner

### DIFF
--- a/.changeset/cool-donkeys-invite.md
+++ b/.changeset/cool-donkeys-invite.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Stop the built-in cookie banner from flashing on sites using a consent integration such as Osano or OneTrust.

--- a/packages/gitbook/src/components/Integrations/LoadIntegrations.tsx
+++ b/packages/gitbook/src/components/Integrations/LoadIntegrations.tsx
@@ -146,13 +146,31 @@ export function useCustomCookieBanner(): CustomCookieBannerStore {
  */
 export function LoadIntegrations() {
     React.useEffect(() => {
-        // Only dispatch 'load' event when there are scripts to load
-
-        dispatchGitBookIntegrationEvent('load');
-
-        integrationsStore.setState({ loaded: true });
+        return whenIntegrationsReady(() => {
+            dispatchGitBookIntegrationEvent('load');
+            integrationsStore.setState({ loaded: true });
+        });
     }, []);
     return null;
+}
+
+/**
+ * Run `callback` once the integrations have had their chance to register.
+ *
+ * Consent integrations register their cookie banner from a `load` listener, so treating
+ * integrations as loaded at hydration flashed our own cookie banner on sites that ship
+ * their own.
+ */
+function whenIntegrationsReady(callback: () => void): () => void {
+    if (document.readyState === 'complete') {
+        callback();
+        return () => {};
+    }
+
+    // Their listener is registered after ours when their script runs after hydration.
+    const onLoad = () => setTimeout(callback, 0);
+    window.addEventListener('load', onLoad, { once: true });
+    return () => window.removeEventListener('load', onLoad);
 }
 
 /**


### PR DESCRIPTION
On sites with a cookie consent integration (Osano, OneTrust), GitBook's own cookie banner flashed for a second before the integration's took over:

1. React hydrates. LoadIntegrations sets integrationsStore.loaded = true.
2. CookiesToast sees integrations loaded and no custom banner registered, so it renders ours.
3. The browser fires load. The integration's script calls registerCookieBanner.
4. CookiesToast re-renders and hides ours, flashing the cookie banner.

Fix: LoadIntegrations now waits for load before setting loaded, so step 1 happens after step 3.

Tradeoff: on sites with Osano or OneTrust, our banner now appears after load rather than at hydration, a very slight delay.

Fixes RND-12687.