### PR TITLE
RND-12706: measuring tabs fix

### DIFF
--- a/.changeset/sparkly-regions-train.md
+++ b/.changeset/sparkly-regions-train.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix the tabs "more" dropdown showing when no tab is overflowing, and stop a tab click re-rendering every tab group on the page.

--- a/packages/gitbook/e2e/tabs-overflow.spec.ts
+++ b/packages/gitbook/e2e/tabs-overflow.spec.ts
@@ -1,0 +1,178 @@
+import { type Page, expect, test } from '@playwright/test';
+
+// Import the specific module (not the package barrel) so this stays free of the `@/` path alias,
+// which Playwright's loader doesn't resolve — same reason as `select.spec.ts`.
+import { resolveOverflowingItems } from '../src/components/hooks/listOverflow';
+
+/**
+ * Behaviour tests for the tab bar's overflow rule (`useListOverflow`), which decides which tabs move
+ * into the "more" dropdown. Rects are measured in a real browser so the geometry is genuine — the
+ * layout below mirrors the tab bar in `DynamicTabs`: a non-wrapping flex row of `shrink-0` items,
+ * clipped by `overflow: hidden`, measured with the dropdown rendered ahead of the tabs.
+ *
+ * The regression these guard is a dropdown appearing when nothing actually overflowed: measuring
+ * with the dropdown present consumes `MENU` pixels, so a bar whose tabs total just under the
+ * container would hand its last tab to a menu it never needed.
+ */
+
+/** Width of the ellipsis button, matching the `px-3.5` + `size-4` icon of the real one. */
+const MENU = 44;
+
+interface Row {
+    /** Container width in px. */
+    container: number;
+    /** Tab widths in px, in order. */
+    tabs: number[];
+    /** Whether the dropdown is reserving space ahead of the tabs, as during a measure pass. */
+    withMenu?: boolean;
+    /** Hide an ancestor, so the row measures with no box at all. */
+    hidden?: boolean;
+}
+
+/**
+ * Lay the row out in the browser and run the real rule over the rects it produces.
+ * Returns the ids reported as overflowing, or `null` when the measurement carried no information.
+ */
+async function measure(page: Page, row: Row): Promise<string[] | null> {
+    const { container, tabs, withMenu = true, hidden = false } = row;
+
+    const items = tabs
+        .map((w, i) => `<div class="item" id="tab-${i}" style="width:${w}px">${i}</div>`)
+        .join('');
+    const menu = withMenu ? `<div class="item" style="width:${MENU}px">…</div>` : '';
+
+    await page.setContent(
+        `<!doctype html><html><head><style>
+            * { box-sizing: border-box; }
+            body { margin: 0; }
+            .pane { ${hidden ? 'display: none;' : ''} }
+            .bar {
+                width: ${container}px;
+                display: inline-flex;
+                overflow: hidden;
+            }
+            .bar::after { content: ""; flex: 1; }
+            .item { flex-shrink: 0; max-width: 100%; }
+        </style></head><body>
+            <div class="pane"><div class="bar" id="bar">${menu}${items}</div></div>
+        </body></html>`
+    );
+
+    const measured = await page.evaluate(() => {
+        const bar = document.getElementById('bar');
+        if (!bar) {
+            throw new Error('missing bar');
+        }
+        const rect = bar.getBoundingClientRect();
+        return {
+            container: { left: rect.left, right: rect.right, width: rect.width },
+            items: [...bar.querySelectorAll<HTMLElement>('.item[id]')].map((el) => {
+                const r = el.getBoundingClientRect();
+                return { id: el.id, rect: { left: r.left, right: r.right } };
+            }),
+        };
+    });
+
+    const result = resolveOverflowingItems(measured.container, measured.items);
+    return result ? [...result].sort() : null;
+}
+
+test.describe('tab overflow rule', () => {
+    test('reports nothing when every tab fits with room to spare', async ({ page }) => {
+        // 3 x 100 = 300 of 600, so even with the menu reserved there is slack.
+        expect(await measure(page, { container: 600, tabs: [100, 100, 100] })).toEqual([]);
+    });
+
+    test('reports nothing when the tabs fit exactly', async ({ page }) => {
+        expect(await measure(page, { container: 300, tabs: [100, 100, 100] })).toEqual([]);
+    });
+
+    test('reports nothing when only the reserved menu made the row overflow', async ({ page }) => {
+        // The regression: tabs total 300 and the container is 320, so they fit — but measuring
+        // reserves 44 for the menu, which used to push the last tab out and show a needless
+        // dropdown. Every width in `container - MENU < 300 <= container` must stay empty.
+        for (const container of [300, 305, 320, 330, 343]) {
+            expect(
+                await measure(page, { container, tabs: [100, 100, 100] }),
+                `container ${container}px`
+            ).toEqual([]);
+        }
+    });
+
+    test('reports the tabs that genuinely do not fit alongside the menu', async ({ page }) => {
+        // 300 of tabs into 290: the row really does overflow, so the menu is warranted and the
+        // remaining tabs must fit beside it (100 + 100 + 44 = 244 <= 290).
+        expect(await measure(page, { container: 290, tabs: [100, 100, 100] })).toEqual(['tab-2']);
+    });
+
+    test('gives up as many tabs as the width demands', async ({ page }) => {
+        expect(await measure(page, { container: 190, tabs: [100, 100, 100] })).toEqual([
+            'tab-1',
+            'tab-2',
+        ]);
+        expect(await measure(page, { container: 150, tabs: [100, 100, 100] })).toEqual([
+            'tab-1',
+            'tab-2',
+        ]);
+    });
+
+    test('moves every tab into the menu once not even the first fits beside it', async ({
+        page,
+    }) => {
+        // 100 + 44 > 120, so no tab can share the row with the menu. Everything goes in, leaving a
+        // bar that is only the menu — deliberately, since the menu is then the sole route to any
+        // tab. Forcing the first tab to stay would push the menu past the clipped edge and strand
+        // the rest.
+        expect(await measure(page, { container: 120, tabs: [100, 100, 100] })).toEqual([
+            'tab-0',
+            'tab-1',
+            'tab-2',
+        ]);
+    });
+
+    test('keeps a single tab that fills the bar rather than hiding it behind a menu', async ({
+        page,
+    }) => {
+        // `max-width: 100%` truncates it to the container, so it fits — a lone tab should never be
+        // the only thing in the dropdown.
+        expect(await measure(page, { container: 200, tabs: [400] })).toEqual([]);
+    });
+
+    test('cuts a nested bar earlier, since its pane padding narrows it', async ({ page }) => {
+        // A nested tab bar sits inside a `p-4` pane, so it has 32px less to work with. At 330 the
+        // outer bar keeps all three tabs; the nested one at 330 - 32 cannot.
+        expect(await measure(page, { container: 330, tabs: [100, 100, 100] })).toEqual([]);
+        expect(await measure(page, { container: 330 - 32, tabs: [100, 100, 100] })).toEqual([
+            'tab-2',
+        ]);
+    });
+
+    test('progressively fills the menu as a long list is squeezed', async ({ page }) => {
+        const tabs = Array.from({ length: 12 }, () => 100);
+        let previous = -1;
+        for (const container of [1300, 1200, 1000, 800, 600, 400, 200]) {
+            const overflowing = await measure(page, { container, tabs });
+            expect(overflowing, `container ${container}px`).not.toBeNull();
+            const hidden = overflowing?.length ?? 0;
+            // Never loses a tab, and never un-hides one as the space shrinks.
+            expect(hidden, `container ${container}px`).toBeGreaterThanOrEqual(previous);
+            expect(hidden, `container ${container}px`).toBeLessThanOrEqual(tabs.length);
+            previous = hidden;
+        }
+        // Widest fits everything; at 200 only the first tab still fits beside the menu.
+        expect(await measure(page, { container: 1300, tabs })).toEqual([]);
+        expect((await measure(page, { container: 200, tabs }))?.length).toBe(11);
+    });
+
+    test('reports nothing measurable while an ancestor is hidden', async ({ page }) => {
+        // A bar behind an inactive tab has no box, so every rect is zero. That says nothing about
+        // what fits, and must not be mistaken for "everything overflows".
+        expect(
+            await measure(page, { container: 200, tabs: [100, 100, 100], hidden: true })
+        ).toBeNull();
+    });
+
+    test('reports nothing measurable for an empty list', async ({ page }) => {
+        expect(await measure(page, { container: 600, tabs: [] })).toBeNull();
+    });
+});

