### PR TITLE
Fix MCP/Markdown copy confirmation closing dropdown instantly

### DIFF
--- a/.changeset/mcp-copy-confirmation-dropdown.md
+++ b/.changeset/mcp-copy-confirmation-dropdown.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the page-actions dropdown closing before the "Copied" confirmation could be shown when copying the MCP server URL, an MCP install command, or the page as Markdown.

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -93,18 +93,17 @@ const createCopiedStateStore = () => {
                 clearTimeout(timeoutRef);
             }
 
-            try {
-                await navigator.clipboard.writeText(data);
-            } catch {
-                return;
-            }
+            await navigator.clipboard.writeText(data);
 
             set({ copied: true });
 
             timeoutRef = setTimeout(() => {
-                set({ copied: false });
                 onSuccess?.();
                 timeoutRef = null;
+
+                // Delay resetting the label past the dropdown's closing animation (`scaleOut`,
+                // 200ms) so the "Copied" label doesn't flip back while still visible mid-fade.
+                setTimeout(() => set({ copied: false }), 200);
             }, 1500);
         },
     }));
@@ -157,11 +156,7 @@ export function ActionCopyMarkdown(props: {
         return result;
     };
 
-    const onClick = async (e: React.MouseEvent) => {
-        if (!isDefaultAction) {
-            e.preventDefault();
-        }
-
+    const onClick = async () => {
         copy(markdownCache.get(markdownPageURL) || (await fetchMarkdown()), {
             onSuccess: () => {
                 // We close the dropdown menu if the action is a dropdown menu item and not the default action.
@@ -424,9 +419,7 @@ export function CopyToClipboard(props: {
             icon={copied ? 'check' : icon}
             label={copied ? tString(language, 'code_copied') : label}
             description={description}
-            onClick={(e) => {
-                e.preventDefault();
-
+            onClick={() => {
                 copy(data, {
                     onSuccess: () => {
                         if (type === 'dropdown-menu-item') {

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -99,11 +99,13 @@ const createCopiedStateStore = () => {
 
             timeoutRef = setTimeout(() => {
                 onSuccess?.();
-                timeoutRef = null;
 
                 // Delay resetting the label past the dropdown's closing animation (`scaleOut`,
                 // 200ms) so the "Copied" label doesn't flip back while still visible mid-fade.
-                setTimeout(() => set({ copied: false }), 200);
+                timeoutRef = setTimeout(() => {
+                    set({ copied: false });
+                    timeoutRef = null;
+                }, 200);
             }, 1500);
         },
     }));

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -93,7 +93,11 @@ const createCopiedStateStore = () => {
                 clearTimeout(timeoutRef);
             }
 
-            await navigator.clipboard.writeText(data);
+            try {
+                await navigator.clipboard.writeText(data);
+            } catch {
+                return;
+            }
 
             set({ copied: true });
 
@@ -154,8 +158,6 @@ export function ActionCopyMarkdown(props: {
     };
 
     const onClick = async (e: React.MouseEvent) => {
-        // Prevent default behavior for non-default actions to avoid closing the dropdown.
-        // This allows showing transient UI (e.g., a "copied" state) inside the menu item.
         if (!isDefaultAction) {
             e.preventDefault();
         }
@@ -179,6 +181,7 @@ export function ActionCopyMarkdown(props: {
             description={tString(language, 'copy_page_markdown')}
             onClick={onClick}
             loading={loading}
+            closeOnClick={false}
         />
     );
 }
@@ -432,6 +435,7 @@ export function CopyToClipboard(props: {
                     },
                 });
             }}
+            closeOnClick={false}
         />
     );
 }
@@ -453,6 +457,7 @@ function PageActionWrapper(props: {
     target?: React.HTMLAttributeAnchorTarget;
     disabled?: boolean;
     loading?: boolean;
+    closeOnClick?: boolean;
 }) {
     const {
         type,
@@ -465,6 +470,7 @@ function PageActionWrapper(props: {
         description,
         disabled,
         loading,
+        closeOnClick,
     } = props;
 
     if (type === 'button') {
@@ -498,6 +504,7 @@ function PageActionWrapper(props: {
             target={target}
             onClick={onClick}
             disabled={disabled || loading}
+            closeOnClick={closeOnClick}
         >
             <div className="flex size-5 items-center justify-center text-tint">
                 {loading ? (


### PR DESCRIPTION
## Summary

Fixed the page-actions dropdown closing before the "Copied" confirmation could be shown when copying the MCP server URL, MCP install command, or page as Markdown.

The fix introduces a delayed reset of the "Copied" label that accounts for the dropdown's closing animation (200ms), preventing the label from disappearing mid-fade. It also adds a `closeOnClick` prop to the `PageActionWrapper` to let certain actions keep the dropdown open temporarily for transient UI like copy confirmations.

## Demo

https://github.com/user-attachments/assets/77e7a27a-aa9a-438e-a17a-224c7d7d7736
