### PR TITLE
Resolve `.md` page URLs in the MCP getPage tool

### DIFF
--- a/.changeset/mcp-getpage-markdown-urls.md
+++ b/.changeset/mcp-getpage-markdown-urls.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the MCP `getPage` tool returning "Page not found" for the Markdown URL of a page (`<page>.md`), which is the form linked from `llms.txt` and the "View as Markdown" page action.

--- a/packages/gitbook/src/lib/pages.test.ts
+++ b/packages/gitbook/src/lib/pages.test.ts
@@ -50,6 +50,27 @@ describe('extractPagePath', () => {
     it('returns empty string when URL equals root base URL', () => {
         expect(extractPagePath('https://docs.example.com/', 'https://docs.example.com/')).toBe('');
     });
+
+    it('resolves the markdown version of a page to the page path', () => {
+        expect(extractPagePath('https://docs.example.com/api/getting-started.md', baseURL)).toBe(
+            'getting-started'
+        );
+        expect(
+            extractPagePath('https://docs.example.com/api/guides/installation.md/', baseURL)
+        ).toBe('guides/installation');
+        expect(
+            extractPagePath('https://docs.example.com/readme.md', 'https://docs.example.com/')
+        ).toBe('readme');
+    });
+
+    it('only strips a trailing .md extension', () => {
+        expect(extractPagePath('https://docs.example.com/api/guides/md-files', baseURL)).toBe(
+            'guides/md-files'
+        );
+        expect(extractPagePath('https://docs.example.com/api/notes.md.html', baseURL)).toBe(
+            'notes.md.html'
+        );
+    });
 });
 
 describe('resolveFirstDocument', () => {

--- a/packages/gitbook/src/lib/pages.ts
+++ b/packages/gitbook/src/lib/pages.ts
@@ -8,7 +8,7 @@ import {
     RevisionPageType,
 } from '@gitbook/api';
 
-import { removeLeadingSlash, removeTrailingSlash } from './paths';
+import { removeLeadingSlash, removeMarkdownExtension, removeTrailingSlash } from './paths';
 
 export type AncestorRevisionPage = RevisionPageDocument | RevisionPageGroup;
 
@@ -412,12 +412,15 @@ function flattenPages(
  * Returns the path segment after the base, or undefined if the URL doesn't match.
  */
 export function extractPagePath(url: string, baseURL: string): string | undefined {
-    const urlPath = getURLPathname(url);
+    const pathname = getURLPathname(url);
     const basePath = getURLPathname(baseURL);
 
-    if (urlPath === undefined || basePath === undefined) {
+    if (pathname === undefined || basePath === undefined) {
         return undefined;
     }
+
+    // Pages are also published at `<page>.md` (the Markdown version linked from llms.txt).
+    const urlPath = removeMarkdownExtension(pathname);
 
     // When basePath is empty, the site is at the root of the domain, so any path matches
     if (basePath === '' || urlPath.startsWith(`${basePath}/`) || urlPath === basePath) {

--- a/packages/gitbook/src/lib/paths.test.ts
+++ b/packages/gitbook/src/lib/paths.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { getExtension } from './paths';
+import { getExtension, removeMarkdownExtension } from './paths';
 
 describe('getExtension', () => {
     it('should return the extension of a path', () => {
@@ -13,5 +13,19 @@ describe('getExtension', () => {
 
     it('should return the extension of a path with multiple dots', () => {
         expect(getExtension('test.with.multiple.dots.txt')).toBe('.txt');
+    });
+});
+
+describe('removeMarkdownExtension', () => {
+    it('should remove a trailing .md extension', () => {
+        expect(removeMarkdownExtension('getting-started.md')).toBe('getting-started');
+        expect(removeMarkdownExtension('/guides/installation.md')).toBe('/guides/installation');
+    });
+
+    it('should leave other paths untouched', () => {
+        expect(removeMarkdownExtension('getting-started')).toBe('getting-started');
+        expect(removeMarkdownExtension('md-files')).toBe('md-files');
+        expect(removeMarkdownExtension('notes.md.html')).toBe('notes.md.html');
+        expect(removeMarkdownExtension('')).toBe('');
     });
 });

--- a/packages/gitbook/src/lib/paths.ts
+++ b/packages/gitbook/src/lib/paths.ts
@@ -37,6 +37,13 @@ export function removeLeadingSlash(path: string): string {
 }
 
 /**
+ * Remove the `.md` extension that identifies the Markdown version of a page.
+ */
+export function removeMarkdownExtension(path: string): string {
+    return path.replace(/\.md$/, '');
+}
+
+/**
  * Normalize a pathname to make it start with a slash
  */
 export function withLeadingSlash(pathname: string): string {

--- a/packages/gitbook/tests/mcp.test.ts
+++ b/packages/gitbook/tests/mcp.test.ts
@@ -55,6 +55,30 @@ it(
     { timeout: 15_000 }
 );
 
+it(
+    'should get a page through MCP from its markdown URL',
+    async () => {
+        const client = await connectMCPClient(
+            getContentTestURL(
+                'https://gitbook-open-e2e-sites.gitbook.io/api-multi-versions-share-links/8tNo6MeXg7CkFMzSSz81/~gitbook/mcp/auth'
+            )
+        );
+
+        // llms.txt and the "view as Markdown" action link to pages as `<page>.md`.
+        const response = await client.callTool({
+            name: 'getPage',
+            arguments: {
+                url: 'https://gitbook-open-e2e-sites.gitbook.io/api-multi-versions-share-links/8tNo6MeXg7CkFMzSSz81/3.0/other-page.md',
+            },
+        });
+
+        expect(response.isError).toBeFalsy();
+        // @ts-expect-error - response.content is of type unknown
+        expect(response.content[0]?.text).toContain('# Other Page');
+    },
+    { timeout: 15_000 }
+);
+
 describe('MCP on a site behind visitor authentication', () => {
     const VA_SITE_URL = 'https://gitbook-open-e2e-sites.gitbook.io/va-site-redirects-fallback';
 


### PR DESCRIPTION
 `getPage` returned `Page not found` for the Markdown URL of a page (`<page>.md`), which is the form `llms.txt` lists and the "View as Markdown" action links to. The HTTP middleware already strips `.md` before routing; the MCP path resolves URLs through `extractPagePath`, which did not.

This adds a `removeMarkdownExtension` helper and applies it in `extractPagePath`, so `getPage` and `askQuestion` accept both forms. Only a trailing .md is stripped.

Repro on production: `getPage` with `https://gitbook.com/docs/getting-started/llm-ready-docs.md` fails, the same URL without `.md` succeeds, and the .md form is what `https://gitbook.com/docs/llms.txt` emits.

Follow-up to #4166, which fixed the root-domain case in the same function.