### PR TITLE
Keep revision search results in preview

### DIFF
--- a/.changeset/preview-search-revisions.md
+++ b/.changeset/preview-search-revisions.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Keep current-space search results inside revision previews.

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.test.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 
-import type { SearchPageResult, SearchSpaceResult, SiteSpace } from '@gitbook/api';
+import type {
+    RevisionPage,
+    RevisionPageDocument,
+    SearchPageResult,
+    SearchSpaceResult,
+    SiteSpace,
+} from '@gitbook/api';
 
 import { orderSearchResultGroups } from './orderSearchResults';
 import { createLinker } from '@/lib/links';
@@ -14,6 +20,13 @@ const linker = createLinker({
     host: 'docs.runway.team',
     siteBasePath: '/',
     spaceBasePath: '/',
+});
+
+const revisionLinker = createLinker({
+    protocol: 'https:',
+    host: 'docs.runway.team',
+    siteBasePath: '/handbook/',
+    spaceBasePath: '/handbook/api/~/revisions/revision_preview/',
 });
 
 const spaceItem: SearchSpaceResult = {
@@ -63,6 +76,33 @@ function transformPage(pageItem: SearchPageResult, asEmbeddable = false) {
         pageItem,
         spaceItem,
         siteSpace,
+    })!;
+}
+
+function createRevisionPage(id: string, path: string): RevisionPageDocument {
+    return {
+        id,
+        type: 'document',
+        path,
+        pages: [],
+    } as RevisionPageDocument;
+}
+
+function createRevisionPages(pagePath: string): RevisionPage[] {
+    return [
+        createRevisionPage('page_home', 'home'),
+        createRevisionPage('page_api_reference', pagePath),
+    ];
+}
+
+function transformRevisionPage(pageItem: SearchPageResult, revisionPages: RevisionPage[]) {
+    return transformSitePageResult({
+        asEmbeddable: false,
+        linker: revisionLinker,
+        pageItem,
+        spaceItem,
+        siteSpace,
+        revisionPages,
     });
 }
 
@@ -83,10 +123,90 @@ describe('transformSitePageResult', () => {
         expect(transformPage(createPageResult({ path: destination }), true).href).toBe(destination);
     });
 
