### PR TITLE
Open inline Ask AI questions in the configured assistant

### DIFF
--- a/.changeset/clean-cats-ask.md
+++ b/.changeset/clean-cats-ask.md
@@ -1,0 +1,5 @@
+---
+'gitbook': patch
+---
+
+Fix inline Ask AI buttons opening a configured custom assistant.

--- a/packages/gitbook/src/components/DocumentView/InlineActionButton.tsx
+++ b/packages/gitbook/src/components/DocumentView/InlineActionButton.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useAI, useAIChatController, useAIChatState } from '../AI';
+import { useAI, useAIChatState } from '../AI';
 import { Button, type ButtonProps, Input } from '../primitives';
 import { useSetSearchState } from '../Search';
 import { tString, useLanguage } from '@/intl/client';
@@ -18,17 +18,13 @@ export function InlineActionButton(
     const { action, query, buttonProps } = props;
 
     const { assistants } = useAI();
-    const chatController = useAIChatController();
     const chatState = useAIChatState();
     const setSearchState = useSetSearchState();
     const language = useLanguage();
 
     const handleSubmit = (value: string) => {
         if (action === 'ask') {
-            chatController.open();
-            if (value ?? query) {
-                chatController.postMessage({ message: value ?? query });
-            }
+            assistants[0]?.open(value || query);
         } else if (action === 'search') {
             setSearchState((prev) => ({
                 ...prev,


### PR DESCRIPTION
Fix inline Ask AI buttons so they open and submit the question to the configured assistant.

`useAI` returns the built-in AI surface first, either Chat or AI Search, followed by configured integration assistants. Inline `Ask` buttons now use that first assistant instead of calling GitBook Chat directly.

https://github.com/GitbookIO/gitbook/blob/73fda8c459c670b55ac0b965c1fd1c01725cbbc1/packages/gitbook/src/components/AI/useAI.tsx#L94-L150