### PR TITLE
Attribute a markdown request from the page actions menu

### DIFF
--- a/.changeset/markdown-page-action-source.md
+++ b/.changeset/markdown-page-action-source.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Bump `@gitbook/api` to 0.199.0, and record a markdown request made from the page actions menu as a page action rather than an agent request.

--- a/bun.lock
+++ b/bun.lock
@@ -354,7 +354,7 @@
   },
   "catalog": {
     "@base-ui/react": "^1.7.0",
-    "@gitbook/api": "0.198.0",
+    "@gitbook/api": "0.199.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -726,7 +726,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.198.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-ZGXqYip6YFsCM5rqlJ+n8/Esw1bMNK4whqiMoWMeQgMKEX5YXVQaBuVRxU1jDEI49kup+T56xPq3I9g6Wcayng=="],
+    "@gitbook/api": ["@gitbook/api@0.199.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-yLxkSTXlGk7jbtThV2vpnTfqZTq6yLgMJt6jhDGqOmP0LsYAVYYtg8NPf2tXp37aF46m3Z0D908wfSQyu374cg=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
             "@base-ui/react": "^1.7.0",
-            "@gitbook/api": "0.198.0",
+            "@gitbook/api": "0.199.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -125,10 +125,6 @@ function useCopiedStore(stateKey: string) {
     return useStore(getOrCreateCopiedStoreByKey(stateKey));
 }
 
-/**
- * The URL a reader gets when they ask for a page's markdown from this menu: without the agent
- * instructions, and telling insights who asked rather than leaving it to be inferred.
- */
 function getReaderMarkdownURL(markdownPageURL: string) {
     return `${markdownPageURL}?displayAgentInstructions=false&markdownSource=${SiteInsightsMarkdownSource.PageAction}`;
 }

--- a/packages/gitbook/src/components/PageActions/PageActions.tsx
+++ b/packages/gitbook/src/components/PageActions/PageActions.tsx
@@ -5,7 +5,7 @@ import QuickLRU from 'quick-lru';
 import React from 'react';
 import { createStore, useStore } from 'zustand';
 
-import type { GitSyncState } from '@gitbook/api';
+import { type GitSyncState, SiteInsightsMarkdownSource } from '@gitbook/api';
 import { Icon, type IconName, IconStyle } from '@gitbook/icons';
 
 import { useAIChatController, useAIChatState } from '@/components/AI';
@@ -126,6 +126,14 @@ function useCopiedStore(stateKey: string) {
 }
 
 /**
+ * The URL a reader gets when they ask for a page's markdown from this menu: without the agent
+ * instructions, and telling insights who asked rather than leaving it to be inferred.
+ */
+function getReaderMarkdownURL(markdownPageURL: string) {
+    return `${markdownPageURL}?displayAgentInstructions=false&markdownSource=${SiteInsightsMarkdownSource.PageAction}`;
+}
+
+/**
  * Cache for the markdown version of the page.
  */
 const markdownCache = new QuickLRU<string, string>({ maxSize: 10 });