-    it('resolves a relative page path through the published site URL', () => {
+    it('keeps published search results on their published destination', () => {
         const result = transformPage(createPageResult({ path: 'guides/getting-started' }));
 
         expect(result.href).toBe('/guides/getting-started');
+    });
+
+    it('keeps a current-space page result inside the revision being previewed', () => {
+        const result = transformRevisionPage(
+            createPageResult({ path: 'guides/getting-started' }),
+            createRevisionPages('guides/getting-started')
+        );
+
+        expect(result?.href).toBe(
+            '/handbook/api/~/revisions/revision_preview/guides/getting-started'
+        );
+    });
+
+    it('uses the current revision path when a page moved after the indexed revision', () => {
+        const result = transformRevisionPage(
+            createPageResult({ path: 'guides/getting-started' }),
+            createRevisionPages('start/quickstart')
+        );
+
+        expect(result?.href).toBe('/handbook/api/~/revisions/revision_preview/start/quickstart');
+    });
+
+    it('keeps a section result and its anchor inside the current revision', () => {
+        const result = transformRevisionPage(
+            createPageResult({
+                path: 'guides/getting-started',
+                sections: [
+                    {
+                        id: 'section_authentication',
+                        title: 'Authentication',
+                        body: 'Synthetic section excerpt',
+                        path: 'guides/getting-started#authentication',
+                        score: 10,
+                        resultType: 'section',
+                        urls: {
+                            app: 'https://app.gitbook.com/o/example/s/example',
+                        },
+                    },
+                ],
+            }),
+            createRevisionPages('guides/getting-started')
+        );
+
+        expect(result?.bestSection?.href).toBe(
+            '/handbook/api/~/revisions/revision_preview/guides/getting-started#authentication'
+        );
+    });
+
+    it('falls back to the revision page root when a section anchor cannot be safely retained', () => {
+        const result = transformRevisionPage(
+            createPageResult({
+                path: 'guides/getting-started',
+                sections: [
+                    {
+                        id: 'section_authentication',
+                        title: 'Authentication',
+                        body: 'Synthetic section excerpt',
+                        path: 'another-page#authentication',
+                        score: 10,
+                        resultType: 'section',
+                        urls: {
+                            app: 'https://app.gitbook.com/o/example/s/example',
+                        },
+                    },
+                ],
+            }),
+            createRevisionPages('start/quickstart')
+        );
+
+        expect(result?.bestSection?.href).toBe(
+            '/handbook/api/~/revisions/revision_preview/start/quickstart'
+        );
+    });
+
+    it('excludes a main-index result that does not exist in the current revision', () => {
+        const result = transformRevisionPage(createPageResult({ path: 'guides/getting-started' }), [
+            createRevisionPage('page_home', 'home'),
+        ]);
+
+        expect(result).toBeNull();
     });
 
     it('keeps embeddable GitBook page links in the embeddable route', () => {
@@ -126,7 +246,33 @@ describe('transformSitePageResult', () => {
             spaceItem,
         });
 
-        expect(result.href).toBe('/guides/getting-started');
+        expect(result?.href).toBe('/guides/getting-started');
+    });
+
+    it('keeps cross-space results on their published destination during a revision preview', () => {
+        const otherSpaceItem = { ...spaceItem, id: 'space_sdk', title: 'SDK' };
+        const otherSiteSpace = {
+            ...siteSpace,
+            id: 'site_space_sdk',
+            path: 'sdk',
+            space: {
+                ...siteSpace.space,
+                id: otherSpaceItem.id,
+                title: otherSpaceItem.title,
+            },
+            urls: {
+                published: 'https://docs.runway.team/handbook/sdk/',
+            },
+        } as SiteSpace;
+        const result = transformSitePageResult({
+            asEmbeddable: false,
+            linker: revisionLinker,
+            pageItem: createPageResult({ path: 'guides/getting-started' }),
+            spaceItem: otherSpaceItem,
+            siteSpace: otherSiteSpace,
+        });
+
+        expect(result?.href).toBe('/handbook/sdk/guides/getting-started');
     });
 
     it('preserves ranks, scores, and result ordering', () => {

--- a/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
+++ b/packages/gitbook/src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.ts
@@ -9,7 +9,7 @@ import { throwIfDataError } from '@/lib/data';
 import { getSiteURLDataFromMiddleware } from '@/lib/middleware';
 import { transformSitePageResult } from '@/lib/search';
 import { getServerActionBaseContext } from '@/lib/server-actions';
-import { findSiteSpaceBy } from '@/lib/sites';
+import { findSiteSpaceBy, getLinkerForSiteSpace } from '@/lib/sites';
 
 export async function POST(request: NextRequest) {
     const { asEmbeddable, query, scope } = (await request.json()) as SearchSiteContentRequest;
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json([]);
     }
 
-    const [searchResults, { structure }] = await Promise.all([
+    const [searchResults, { structure }, revision] = await Promise.all([
         throwIfDataError(
             context.dataFetcher.searchSiteContent({
                 organizationId: siteURLData.organization,
@@ -38,7 +38,23 @@ export async function POST(request: NextRequest) {
                 siteShareKey: siteURLData.shareKey,
             })
         ),
+        siteURLData.revision
+            ? throwIfDataError(
+                  context.dataFetcher.getRevision({
+                      spaceId: siteURLData.space,
+                      revisionId: siteURLData.revision,
+                  })
+              )
+            : Promise.resolve(undefined),
     ]);
+
+    const currentSiteSpace = revision
+        ? findSiteSpaceBy(structure, (siteSpace) => siteSpace.id === siteURLData.siteSpace)
+        : null;
+    const revisionLinker =
+        revision && currentSiteSpace
+            ? getLinkerForSiteSpace(context.linker, currentSiteSpace.siteSpace, revision.pages)
+            : context.linker;
 
     const results = orderSearchResultGroups<OrderedComputedResult>(
         searchResults.map((resultItem) => {
@@ -55,25 +71,31 @@ export async function POST(request: NextRequest) {
                 return { type: 'context' as const, results: [result] };
             }
 
-            const found = findSiteSpaceBy(
-                structure,
-                (siteSpace) => siteSpace.space.id === resultItem.id
-            );
+            const isCurrentRevisionSpace = Boolean(revision && resultItem.id === siteURLData.space);
+            const found =
+                isCurrentRevisionSpace && currentSiteSpace
+                    ? currentSiteSpace
+                    : findSiteSpaceBy(
+                          structure,
+                          (siteSpace) => siteSpace.space.id === resultItem.id
+                      );
 
             return {
                 type: 'pages' as const,
-                results: resultItem.pages.map((pageItem) => ({
-                    rank: pageItem.rank,
-                    result: transformSitePageResult({
+                results: resultItem.pages.flatMap((pageItem) => {
+                    const result = transformSitePageResult({
                         asEmbeddable: Boolean(asEmbeddable),
-                        linker: context.linker,
+                        linker: isCurrentRevisionSpace ? revisionLinker : context.linker,
                         pageItem,
                         spaceItem: resultItem,
                         siteSpace: found?.siteSpace,
                         siteSection: found?.siteSection ?? undefined,
                         siteSectionGroup: found?.siteSectionGroup ?? undefined,
-                    }),
-                })),
+                        revisionPages: isCurrentRevisionSpace ? revision?.pages : undefined,
+                    });
+
+                    return result ? [{ rank: pageItem.rank, result }] : [];
+                }),
             };
         })
     );

--- a/packages/gitbook/src/lib/search.ts
+++ b/packages/gitbook/src/lib/search.ts
@@ -1,4 +1,6 @@
 import type {
+    Revision,
+    RevisionPageDocument,
     SearchPageResult,
     SearchSpaceResult,
     SiteSection,
@@ -10,6 +12,7 @@ import type { IconName } from '@gitbook/icons';
 import type { ComputedPageResult, ComputedSectionResult } from '@/components/Search/search-types';
 import { toEmbeddableLinkForPublishedContent } from '@/lib/embeddable-linker';
 import type { GitBookLinker } from '@/lib/links';
+import { resolvePageId } from '@/lib/pages';
 import { joinPathWithBaseURL } from '@/lib/paths';
 import { getLocalizedTitle } from '@/lib/sites';
 import { checkIsHttpURL } from '@/lib/urls';
@@ -22,12 +25,31 @@ export function transformSitePageResult(args: {
     siteSpace?: SiteSpace;
     siteSection?: SiteSection;
     siteSectionGroup?: SiteSectionGroup | null;
-}): ComputedPageResult {
-    const { asEmbeddable, pageItem, spaceItem, siteSection, siteSectionGroup, siteSpace, linker } =
-        args;
+    revisionPages?: Revision['pages'];
+}): ComputedPageResult | null {
+    const {
+        asEmbeddable,
+        pageItem,
+        spaceItem,
+        siteSection,
+        siteSectionGroup,
+        siteSpace,
+        linker,
+        revisionPages,
+    } = args;
     const currentLanguage = siteSpace?.space.language;
     const spaceURL = siteSpace?.urls.published;
     const breadcrumbs: NonNullable<ComputedPageResult['breadcrumbs']> = [];
+
+    let revisionTarget: { pages: Revision['pages']; page: RevisionPageDocument } | undefined;
+    if (revisionPages) {
+        const resolved = resolvePageId(revisionPages, pageItem.id);
+        if (!resolved || resolved.page.id !== pageItem.id) {
+            return null;
+        }
+
+        revisionTarget = { pages: revisionPages, page: resolved.page };
+    }
 
     if (siteSectionGroup) {
         breadcrumbs.push({
@@ -63,13 +85,9 @@ export function transformSitePageResult(args: {
         }))
     );
 
-    const pageHref = checkIsHttpURL(pageItem.path)
-        ? pageItem.path
-        : !spaceURL
-          ? linker.toPathInSpace(pageItem.path)
-          : asEmbeddable
-            ? toEmbeddableLinkForPublishedContent(linker, spaceURL, pageItem.path)
-            : linker.toLinkForContent(joinPathWithBaseURL(spaceURL, pageItem.path));
+    const pageHref = revisionTarget
+        ? linker.toPathForPage(revisionTarget)
+        : getPublishedPageHref({ asEmbeddable, linker, pagePath: pageItem.path, spaceURL });
 
     const page: ComputedPageResult = {
         type: 'page',
@@ -90,21 +108,20 @@ export function transformSitePageResult(args: {
         pageItem.sections
             ?.filter((section) => section.title || section.body)
             .map<ComputedSectionResult>((section) => {
-                let sectionHref = linker.toPathInSpace(section.path);
-
-                if (spaceURL) {
-                    if (asEmbeddable) {
-                        sectionHref = toEmbeddableLinkForPublishedContent(
-                            linker,
-                            spaceURL,
-                            section.path
-                        );
-                    } else {
-                        sectionHref = linker.toLinkForContent(
-                            joinPathWithBaseURL(spaceURL, section.path)
-                        );
-                    }
-                }
+                const anchor = revisionTarget
+                    ? getRetainableSectionAnchor(section.path, pageItem.path)
+                    : undefined;
+                const sectionHref = revisionTarget
+                    ? linker.toPathForPage({
+                          ...revisionTarget,
+                          anchor,
+                      })
+                    : getPublishedPageHref({
+                          asEmbeddable,
+                          linker,
+                          pagePath: section.path,
+                          spaceURL,
+                      });
 
                 return {
                     type: 'section',
@@ -130,4 +147,34 @@ export function transformSitePageResult(args: {
     }
 
     return page;
+}
+
+function getRetainableSectionAnchor(sectionPath: string, pagePath: string): string | undefined {
+    const hashIndex = sectionPath.indexOf('#');
+    if (hashIndex === -1 || sectionPath.slice(0, hashIndex) !== pagePath) {
+        return undefined;
+    }
+
+    return sectionPath.slice(hashIndex + 1) || undefined;
+}
+
+function getPublishedPageHref(input: {
+    asEmbeddable: boolean;
+    linker: GitBookLinker;
+    pagePath: string;
+    spaceURL: string | undefined;
+}) {
+    const { asEmbeddable, linker, pagePath, spaceURL } = input;
+
+    if (checkIsHttpURL(pagePath)) {
+        return pagePath;
+    }
+
+    if (!spaceURL) {
+        return linker.toPathInSpace(pagePath);
+    }
+
+    return asEmbeddable
+        ? toEmbeddableLinkForPublishedContent(linker, spaceURL, pagePath)
+        : linker.toLinkForContent(joinPathWithBaseURL(spaceURL, pagePath));
 }


### PR DESCRIPTION
## Summary

- Fix [RND-11624](https://linear.app/gitbook-x/issue/RND-11624/search-result-redirection-issue-on-preview-deployment) by mapping current-space search hits back to the revision page tree using stable page IDs.
- Generate valid current-space destinations with the revision-aware `GitBookLinker`, including moved pages and safe section anchors, and filter results missing from the preview.
- Preserve published and cross-space navigation, custom domains and base paths, result presentation, ranking, and ordering.

Search is intentionally not revision-specific after this change: candidates still come from the main published-content index. Valid current-space candidates are mapped back into the revision currently being viewed.

## Testing

- `bun test src/app/sites/dynamic/[mode]/[siteURL]/[siteData]/~gitbook/search/route.test.ts`
- `bun run format`
- `bunx oxlint --quiet` on the changed search files
- `bun run typecheck` *(blocked by pre-existing errors in `ContentKitWithClientContext.tsx`; the changed search files produce no reported errors)*