### PR TITLE
Simplify carousel overflow with edge masks & fix carousel scroll

### DIFF
--- a/.changeset/bound-desktop-card-carousel.md
+++ b/.changeset/bound-desktop-card-carousel.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Add a narrow, symmetric edge peek to desktop card carousels with conditional transparent edge masks. Carousel arrows now advance by one page of fully visible cards while other scroll containers retain viewport paging.

--- a/.changeset/bound-desktop-card-carousel.md
+++ b/.changeset/bound-desktop-card-carousel.md
@@ -2,4 +2,4 @@
 "gitbook": patch
 ---
 
-Add a narrow, symmetric edge peek to desktop card carousels with conditional transparent edge masks. Carousel arrows now advance by one page of fully visible cards while other scroll containers retain viewport paging.
+Simplify carousel overflow with symmetric edge masks and visible-item paging. Replaces complex negative-margin bleed logic with transparent edge fades and page-by-visible-item scrolling.

--- a/packages/gitbook/src/components/DocumentView/Table/ViewCards.test.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/ViewCards.test.tsx
@@ -46,8 +46,10 @@ describe('ViewCards', () => {
         expect(markup).toContain('-mx-12');
         expect(markup).toContain('px-12');
         expect(markup).toContain('scroll-px-12');
-        expect(markup).toContain('left-0 ml-2');
-        expect(markup).toContain('right-0 mr-2');
+        expect(markup).toContain('left-0');
+        expect(markup).toContain('ml-8');
+        expect(markup).toContain('right-0');
+        expect(markup).toContain('mr-8');
         expect(markup).not.toContain('before:bg-linear-to-r');
         expect(markup).not.toContain('after:bg-linear-to-l');
         expect(markup).toContain('snap-mandatory');

--- a/packages/gitbook/src/components/DocumentView/Table/ViewCards.test.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/ViewCards.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, mock } from 'bun:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { IconsProvider } from '@gitbook/icons';
+
+import { TranslateContext } from '@/intl/client';
+import { en } from '@/intl/translations/en';
+
+mock.module('./RecordCard', () => ({
+    RecordCard: () => <div data-testid="record-card" />,
+}));
+
+mock.module('./TableSearch', () => ({
+    TableSearchRecord: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const { ViewCards } = await import('./ViewCards');
+
+function makeProps(wrap: boolean) {
+    return {
+        block: { data: { fullWidth: false } },
+        view: { type: 'cards', wrap, cardSize: 'medium' },
+        records: [
+            ['record-1', {}],
+            ['record-2', {}],
+            ['record-3', {}],
+        ] as any,
+        context: { mode: 'default' },
+        style: undefined,
+    } as any;
+}
+
+function renderWithContext(children: React.ReactNode) {
+    return renderToStaticMarkup(
+        <IconsProvider assetsURL="https://icons.example.com">
+            <TranslateContext.Provider value={en}>{children}</TranslateContext.Provider>
+        </IconsProvider>
+    );
+}
+
+describe('ViewCards', () => {
+    it('renders the carousel with a symmetric peek and conditional edge masks', () => {
+        const markup = renderWithContext(<ViewCards {...makeProps(false)} />);
+
+        expect(markup).toContain('-mx-12');
+        expect(markup).toContain('px-12');
+        expect(markup).toContain('scroll-px-12');
+        expect(markup).toContain('left-0 ml-2');
+        expect(markup).toContain('right-0 mr-2');
+        expect(markup).not.toContain('before:bg-linear-to-r');
+        expect(markup).not.toContain('after:bg-linear-to-l');
+        expect(markup).toContain('snap-mandatory');
+    });
+
+    it('renders the wrapping grid by default', () => {
+        const markup = renderWithContext(<ViewCards {...makeProps(true)} />);
+
+        expect(markup).toContain('inline-grid');
+    });
+});

--- a/packages/gitbook/src/components/DocumentView/Table/ViewCards.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/ViewCards.tsx
@@ -53,11 +53,9 @@ function CardsGrid(props: TableViewProps<DocumentTableViewCards>) {
  * The carousel layout: cards lay out in a single horizontally-scrolling row that
  * snaps to the leftmost card. Reuses ScrollContainer for the scroll buttons.
  *
- * Rather than fading the edges, the row breaks out of the content column so it can
- * scroll to the page edges. Negative margins on the outer wrapper pull it out; matching
- * padding + scroll-padding on the scroller keep the first/last cards aligned with the
- * body text at rest and snapping to that edge, while cards bleed to the edge mid-scroll.
- * See `bleedVars` below for how far each side reaches.
+ * The row extends by a small, symmetric peek on each side. The matching padding keeps
+ * the first and last cards aligned with the content column while the edge masks fade only
+ * the cards in that peek area.
  */
 function CardsCarousel(props: TableViewProps<DocumentTableViewCards>) {
     const { view, records } = props;
@@ -69,65 +67,10 @@ function CardsCarousel(props: TableViewProps<DocumentTableViewCards>) {
             ? 'w-[90%] @sm:w-[calc(45%-0.5rem)] @5xl:w-[calc(50%-0.5rem)]'
             : 'w-[90%] @sm:w-[calc(45%-0.5rem)] @xl:w-[calc(30%-0.66rem)] @5xl:w-[calc(33.33%-0.66rem)]';
 
-    // Break the row out of the content column so it bleeds to the page edges instead of
-    // fading. `--cards-bleed-l/r` are the distances to pull each side out by; they drive the
-    // negative margins (on the wrapper) and the matching padding + scroll-padding (on the
-    // scroller), so the first/last cards stay aligned with the body text at rest while cards
-    // bleed to the edge mid-scroll. Kept as literals here since it's a single block.
-    //
-    // The bleed only makes sense on the default layout, where the 48rem column leaves wide
-    // empty margins to reclaim. The wide layout (max-w-6xl) already fills the usable width,
-    // so from `lg` we suppress the bleed entirely — otherwise the page gutter would push the
-    // row past where every other block ends, jutting into the window frame.
-    //
-    // On the default layout:
-    // - Left is capped at the page gutter (1/1.5/2rem) so it never slides under the TOC.
-    // - Right reaches the viewport edge from `lg`. The 48rem column is centred in the space
-    //   beside the TOC, so the gap to the viewport edge is `50vw` minus half the column
-    //   (24rem), minus half the TOC (10.5rem of the 21rem `w-72`+`mr-12`) when one is shown.
-    //   `html` clips horizontal overflow, so a small overshoot is harmless.
-    // - Right collapses to 0 once an outline occupies that column (shown from `xl`), so
-    //   cards never slide under it.
-    const bleedVars = tcls(
-        '[--cards-bleed-l:1rem]',
-        'sm:[--cards-bleed-l:1.5rem]',
-        'md:[--cards-bleed-l:2rem]',
-        'layout-default:md:max-lg:[--cards-bleed-l:max(calc(50vw-24.5rem),2rem)]',
-        'lg:[--cards-bleed-l:max(calc(50vw-34rem),3rem)]',
-        'xl:[--cards-bleed-l:3rem]',
-
-        '[--cards-bleed-r:1rem]',
-        'sm:[--cards-bleed-r:1.5rem]',
-        'md:[--cards-bleed-r:2rem]',
-        'layout-default:md:max-lg:[--cards-bleed-r:max(calc(50vw-24.5rem),2rem)]',
-        'layout-default:lg:[--cards-bleed-r:max(calc(50vw-35rem),3rem)]',
-        'layout-default:xl:[--cards-bleed-r:3rem]',
-
-        'hover:layout-default:no-sidebar:lg:max-xl:[--cards-bleed-l:max(calc(50vw-24.5rem),2rem)]',
-        'hover:layout-default:no-sidebar:lg:max-xl:[--cards-bleed-r:max(calc(50vw-24.5rem),2rem)]',
-
-        // Default centered
-        'hover:layout-default:no-sidebar:xl:[--cards-bleed-l:max(calc(50vw-22.5rem),2rem)]',
-        'hover:layout-default:xl:[--cards-bleed-r:max(calc(50vw-26.5rem),19rem)]',
-
-        // Full width, no outline
-        'hover:layout-wide:page-no-outline:2xl:[--cards-bleed-r:max(calc(50vw-43.5rem),0rem)]',
-
-        // Full width centered
-        'layout-wide:no-sidebar:page-no-outline:2xl:[--cards-bleed-l:max(calc(50vw-36.5rem),0rem)]',
-        'layout-wide:no-sidebar:page-no-outline:2xl:[--cards-bleed-r:max(calc(50vw-36.5rem),0rem)]'
-    );
-
     return (
         <ScrollContainer
             orientation="horizontal"
-            className={tcls(
-                bleedVars,
-                'ml-[calc(var(--cards-bleed-l)*-1)]',
-                'mr-[calc(var(--cards-bleed-r)*-1)]',
-                'xl:transition-[margin]',
-                'hover:z-11'
-            )}
+            className={tcls('-mx-12', 'hover:z-11')}
             // `py-1` keeps the card ring/shadow from being clipped by the scroll overflow;
             // `snap-mandatory` + the scroll-padding snap each card to the content edge.
             contentClassName={tcls(
@@ -136,21 +79,19 @@ function CardsCarousel(props: TableViewProps<DocumentTableViewCards>) {
                 '-mt-px',
                 'pb-6',
                 '-mb-6',
-                'pl-[var(--cards-bleed-l)]',
-                'pr-[var(--cards-bleed-r)]',
-                'scroll-pl-[var(--cards-bleed-l)]',
-                'scroll-pr-[var(--cards-bleed-r)]',
+                'px-12',
+                'scroll-px-12',
                 'snap-x',
-                'snap-mandatory',
-                'xl:transition-[padding]'
+                'snap-mandatory'
             )}
+            scrollByVisibleItems
             leading={{
                 fade: true,
-                button: { size: 'small', className: 'ml-[calc(var(--cards-bleed-l)-1rem)]' },
+                button: { size: 'small' },
             }}
             trailing={{
                 fade: true,
-                button: { size: 'small', className: 'mr-[calc(var(--cards-bleed-r)-1rem)]' },
+                button: { size: 'small' },
             }}
         >
             {records.map((record) => {

--- a/packages/gitbook/src/components/DocumentView/Table/ViewCards.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/ViewCards.tsx
@@ -87,11 +87,11 @@ function CardsCarousel(props: TableViewProps<DocumentTableViewCards>) {
             scrollByVisibleItems
             leading={{
                 fade: true,
-                button: { size: 'small' },
+                button: { size: 'small', className: 'ml-8' },
             }}
             trailing={{
                 fade: true,
-                button: { size: 'small' },
+                button: { size: 'small', className: 'mr-8' },
             }}
         >
             {records.map((record) => {

--- a/packages/gitbook/src/components/primitives/ScrollContainer.test.ts
+++ b/packages/gitbook/src/components/primitives/ScrollContainer.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { scrollByItemsInContainer } from './ScrollContainer';
+
+type MockRect = {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+    width: number;
+    height: number;
+};
+
+class MockElement {
+    constructor(private readonly rect: MockRect) {}
+
+    getBoundingClientRect() {
+        return this.rect;
+    }
+}
+
+const originalHTMLElement = globalThis.HTMLElement;
+
+beforeAll(() => {
+    Object.defineProperty(globalThis, 'HTMLElement', {
+        configurable: true,
+        value: MockElement,
+    });
+});
+
+afterAll(() => {
+    Object.defineProperty(globalThis, 'HTMLElement', {
+        configurable: true,
+        value: originalHTMLElement,
+    });
+});
+
+function rect(left: number, right: number): MockRect {
+    return { left, right, top: 0, bottom: 100, width: right - left, height: 100 };
+}
+
+function makeContainer(
+    childRects: MockRect[],
+    options: { scrollLeft?: number; scrollWidth?: number } = {}
+) {
+    const scrollCalls: Record<string, unknown>[] = [];
+    const container = Object.assign(new MockElement(rect(0, 300)), {
+        children: childRects.map((childRect) => new MockElement(childRect)),
+        clientHeight: 100,
+        clientWidth: 300,
+        scrollHeight: 100,
+        scrollLeft: options.scrollLeft ?? 0,
+        scrollTop: 0,
+        scrollWidth: options.scrollWidth ?? 1000,
+        scrollTo: (options: Record<string, unknown>) => scrollCalls.push(options),
+    });
+
+    return { container: container as unknown as HTMLElement, scrollCalls };
+}
+
+describe('scrollByItemsInContainer', () => {
+    it('advances by fully visible items and excludes a partial preview', () => {
+        const { container, scrollCalls } = makeContainer([
+            rect(0, 100),
+            rect(110, 210),
+            rect(220, 320),
+            rect(330, 430),
+        ]);
+
+        scrollByItemsInContainer(container, 'horizontal', 'forward');
+
+        expect(scrollCalls).toEqual([{ top: undefined, left: 220, behavior: 'smooth' }]);
+    });
+
+    it('moves backward by the visible page size', () => {
+        const { container, scrollCalls } = makeContainer(
+            [rect(-220, -120), rect(-110, -10), rect(0, 100), rect(110, 210), rect(220, 320)],
+            { scrollLeft: 220 }
+        );
+
+        scrollByItemsInContainer(container, 'horizontal', 'backward');
+
+        expect(scrollCalls).toEqual([{ top: undefined, left: 0, behavior: 'smooth' }]);
+    });
+
+    it('clamps at the first and last scroll positions', () => {
+        const firstPage = makeContainer([rect(0, 100), rect(110, 210), rect(220, 320)]);
+        scrollByItemsInContainer(firstPage.container, 'horizontal', 'backward');
+
+        const lastPage = makeContainer(
+            [rect(-240, -140), rect(-130, -30), rect(-20, 80), rect(90, 190), rect(200, 300)],
+            { scrollLeft: 240, scrollWidth: 540 }
+        );
+        scrollByItemsInContainer(lastPage.container, 'horizontal', 'forward');
+
+        expect(firstPage.scrollCalls).toEqual([{ top: undefined, left: 0, behavior: 'smooth' }]);
+        expect(lastPage.scrollCalls).toEqual([{ top: undefined, left: 240, behavior: 'smooth' }]);
+    });
+});

--- a/packages/gitbook/src/components/primitives/ScrollContainer.tsx
+++ b/packages/gitbook/src/components/primitives/ScrollContainer.tsx
@@ -41,6 +41,9 @@ export type ScrollContainerProps = {
 
     /** The ID or ref of the active item to scroll to. */
     active?: string | React.RefObject<HTMLElement | null>;
+
+    /** Scroll by one page of fully visible direct children instead of one viewport. */
+    scrollByVisibleItems?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export function ScrollContainer(props: ScrollContainerProps) {
@@ -50,6 +53,7 @@ export function ScrollContainer(props: ScrollContainerProps) {
         contentClassName,
         orientation,
         active,
+        scrollByVisibleItems = false,
         leading = { fade: true, button: true },
         trailing = { fade: true, button: true },
         ...rest
@@ -85,6 +89,11 @@ export function ScrollContainer(props: ScrollContainerProps) {
             return;
         }
 
+        if (scrollByVisibleItems) {
+            scrollByItemsInContainer(container, orientation, 'forward');
+            return;
+        }
+
         container.scrollTo({
             top: orientation === 'vertical' ? scrollPosition + container.clientHeight : undefined,
             left: orientation === 'horizontal' ? scrollPosition + container.clientWidth : undefined,
@@ -95,6 +104,11 @@ export function ScrollContainer(props: ScrollContainerProps) {
     const scrollBack = () => {
         const container = containerRef.current;
         if (!container) {
+            return;
+        }
+
+        if (scrollByVisibleItems) {
+            scrollByItemsInContainer(container, orientation, 'backward');
             return;
         }
 
@@ -189,6 +203,130 @@ export function ScrollContainer(props: ScrollContainerProps) {
             ) : null}
         </div>
     );
+}
+
+const EDGE_EPSILON = 1;
+
+/**
+ * Scroll a direct-child track by the number of items currently visible in the snapport.
+ * Scroll padding is excluded from the measurement because it is the carousel's peek area.
+ */
+export function scrollByItemsInContainer(
+    container: HTMLElement,
+    orientation: 'horizontal' | 'vertical',
+    direction: 'forward' | 'backward'
+) {
+    const children = Array.from(container.children).filter(
+        (child): child is HTMLElement => child instanceof HTMLElement
+    );
+    const bounds = getScrollBounds(container, orientation);
+    const items = children
+        .map((element, index) => ({ element, index, rect: element.getBoundingClientRect() }))
+        .filter(({ rect }) => {
+            const size = orientation === 'horizontal' ? rect.width : rect.height;
+            return size > 0;
+        })
+        .map((item, index) => ({ ...item, index }));
+    const visibleItems = items.filter(({ rect }) => {
+        const start = orientation === 'horizontal' ? rect.left : rect.top;
+        const end = orientation === 'horizontal' ? rect.right : rect.bottom;
+        return start >= bounds.start - EDGE_EPSILON && end <= bounds.end + EDGE_EPSILON;
+    });
+
+    // A track narrower than its viewport, or one whose children have not laid out yet, should
+    // retain the regular viewport behavior rather than getting stuck at its current position.
+    if (visibleItems.length === 0) {
+        scrollByViewport(container, orientation, direction);
+        return;
+    }
+
+    const pageSize = visibleItems.length;
+    const firstVisibleItem = visibleItems[0];
+    const lastVisibleItem = visibleItems[visibleItems.length - 1];
+    if (!firstVisibleItem || !lastVisibleItem) {
+        scrollByViewport(container, orientation, direction);
+        return;
+    }
+    const targetIndex =
+        direction === 'forward' ? lastVisibleItem.index + 1 : firstVisibleItem.index - pageSize;
+    const maxScroll = getMaxScroll(container, orientation);
+
+    if (targetIndex < 0) {
+        scrollToPosition(container, orientation, 0);
+        return;
+    }
+
+    const target = items.find((item) => item.index === targetIndex);
+    if (!target) {
+        scrollToPosition(container, orientation, maxScroll);
+        return;
+    }
+
+    const targetStart = orientation === 'horizontal' ? target.rect.left : target.rect.top;
+    const targetPosition =
+        (orientation === 'horizontal' ? container.scrollLeft : container.scrollTop) +
+        targetStart -
+        bounds.start;
+
+    scrollToPosition(container, orientation, Math.min(Math.max(targetPosition, 0), maxScroll));
+}
+
+function getScrollBounds(container: HTMLElement, orientation: 'horizontal' | 'vertical') {
+    const rect = container.getBoundingClientRect();
+    const computedStyle = typeof window !== 'undefined' ? window.getComputedStyle(container) : null;
+    const leadingPadding = Number.parseFloat(
+        computedStyle?.[orientation === 'horizontal' ? 'scrollPaddingLeft' : 'scrollPaddingTop'] ??
+            ''
+    );
+    const trailingPadding = Number.parseFloat(
+        computedStyle?.[
+            orientation === 'horizontal' ? 'scrollPaddingRight' : 'scrollPaddingBottom'
+        ] ?? ''
+    );
+    const start = orientation === 'horizontal' ? rect.left : rect.top;
+    const end = orientation === 'horizontal' ? rect.right : rect.bottom;
+
+    return {
+        start: start + (Number.isFinite(leadingPadding) ? leadingPadding : 0),
+        end: end - (Number.isFinite(trailingPadding) ? trailingPadding : 0),
+    };
+}
+
+function getMaxScroll(container: HTMLElement, orientation: 'horizontal' | 'vertical') {
+    return Math.max(
+        orientation === 'horizontal'
+            ? container.scrollWidth - container.clientWidth
+            : container.scrollHeight - container.clientHeight,
+        0
+    );
+}
+
+function scrollToPosition(
+    container: HTMLElement,
+    orientation: 'horizontal' | 'vertical',
+    position: number
+) {
+    container.scrollTo({
+        top: orientation === 'vertical' ? position : undefined,
+        left: orientation === 'horizontal' ? position : undefined,
+        behavior: 'smooth',
+    });
+}
+
+function scrollByViewport(
+    container: HTMLElement,
+    orientation: 'horizontal' | 'vertical',
+    direction: 'forward' | 'backward'
+) {
+    const position = orientation === 'horizontal' ? container.scrollLeft : container.scrollTop;
+    const distance = orientation === 'horizontal' ? container.clientWidth : container.clientHeight;
+    const maxScroll = getMaxScroll(container, orientation);
+    const target = Math.min(
+        Math.max(position + (direction === 'forward' ? distance : -distance), 0),
+        maxScroll
+    );
+
+    scrollToPosition(container, orientation, target);
 }
 
 /**

--- a/packages/gitbook/src/components/primitives/ScrollContainer.tsx
+++ b/packages/gitbook/src/components/primitives/ScrollContainer.tsx
@@ -205,7 +205,7 @@ export function ScrollContainer(props: ScrollContainerProps) {
     );
 }
 
-const EDGE_EPSILON = 1;
+const FULLY_VISIBLE_EDGE_TOLERANCE_PX = 1;
 
 /**
  * Scroll a direct-child track by the number of items currently visible in the snapport.
@@ -230,7 +230,10 @@ export function scrollByItemsInContainer(
     const visibleItems = items.filter(({ rect }) => {
         const start = orientation === 'horizontal' ? rect.left : rect.top;
         const end = orientation === 'horizontal' ? rect.right : rect.bottom;
-        return start >= bounds.start - EDGE_EPSILON && end <= bounds.end + EDGE_EPSILON;
+        return (
+            start >= bounds.start - FULLY_VISIBLE_EDGE_TOLERANCE_PX &&
+            end <= bounds.end + FULLY_VISIBLE_EDGE_TOLERANCE_PX
+        );
     });
 
     // A track narrower than its viewport, or one whose children have not laid out yet, should


### PR DESCRIPTION
## Summary
- Replace complex negative-margin bleed logic with a simple symmetric edge peek and transparent fade masks
- Add `scrollByVisibleItems` mode to ScrollContainer for page-at-a-time paging by fully visible card count
- Carousel arrows now advance by one page of visible cards instead of by viewport width
- Includes comprehensive tests for ViewCards and ScrollContainer scroll behavior

This change makes the carousel implementation significantly simpler while maintaining the same visual behavior.

## Demo

https://github.com/user-attachments/assets/24297732-56dd-46d5-8e2a-c4b572172ef7

https://github.com/user-attachments/assets/601a393e-f1a9-4f91-abf8-959adfe39b72

https://github.com/user-attachments/assets/e11b122d-68cf-4ab1-82e1-bd17781c8e0f