--- a/packages/gitbook/package.json
+++ b/packages/gitbook/package.json
@@ -132,7 +132,7 @@
         "dev:cf:middleware": "wrangler dev --port 8771 --inspector-port 9230 --env dev --config ./openNext/customWorkers/middlewareWrangler.jsonc",
         "dev:cf:server": "wrangler dev --port 8772 --env dev --config ./openNext/customWorkers/defaultWrangler.jsonc",
         "profile:cf:memory": "bun run build:cloudflare && bun ./scripts/profile-opennext-memory.ts",
-        "e2e": "playwright test e2e/internal.spec.ts e2e/cookie-banner.spec.ts e2e/pdf.spec.ts e2e/select.spec.ts --project=chromium",
+        "e2e": "playwright test e2e/internal.spec.ts e2e/cookie-banner.spec.ts e2e/pdf.spec.ts e2e/select.spec.ts e2e/tabs-overflow.spec.ts --project=chromium",
         "e2e-customers": "playwright test e2e/customers.spec.ts --project=chromium",
         "e2e-style-perf": "playwright test e2e/style-perf.spec.ts --project=chromium --reporter=list",
         "unit": "bun run generate:assets && bun test {src,packages} --preload ./tests/preload-bun.ts",

--- a/packages/gitbook/src/components/Select/useSelect.ts
+++ b/packages/gitbook/src/components/Select/useSelect.ts
@@ -5,18 +5,13 @@ import { useCallback, useSyncExternalStore } from 'react';
 import { selectStore } from '@/lib/select';
 
 /**
- * Subscribe to the site-wide `select` state. Returns the current recency list plus the setters.
- * Consumers that only need "which of my options is active" should prefer {@link useResolvedSlug}.
+ * Setters for the site-wide `select` state. Deliberately does not subscribe: the store notifies on
+ * every activation anywhere on the page, so returning the recency list here would re-render every
+ * block that only ever wanted to *write* a selection. To read one, use {@link useResolvedSlug},
+ * which re-renders a block only when its own resolved option changes.
  */
 export function useSelect() {
-    const slugs = useSyncExternalStore(
-        selectStore.subscribe,
-        selectStore.getState,
-        selectStore.getState
-    ).slugs;
-
     return {
-        slugs,
         activate: selectStore.activate,
         deactivate: selectStore.deactivate,
     };

--- a/packages/gitbook/src/components/hooks/listOverflow.ts
+++ b/packages/gitbook/src/components/hooks/listOverflow.ts
@@ -1,0 +1,53 @@
+/**
+ * Geometry rule behind {@link useListOverflow}, kept free of React so it can be tested directly
+ * against rects measured in a real browser.
+ */
+
+export interface MeasuredRect {
+    left: number;
+    right: number;
+}
+
+export interface MeasuredItem {
+    id: string;
+    rect: MeasuredRect;
+}
+
+/** Sub-pixel tolerance, so a row that fits exactly isn't reported as overflowing. */
+const EPSILON = 1;
+
+/**
+ * Decide which items don't fit the container.
+ *
+ * Items are expected to be measured with the overflow affordance (a "more" menu, say) already
+ * rendered *ahead* of them, which is what lets a single measurement answer both questions: the space
+ * before the first item is the width that affordance is reserving, so subtracting it gives the
+ * position each item would have without it. The list only has to make room for the affordance if it
+ * overflows without one — otherwise a row that fits on its own would give up its last item to a menu
+ * it never needed.
+ *
+ * Returns `null` when the measurement carries no information — an empty list, or a container with no
+ * width because an ancestor is hidden (a pane behind an inactive tab). Callers should keep their
+ * previous result and re-measure once it is visible.
+ */
+export function resolveOverflowingItems(
+    container: MeasuredRect & { width: number },
+    items: MeasuredItem[]
+): Set<string> | null {
+    if (container.width <= 0 || items.length === 0) {
+        return null;
+    }
+
+    const reserved = Math.min(...items.map((item) => item.rect.left)) - container.left;
+    const fitsUnaided = items.every(
+        (item) => item.rect.right - reserved <= container.right + EPSILON
+    );
+
+    if (fitsUnaided) {
+        return new Set();
+    }
+
+    return new Set(
+        items.filter((item) => item.rect.right > container.right + EPSILON).map((item) => item.id)
+    );
+}

--- a/packages/gitbook/src/components/hooks/useListOverflow.tsx
+++ b/packages/gitbook/src/components/hooks/useListOverflow.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
+import { resolveOverflowingItems } from './listOverflow';
+
 interface OverflowState {
     /**
      * Ref for the container element.
@@ -24,12 +26,23 @@ interface OverflowState {
  * Detects which items are overflowing in a horizontal list.
  * The items must have unique IDs set on their elements.
  *
- * In the measuring phase indicated by `isMeasuring`, all items must be rendered.
+ * In the measuring phase indicated by `isMeasuring`, all items must be rendered. Whatever the list
+ * shows *because* items overflow (a "more" menu, say) has to be rendered ahead of the items in that
+ * phase: the measurement discounts the space taken before the first item, so a list that fits on its
+ * own is not reported as overflowing merely because that menu was reserving room for itself.
  */
 export function useListOverflow(): OverflowState {
     const containerRef = useRef<HTMLDivElement>(null);
     const [overflowing, setOverflowing] = useState<Set<string>>(new Set());
-    const [isMeasuring, setIsMeasuring] = useState(false);
+    // Measuring is a request/completed pair of counters rather than a boolean, because a boolean
+    // reset can be swallowed: the observer re-arms measuring from a rAF, and when that lands in the
+    // same batch as the measure effect's reset the net value is unchanged, so React bails out and the
+    // effect — keyed on that value — never runs again, leaving the list stuck measuring with its
+    // "more" menu permanently on show. Counters only increase, so a request can't cancel a
+    // completion; it just queues another pass.
+    const [measureRequest, setMeasureRequest] = useState(0);
+    const [measureCompleted, setMeasureCompleted] = useState(0);
+    const isMeasuring = measureRequest !== measureCompleted;
     const itemRefs = useRef(new Map<string, HTMLElement>());
     const rafRef = useRef(0);
 
@@ -43,19 +56,19 @@ export function useListOverflow(): OverflowState {
         };
     }, []);
 
+    const requestMeasure = useCallback(() => setMeasureRequest((request) => request + 1), []);
+
     // Measure on mount and when container size changes
     useEffect(() => {
         if (!containerRef.current) {
             return;
         }
 
-        setIsMeasuring(true);
+        requestMeasure();
 
         const ro = new ResizeObserver(() => {
             cancelAnimationFrame(rafRef.current);
-            rafRef.current = requestAnimationFrame(() => {
-                setIsMeasuring(true);
-            });
+            rafRef.current = requestAnimationFrame(requestMeasure);
         });
 
         ro.observe(containerRef.current);
@@ -64,7 +77,7 @@ export function useListOverflow(): OverflowState {
             ro.disconnect();
             cancelAnimationFrame(rafRef.current);
         };
-    }, []);
+    }, [requestMeasure]);
 
     // Measure which items are overflowing
     useLayoutEffect(() => {
@@ -72,29 +85,32 @@ export function useListOverflow(): OverflowState {
             return;
         }
 
-        const containerRect = containerRef.current.getBoundingClientRect();
-        const newOverflowing = new Set<string>();
+        const newOverflowing = resolveOverflowingItems(
+            containerRef.current.getBoundingClientRect(),
+            Array.from(itemRefs.current, ([id, element]) => ({
+                id,
+                rect: element.getBoundingClientRect(),
+            }))
+        );
 
-        itemRefs.current.forEach((el, id) => {
-            const elRect = el.getBoundingClientRect();
-            if (elRect.right > containerRect.right + 1) {
-                newOverflowing.add(id);
-            }
-        });
-
-        setOverflowing((previous) => {
-            if (previous.size !== newOverflowing.size) {
-                return newOverflowing;
-            }
-            for (const id of previous) {
-                if (!newOverflowing.has(id)) {
+        // `null` means the measurement said nothing (hidden ancestor, or no items) — keep what we
+        // had and wait for the observer to fire once it is visible.
+        if (newOverflowing) {
+            setOverflowing((previous) => {
+                if (previous.size !== newOverflowing.size) {
                     return newOverflowing;
                 }
-            }
-            return previous;
-        });
-        setIsMeasuring(false);
-    }, [isMeasuring]);
+                for (const id of previous) {
+                    if (!newOverflowing.has(id)) {
+                        return newOverflowing;
+                    }
+                }
+                return previous;
+            });
+        }
+
+        setMeasureCompleted(measureRequest);
+    }, [isMeasuring, measureRequest]);
 
     return { containerRef, itemRef, overflowing, isMeasuring };
 }


### PR DESCRIPTION
We got stuck in a state of isMeasuring for the tabs which meant the ellipsis at start showed always. 

This change:
1. fixes the issue with measurement
2. improves rendering of useSelect
3. adds an e2e test for dynamic tab measuring