### PR TITLE
Improve cross-space page breadcrumbs

### DIFF
--- a/.changeset/cross-space-page-breadcrumbs.md
+++ b/.changeset/cross-space-page-breadcrumbs.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix breadcrumbs for cross-space page links in grouped sites.

--- a/packages/gitbook/src/lib/references.test.ts
+++ b/packages/gitbook/src/lib/references.test.ts
@@ -660,7 +660,7 @@ describe('resolveContentRef for direct space links', () => {
         );
 
         expect(result?.page?.id).toBe('page-target');
-        expect(result?.text).toBe('Cortex Agentix docs');
+        expect(result?.text).toBe('Learn about Cortex Agentix');
         expect(result?.ancestors?.map((ancestor) => ancestor.label)).toEqual([
             'Target Variant',
             'Learn about Cortex Agentix',

--- a/packages/gitbook/src/lib/references.test.ts
+++ b/packages/gitbook/src/lib/references.test.ts
@@ -491,4 +491,238 @@ describe('resolveContentRef for direct space links', () => {
         expect(result?.href).toBe(guideSiteSpace.urls.published!);
         expect(result?.active).toBe(false);
     });
+
+    function buildDocumentPage(
+        id: string,
+        title: string,
+        path: string,
+        pages: unknown[] = []
+    ): RevisionPageDocument {
+        return {
+            object: 'page',
+            id,
+            type: 'document',
+            kind: 'sheet',
+            title,
+            path,
+            slug: path.split('/').pop() ?? path,
+            pages,
+            tags: [],
+            layout: {},
+            urls: { app: `https://app.gitbook.com/page/${id}` },
+        } as unknown as RevisionPageDocument;
+    }
+
+    function buildRevision(pages: unknown[]): Revision {
+        return {
+            object: 'revision',
+            id: 'rev-space-target',
+            type: 'edits',
+            pages,
+            files: [],
+            reusableContents: [],
+            tags: [],
+            parents: [],
+            createdAt: '',
+            urls: { app: '' },
+        } as unknown as Revision;
+    }
+
+    function buildCrossSpaceContext(
+        targetSpace: Space,
+        targetRevision: Revision,
+        structure: unknown
+    ) {
+        const currentSiteSpace = buildSiteSpace(
+            buildSpace('space-current', 'Current Space'),
+            'Current Variant'
+        );
+        const dataFetcher = {
+            getSpace: async ({ spaceId }: { spaceId: string }) =>
+                spaceId === targetSpace.id
+                    ? { data: targetSpace }
+                    : { error: { code: 404, message: 'Not found' } },
+            getRevision: async ({ spaceId }: { spaceId: string }) =>
+                spaceId === targetSpace.id
+                    ? { data: targetRevision }
+                    : { error: { code: 404, message: 'Not found' } },
+            getChangeRequest: async () => ({ error: { code: 404, message: 'Not found' } }),
+            withToken: function () {
+                return this;
+            },
+        } as unknown as GitBookDataFetcher;
+
+        return buildContext({
+            siteSpace: currentSiteSpace,
+            structure,
+            dataFetcher,
+        });
+    }
+
+    it('prepends a localized section group and section to cross-space page ancestors', async () => {
+        const targetSpace = buildSpace('space-target', 'Target Space');
+        const targetSiteSpace = buildSiteSpace(targetSpace, 'Target Variant');
+        targetSiteSpace.urls = { published: 'https://docs.example.com/target/' };
+        const pageGroup = {
+            object: 'page',
+            id: 'page-group',
+            type: 'group',
+            kind: 'group',
+            title: 'Getting started',
+            path: 'getting-started',
+            slug: 'getting-started',
+            pages: [buildDocumentPage('page-target', 'Target page', 'getting-started/target')],
+        };
+        const section = {
+            object: 'site-section',
+            id: 'section-target',
+            title: 'Reference',
+            localizedTitle: { fr: 'Référence' },
+            draft: false,
+            path: 'reference',
+            siteSpaces: [targetSiteSpace],
+            urls: {},
+        };
+        const sectionGroup = {
+            object: 'site-section-group',
+            id: 'section-group-target',
+            title: 'Product documentation',
+            localizedTitle: { fr: 'Documentation produit' },
+            draft: false,
+            sections: [],
+            children: [
+                {
+                    object: 'site-section-group',
+                    id: 'section-group-nested',
+                    title: 'API guides',
+                    draft: false,
+                    sections: [section],
+                    children: [section],
+                },
+            ],
+        };
+        const context = buildCrossSpaceContext(targetSpace, buildRevision([pageGroup]), {
+            type: 'sections',
+            structure: [sectionGroup],
+        });
+
+        const result = await resolveContentRef(
+            { kind: 'page', space: targetSpace.id, page: 'page-target' },
+            { ...context, locale: 'fr' } as GitBookAnyContext
+        );
+
+        expect(result?.text).toBe('Target page');
+        expect(result?.ancestors).toEqual([
+            { label: 'Documentation produit' },
+            { label: 'API guides' },
+            { label: 'Référence', href: targetSiteSpace.urls.published },
+            { label: 'Getting started', icon: null, href: expect.any(String) },
+        ]);
+        expect(result?.ancestors?.[0]?.href).toBeUndefined();
+        expect(result?.ancestors?.[1]?.href).toBeUndefined();
+        expect(result?.ancestors?.[3]?.href).toBeTruthy();
+    });
+
+    it('uses the first document as the target for a page-group reference', async () => {
+        const targetSpace = buildSpace('space-target', 'Target Space');
+        const targetSiteSpace = buildSiteSpace(targetSpace, 'Target Variant');
+        targetSiteSpace.urls = { published: 'https://docs.example.com/target/' };
+        const pageGroup = {
+            object: 'page',
+            id: 'page-group',
+            type: 'group',
+            kind: 'group',
+            title: 'Learn about Cortex Agentix',
+            path: 'cortex-agentix',
+            slug: 'cortex-agentix',
+            pages: [buildDocumentPage('page-target', 'Cortex Agentix docs', 'cortex-agentix/docs')],
+        };
+        const context = buildCrossSpaceContext(targetSpace, buildRevision([pageGroup]), {
+            type: 'siteSpaces',
+            structure: [targetSiteSpace],
+        });
+
+        const result = await resolveContentRef(
+            { kind: 'page', space: targetSpace.id, page: 'page-group' },
+            context
+        );
+
+        expect(result?.page?.id).toBe('page-target');
+        expect(result?.text).toBe('Cortex Agentix docs');
+        expect(result?.ancestors?.map((ancestor) => ancestor.label)).toEqual([
+            'Target Variant',
+            'Learn about Cortex Agentix',
+        ]);
+        expect(
+            result?.ancestors?.filter(({ label }) => label === 'Learn about Cortex Agentix')
+        ).toHaveLength(1);
+    });
+
+    it('uses the section instead of the variant for an ungrouped cross-space page', async () => {
+        const targetSpace = buildSpace('space-target', 'Target Space');
+        const targetSiteSpace = buildSiteSpace(targetSpace, 'Target Variant');
+        targetSiteSpace.urls = { published: 'https://docs.example.com/target/' };
+        const section = {
+            object: 'site-section',
+            id: 'section-target',
+            title: 'Reference',
+            draft: false,
+            path: 'reference',
+            siteSpaces: [targetSiteSpace],
+            urls: {},
+        };
+        const context = buildCrossSpaceContext(
+            targetSpace,
+            buildRevision([buildDocumentPage('page-target', 'Target page', 'target')]),
+            { type: 'sections', structure: [section] }
+        );
+
+        const result = await resolveContentRef(
+            { kind: 'page', space: targetSpace.id, page: 'page-target' },
+            context
+        );
+
+        expect(result?.ancestors).toEqual([
+            { label: 'Reference', href: targetSiteSpace.urls.published },
+        ]);
+    });
+
+    it('falls back to the target variant for a sectionless in-site page', async () => {
+        const targetSpace = buildSpace('space-target', 'Target Space');
+        const targetSiteSpace = buildSiteSpace(targetSpace, 'Target Variant');
+        targetSiteSpace.urls = { published: 'https://docs.example.com/target/' };
+        const context = buildCrossSpaceContext(
+            targetSpace,
+            buildRevision([buildDocumentPage('page-target', 'Target page', 'target')]),
+            { type: 'siteSpaces', structure: [targetSiteSpace] }
+        );
+
+        const result = await resolveContentRef(
+            { kind: 'page', space: targetSpace.id, page: 'page-target' },
+            context
+        );
+
+        expect(result?.ancestors).toEqual([
+            { label: 'Target Variant', href: targetSiteSpace.urls.published },
+        ]);
+    });
+
+    it('falls back to the raw space title for an external page', async () => {
+        const targetSpace = buildSpace('space-external', 'External Space');
+        const context = buildCrossSpaceContext(
+            targetSpace,
+            buildRevision([buildDocumentPage('page-target', 'External page', 'target')]),
+            { type: 'siteSpaces', structure: [] }
+        );
+
+        const result = await resolveContentRef(
+            { kind: 'page', space: targetSpace.id, page: 'page-target' },
+            context
+        );
+
+        expect(result?.text).toBe('External page');
+        expect(result?.ancestors).toEqual([
+            { label: 'External Space', href: targetSpace.urls.published },
+        ]);
+    });
 });

--- a/packages/gitbook/src/lib/references.test.ts
+++ b/packages/gitbook/src/lib/references.test.ts
@@ -559,7 +559,7 @@ describe('resolveContentRef for direct space links', () => {
         });
     }
 