@@ -149,7 +157,7 @@ export function ActionCopyMarkdown(props: {
     const fetchMarkdown = async () => {
         setLoading(true);
 
-        const humanURL = `${markdownPageURL}?displayAgentInstructions=false`;
+        const humanURL = getReaderMarkdownURL(markdownPageURL);
         const result = await fetch(humanURL).then((res) => res.text());
         markdownCache.set(markdownPageURL, result);
 
@@ -196,7 +204,7 @@ export function ActionViewAsMarkdown(props: { markdownPageURL: string; type: Pag
             icon="markdown"
             label={tString(language, 'view_page_markdown')}
             description={tString(language, 'view_page_plaintext')}
-            href={`${markdownPageURL}?displayAgentInstructions=false`}
+            href={getReaderMarkdownURL(markdownPageURL)}
         />
     );
 }

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -13,6 +13,7 @@ import {
     SiteInsightsDisplayContext,
     type SiteInsightsEventLocation,
     SiteInsightsLLMSVariant,
+    SiteInsightsMarkdownSource,
 } from '@gitbook/api';
 
 import {
@@ -897,6 +898,10 @@ function encodePathInSiteContent(
                 // It is encoded as a second path segment (the route is statically rendered, so it can't
                 // read query params at runtime — the question is path-encoded for the same reason).
                 const goal = searchParams.get('goal');
+                // The page-actions menu is the only caller that asks for markdown without the
+                // agent instructions, so it is what tells a reader apart from a client fetching
+                // the URL. Without it every one of those clicks counts as an agent request.
+                const fromPageAction = searchParams.get('displayAgentInstructions') === 'false';
                 return {
                     pathname:
                         typeof ask === 'string'
@@ -922,6 +927,11 @@ function encodePathInSiteContent(
                         : [
                               {
                                   type: 'page_markdown_request',
+                                  ...(fromPageAction
+                                      ? {
+                                            markdownSource: SiteInsightsMarkdownSource.PageAction,
+                                        }
+                                      : {}),
                                   location: {
                                       displayContext: SiteInsightsDisplayContext.Server,
                                   },

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -534,6 +534,9 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         if (rewrittenURL.searchParams.has('displayAgentInstructions')) {
             rewrittenURL.searchParams.delete('displayAgentInstructions');
         }
+        if (rewrittenURL.searchParams.has('markdownSource')) {
+            rewrittenURL.searchParams.delete('markdownSource');
+        }
 
         const response = NextResponse.rewrite(rewrittenURL, {
             request: {
@@ -898,10 +901,11 @@ function encodePathInSiteContent(
                 // It is encoded as a second path segment (the route is statically rendered, so it can't
                 // read query params at runtime — the question is path-encoded for the same reason).
                 const goal = searchParams.get('goal');
-                // The page-actions menu is the only caller that asks for markdown without the
-                // agent instructions, so it is what tells a reader apart from a client fetching
-                // the URL. Without it every one of those clicks counts as an agent request.
-                const fromPageAction = searchParams.get('displayAgentInstructions') === 'false';
+                // Matched against the API's own values, so a hand-written URL cannot record
+                // something insights does not know.
+                const markdownSource = Object.values(SiteInsightsMarkdownSource).find(
+                    (source) => source === searchParams.get('markdownSource')
+                );
                 return {
                     pathname:
                         typeof ask === 'string'
@@ -927,11 +931,7 @@ function encodePathInSiteContent(
                         : [
                               {
                                   type: 'page_markdown_request',
-                                  ...(fromPageAction
-                                      ? {
-                                            markdownSource: SiteInsightsMarkdownSource.PageAction,
-                                        }
-                                      : {}),
+                                  ...(markdownSource ? { markdownSource } : {}),
                                   location: {
                                       displayContext: SiteInsightsDisplayContext.Server,
                                   },

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -901,8 +901,7 @@ function encodePathInSiteContent(
                 // It is encoded as a second path segment (the route is statically rendered, so it can't
                 // read query params at runtime — the question is path-encoded for the same reason).
                 const goal = searchParams.get('goal');
-                // Matched against the API's own values, so a hand-written URL cannot record
-                // something insights does not know.
+                // Validated: this is user input going into insights.
                 const markdownSource = Object.values(SiteInsightsMarkdownSource).find(
                     (source) => source === searchParams.get('markdownSource')
                 );


### PR DESCRIPTION
Clicking **View markdown** or **Copy markdown** fetches the same URL an AI agent does, so both landed in insights as an agent request.

`@gitbook/api` 0.199.0 adds `SiteInsightsMarkdownSource`. The page actions menu now appends `?markdownSource=page-action`, and the middleware records it on the `page_markdown_request` event — validated against the API's own values, and stripped from the rewritten URL like `fallback` and `displayAgentInstructions` already are.

Bumps the catalog from 0.198.0 to 0.199.0; only `@gitbook/api` moves in the lockfile.