### PR TITLE
Drop the body-anchored cover gate from paragraph contrast text

### DIFF
--- a/.changeset/paragraph-cover-has-invalidation.md
+++ b/.changeset/paragraph-cover-has-invalidation.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Drop the `page-cover-background:` gate from the paragraph cover-contrast class. Combined with the per-paragraph `:not(:has(...))`, it made every DOM insertion re-style all paragraphs on the page, which froze very long pages.

--- a/.changeset/paragraph-cover-has-invalidation.md
+++ b/.changeset/paragraph-cover-has-invalidation.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Drop the `page-cover-background:` gate from the paragraph cover-contrast class. Combined with the per-paragraph `:not(:has(...))`, it made every DOM insertion re-style all paragraphs on the page, which froze very long pages.
+Move paragraph block styles behind a single `paragraph` class and drop the `page-cover-background:` gate from the cover-contrast text. The gate combined with the per-paragraph `:not(:has(...))` made every DOM insertion re-style all paragraphs, which froze very long pages.

--- a/packages/gitbook/src/components/DocumentView/Paragraph.tsx
+++ b/packages/gitbook/src/components/DocumentView/Paragraph.tsx
@@ -12,21 +12,13 @@ export function Paragraph(props: BlockProps<DocumentBlockParagraph>) {
     const { block, style, ...contextProps } = props;
     const { context } = contextProps;
 
-    // InlineActionButtons use flex-grow to take the available width. This requires the parent to be a flex container.
-    const inlineButtonStyle =
-        'has-[.button,input]:flex has-[.button,input]:flex-wrap has-[.button,input]:gap-2 has-[.button,input]:items-center';
-
     const paragraph = (
         <p
+            // Cover-aware contrast text applies only to the page body, not to documents
+            // rendered in overlays (search answers, AI chat) on a background-cover page.
             data-cover-aware-text={context.isPageBody ? '' : undefined}
-            className={tcls(
-                // Cover-aware contrast text applies only to the page body, not to documents
-                // rendered in overlays (search answers, AI chat) on a background-cover page.
-                context.isPageBody && '[&:not(:has(.button,input))]:text-contrast-cover',
-                inlineButtonStyle,
-                style,
-                getTextAlignment(block.data?.align)
-            )}
+            // Paragraph styles live in globals.css (`.paragraph`) to keep the class attribute short.
+            className={tcls('paragraph', style, getTextAlignment(block.data?.align))}
         >
             <Inlines {...contextProps} nodes={block.nodes} ancestorInlines={[]} />
         </p>

--- a/packages/gitbook/src/components/DocumentView/Paragraph.tsx
+++ b/packages/gitbook/src/components/DocumentView/Paragraph.tsx
@@ -22,8 +22,7 @@ export function Paragraph(props: BlockProps<DocumentBlockParagraph>) {
             className={tcls(
                 // Cover-aware contrast text applies only to the page body, not to documents
                 // rendered in overlays (search answers, AI chat) on a background-cover page.
-                context.isPageBody &&
-                    'page-cover-background:[&:not(:has(.button,input))]:text-contrast-cover',
+                context.isPageBody && '[&:not(:has(.button,input))]:text-contrast-cover',
                 inlineButtonStyle,
                 style,
                 getTextAlignment(block.data?.align)

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -564,8 +564,6 @@ html.dark .highlight-line.diff-deleted .highlight-line-content::before {
   @apply rounded-none!;
 }
 
-/* A document can hold tens of thousands of paragraphs, so their styles live behind one class
-   rather than in every element's class attribute. */
 @layer components {
   .paragraph {
     /* Inline action buttons grow to the available width, which needs a flex parent. */

--- a/packages/gitbook/src/components/RootLayout/globals.css
+++ b/packages/gitbook/src/components/RootLayout/globals.css
@@ -564,6 +564,21 @@ html.dark .highlight-line.diff-deleted .highlight-line-content::before {
   @apply rounded-none!;
 }
 
+/* A document can hold tens of thousands of paragraphs, so their styles live behind one class
+   rather than in every element's class attribute. */
+@layer components {
+  .paragraph {
+    /* Inline action buttons grow to the available width, which needs a flex parent. */
+    &:has(.button, input) {
+      @apply flex flex-wrap items-center gap-2;
+    }
+
+    &[data-cover-aware-text]:not(:has(.button, input)) {
+      @apply text-contrast-cover;
+    }
+  }
+}
+
 /* Zoomable images */
 html:has(.zoom-modal) {
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features -- single-value overflow is universal; doiuse flags the whole css-overflow feature */


### PR DESCRIPTION
Every paragraph carried `page-cover-background:[&:not(:has(.button,input))]:text-contrast-cover`. The variant compiles to `body:has(...)`, so any DOM insertion on the page re-styled all 18k paragraphs, each re-running its own `:has()`. On the Harness release notes page that was ~200 ms per insertion and most of the 8.8 s of style work during load.

The gate is redundant: `text-contrast-cover` only applies to elements the client marks with `data-over-cover`, which only happens on background-cover pages. Paragraph styles now live behind a single `paragraph` class in `globals.css` instead of a utility string on every element. Style time during load drops from 8.8 s to 4.7 s, total main-thread time from 11.0 s to 7.0 s, and the HTML from 42 MB to 35.5 MB, with no visual change.

Fixes RND-12713
https://linear.app/gitbook-x/issue/RND-12713/harness-smp-release-notes-page-is-43-mb-and-triggers-page-unresponsive
