### PR TITLE
Scroll to top when selecting current page in search

### DIFF
--- a/.changeset/rnd-12673-search-current-page.md
+++ b/.changeset/rnd-12673-search-current-page.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Scroll to the top when selecting a search result for the page already being viewed.

--- a/packages/gitbook/src/components/Search/SearchResults.tsx
+++ b/packages/gitbook/src/components/Search/SearchResults.tsx
@@ -198,14 +198,23 @@ export const SearchResults = React.forwardRef(function SearchResults(
                             const itemKey = getResultKey(item);
                             const shouldAnimateItem =
                                 shouldAnimateResults || !seenResultKeys.current.has(itemKey);
-                            const handleResultSelect = () => {
+                            const handleResultSelect = (
+                                event: React.MouseEvent<HTMLAnchorElement>
+                            ) => {
+                                const isPageResult =
+                                    item.type === 'local-page' ||
+                                    item.type === 'page' ||
+                                    item.type === 'record';
+
                                 if (
-                                    query &&
-                                    siteSpaceId &&
-                                    (item.type === 'local-page' ||
-                                        item.type === 'page' ||
-                                        item.type === 'record')
+                                    isPageResult &&
+                                    !event.currentTarget.hash &&
+                                    event.currentTarget.pathname === window.location.pathname
                                 ) {
+                                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                                }
+
+                                if (query && siteSpaceId && isPageResult) {
                                     addRecentSearchQuery(siteSpaceId, query, 'search');
                                 }
 


### PR DESCRIPTION
## Summary
When a user selects a search result for a page they're already viewing, scroll to the top of that page to focus their attention and provide clear feedback that the action was registered.

## Demo

https://github.com/user-attachments/assets/bda9adbf-1b17-4f19-a6e6-b421a4cbdfb9


## Changes
- Modified the search result handler to detect when a result links to the current page
- Added smooth scroll-to-top behavior for same-page selections
- Extracted page type checking into a reusable variable for clarity