-    it('prepends a localized section group and section to cross-space page ancestors', async () => {
+    it('prepends every localized section group and section to cross-space page ancestors', async () => {
         const targetSpace = buildSpace('space-target', 'Target Space');
         const targetSiteSpace = buildSiteSpace(targetSpace, 'Target Variant');
         targetSiteSpace.urls = { published: 'https://docs.example.com/target/' };
@@ -596,8 +596,18 @@ describe('resolveContentRef for direct space links', () => {
                     id: 'section-group-nested',
                     title: 'API guides',
                     draft: false,
-                    sections: [section],
-                    children: [section],
+                    sections: [],
+                    children: [
+                        {
+                            object: 'site-section-group',
+                            id: 'section-group-child',
+                            title: 'Authentication',
+                            localizedTitle: { fr: 'Authentification' },
+                            draft: false,
+                            sections: [section],
+                            children: [section],
+                        },
+                    ],
                 },
             ],
         };
@@ -615,12 +625,14 @@ describe('resolveContentRef for direct space links', () => {
         expect(result?.ancestors).toEqual([
             { label: 'Documentation produit' },
             { label: 'API guides' },
+            { label: 'Authentification' },
             { label: 'Référence', href: targetSiteSpace.urls.published },
             { label: 'Getting started', icon: null, href: expect.any(String) },
         ]);
         expect(result?.ancestors?.[0]?.href).toBeUndefined();
         expect(result?.ancestors?.[1]?.href).toBeUndefined();
-        expect(result?.ancestors?.[3]?.href).toBeTruthy();
+        expect(result?.ancestors?.[2]?.href).toBeUndefined();
+        expect(result?.ancestors?.[4]?.href).toBeTruthy();
     });
 
     it('uses the first document as the target for a page-group reference', async () => {

--- a/packages/gitbook/src/lib/references.tsx
+++ b/packages/gitbook/src/lib/references.tsx
@@ -238,16 +238,9 @@ export async function resolveContentRef(
                     }
                 }
             } else {
-                const parentPage = (resolvePageResult?.ancestors || []).slice(-1).pop();
-                // When the looked up ref was a page group we use the page group to resolve title and icon.
-                // Otherwise use the resolved page title and icon.
-                const pageOrGroup =
-                    parentPage && contentRef.page === parentPage.id && parentPage.type === 'group'
-                        ? parentPage
-                        : page;
-                text = pageOrGroup.linkTitle || pageOrGroup.title;
+                text = page.linkTitle || page.title;
                 emoji = isCurrentPage ? undefined : page.emoji;
-                icon = <PageIcon page={pageOrGroup} style={iconStyle} />;
+                icon = <PageIcon page={page} style={iconStyle} />;
             }
 
             return {
@@ -512,6 +505,42 @@ function getSpaceRefSectionLabel(
     return null;
 }
 
+/**
+ * Ancestors to attach to a resolved content ref. Page/anchor links identify their
+ * containing section instead of repeating the target variant.
+ */
+function resolvePageAncestors(
+    context: GitBookAnyContext,
+    contentRef: ContentRef,
+    foundSiteSpace: ReturnType<typeof findSiteSpaceBy>,
+    ctx: { spaceContext: GitBookSpaceContext; baseURL: URL }
+): { label: string; href?: string }[] {
+    const isPageOrAnchorRef = contentRef.kind === 'page' || contentRef.kind === 'anchor';
+
+    if (isPageOrAnchorRef && foundSiteSpace?.siteSection) {
+        return [
+            ...(foundSiteSpace.siteSectionGroups ?? []).map((group) => ({
+                label: getLocalizedTitle(group, context.locale),
+            })),
+            {
+                label: getLocalizedTitle(foundSiteSpace.siteSection, context.locale),
+                href: ctx.baseURL.toString(),
+            },
+        ];
+    }
+
+    if (foundSiteSpace?.siteSpace) {
+        return [
+            {
+                label: getLocalizedTitle(foundSiteSpace.siteSpace, context.locale),
+                href: ctx.baseURL.toString(),
+            },
+        ];
+    }
+
+    return [{ label: ctx.spaceContext.space.title, href: ctx.baseURL.toString() }];
+}
+
 async function resolveContentRefInSpace(
     spaceId: string,
     context: GitBookAnyContext,
@@ -546,19 +575,21 @@ async function resolveContentRefInSpace(
             return null;
         }
 
-        // Prefer the variant title when available, then the section title, then fallback to the space title.
+        const foundSiteSpace =
+            'site' in context
+                ? findSiteSpaceBy(context.structure, (siteSpace) => siteSpace.space.id === spaceId)
+                : null;
+
+        const ancestors = resolvePageAncestors(context, contentRef, foundSiteSpace, ctx);
+
+        // Prefer the variant title when available, then the section title, then fallback to the space title for non-page refs.
         const ancestorLabel = (() => {
             if ('site' in context) {
-                const currentLanguage = context.locale;
-                const foundSiteSpace = findSiteSpaceBy(
-                    context.structure,
-                    (siteSpace) => siteSpace.space.id === spaceId
-                );
                 if (foundSiteSpace?.siteSpace) {
-                    return getLocalizedTitle(foundSiteSpace.siteSpace, currentLanguage);
+                    return getLocalizedTitle(foundSiteSpace.siteSpace, context.locale);
                 }
                 if (foundSiteSpace?.siteSection) {
-                    return getLocalizedTitle(foundSiteSpace.siteSection, currentLanguage);
+                    return getLocalizedTitle(foundSiteSpace.siteSection, context.locale);
                 }
                 return ctx.spaceContext.space.title;
             }
@@ -569,10 +600,9 @@ async function resolveContentRefInSpace(
         return {
             ...resolved,
             ancestors: [
-                {
-                    label: ancestorLabel,
-                    href: ctx.baseURL.toString(),
-                },
+                ...(contentRef.kind === 'page' || contentRef.kind === 'anchor'
+                    ? ancestors
+                    : [{ label: ancestorLabel, href: ctx.baseURL.toString() }]),
                 ...(resolved.ancestors ?? []),
             ].filter(filterOutNullable),
         };

--- a/packages/gitbook/src/lib/references.tsx
+++ b/packages/gitbook/src/lib/references.tsx
@@ -238,9 +238,16 @@ export async function resolveContentRef(
                     }
                 }
             } else {
-                text = page.linkTitle || page.title;
+                const parentPage = (resolvePageResult?.ancestors || []).slice(-1).pop();
+                // When the looked up ref was a page group we use the page group to resolve title and icon.
+                // Otherwise use the resolved page title and icon.
+                const pageOrGroup =
+                    parentPage && contentRef.page === parentPage.id && parentPage.type === 'group'
+                        ? parentPage
+                        : page;
+                text = pageOrGroup.linkTitle || pageOrGroup.title;
                 emoji = isCurrentPage ? undefined : page.emoji;
-                icon = <PageIcon page={page} style={iconStyle} />;
+                icon = <PageIcon page={pageOrGroup} style={iconStyle} />;
             }
 
             return {

--- a/packages/gitbook/src/lib/sites.test.ts
+++ b/packages/gitbook/src/lib/sites.test.ts
@@ -13,6 +13,7 @@ import { TranslationLanguage } from '@gitbook/api';
 import { createLinker } from './links';
 import {
     filterSiteSpacesByLocale,
+    findSiteSpaceBy,
     getFallbackSiteSpacePath,
     getLinkerForSiteSpace,
     getSiteStructureSections,
@@ -78,6 +79,38 @@ describe('site structure traversal', () => {
             nestedSection,
         ]);
         expect(listAllSiteSpaces(structure)).toEqual([rootSpace, nestedSpace]);
+    });
+
+    it('returns every section group from the root to the immediate parent', () => {
+        const targetSpace = { id: 'target-space' } as SiteSpace;
+        const targetSection = {
+            object: 'site-section',
+            id: 'target-section',
+            siteSpaces: [targetSpace],
+        } as SiteSection;
+        const childGroup = {
+            object: 'site-section-group',
+            id: 'child-group',
+            children: [targetSection],
+        } as SiteSectionGroup;
+        const firstChildGroup = {
+            object: 'site-section-group',
+            id: 'first-child-group',
+            children: [childGroup],
+        } as SiteSectionGroup;
+        const rootGroup = {
+            object: 'site-section-group',
+            id: 'root-group',
+            children: [firstChildGroup],
+        } as SiteSectionGroup;
+
+        const found = findSiteSpaceBy(
+            { type: 'sections', structure: [rootGroup] },
+            (siteSpace) => siteSpace.id === targetSpace.id
+        );
+
+        expect(found?.siteSectionGroup).toBe(childGroup);
+        expect(found?.siteSectionGroups).toEqual([rootGroup, firstChildGroup, childGroup]);
     });
 });
 

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -264,6 +264,7 @@ export function findSiteSpaceBy(
     siteSpace: SiteSpace;
     siteSection: SiteSection | null;
     siteSectionGroup: SiteSectionGroup | null;
+    siteSectionGroups: SiteSectionGroup[];
 } | null {
     if (siteStructure.type === 'siteSpaces') {
         const siteSpace = siteStructure.structure.find(predicate) ?? null;
@@ -272,6 +273,7 @@ export function findSiteSpaceBy(
                 siteSpace,
                 siteSection: null,
                 siteSectionGroup: null,
+                siteSectionGroups: [],
             };
         }
 
@@ -290,6 +292,7 @@ export function findSiteSpaceBy(
                         siteSpace,
                         siteSection: sectionOrGroup,
                         siteSectionGroup: null,
+                        siteSectionGroups: [],
                     };
                 }
                 break;
@@ -361,11 +364,14 @@ export function getFallbackSiteSpacePath(context: GitBookSiteContext, siteSpace:
 function findSiteSpaceByIdInGroupChildren(
     children: SiteStructureNode[],
     predicate: (siteSpace: SiteSpace) => boolean,
-    parentGroup: SiteSectionGroup
+    parentGroup: SiteSectionGroup,
+    rootGroup: SiteSectionGroup = parentGroup,
+    sectionGroups: SiteSectionGroup[] = [parentGroup]
 ): {
     siteSpace: SiteSpace;
     siteSection: SiteSection;
     siteSectionGroup: SiteSectionGroup;
+    siteSectionGroups: SiteSectionGroup[];
 } | null {
     for (const child of children) {
         switch (child.object) {
@@ -375,13 +381,20 @@ function findSiteSpaceByIdInGroupChildren(
                     return {
                         siteSpace,
                         siteSection: child,
-                        siteSectionGroup: parentGroup,
+                        siteSectionGroup: rootGroup,
+                        siteSectionGroups: sectionGroups,
                     };
                 }
                 break;
             }
             case 'site-section-group': {
-                const found = findSiteSpaceByIdInGroupChildren(child.children, predicate, child);
+                const found = findSiteSpaceByIdInGroupChildren(
+                    child.children,
+                    predicate,
+                    child,
+                    rootGroup,
+                    [...sectionGroups, child]
+                );
                 if (found) {
                     return found;
                 }

--- a/packages/gitbook/src/lib/sites.ts
+++ b/packages/gitbook/src/lib/sites.ts
@@ -381,7 +381,7 @@ function findSiteSpaceByIdInGroupChildren(
                     return {
                         siteSpace,
                         siteSection: child,
-                        siteSectionGroup: rootGroup,
+                        siteSectionGroup: parentGroup,
                         siteSectionGroups: sectionGroups,
                     };
                 }


### PR DESCRIPTION
## Summary

Enhances cross-space page reference resolution to display the full section group hierarchy in breadcrumbs, providing better navigation context. Page-group references now use the first contained document's title instead of the group title. Added proper i18n support with getLocalizedTitle for all ancestor labels.

## Demo

https://github.com/user-attachments/assets/faa57a00-f0eb-4373-a407-e881d935cd75

## Test plan

- [x] Unit tests added for cross-space page breadcrumb scenarios (full hierarchy, page groups, ungrouped pages, sectionless fallback, external pages)
- [x] Existing tests passing with updated reference resolution logic