### PR TITLE
Read the permanent flag from the typed site redirect

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -354,7 +354,7 @@
   },
   "catalog": {
     "@base-ui/react": "^1.7.0",
-    "@gitbook/api": "0.199.0",
+    "@gitbook/api": "0.200.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -726,7 +726,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.199.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-yLxkSTXlGk7jbtThV2vpnTfqZTq6yLgMJt6jhDGqOmP0LsYAVYYtg8NPf2tXp37aF46m3Z0D908wfSQyu374cg=="],
+    "@gitbook/api": ["@gitbook/api@0.200.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-JgPosRwabDqw8FzTpSZdEWCUdwUxO2vIHJH9A8CXYXBmubjjj/Ft01qnzbL2T5q1CSLSQKe9PvW9t5V+R/8iJA=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
             "@base-ui/react": "^1.7.0",
-            "@gitbook/api": "0.199.0",
+            "@gitbook/api": "0.200.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/src/components/SitePage/fetch.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.ts
@@ -97,10 +97,8 @@ async function resolvePage(context: GitBookSiteContext, params: PagePathParams |
                     context.revisionId === context.space.revision &&
                     !context.isLoggedInVisitor;
                 if (
-                    resolvedSiteRedirect.redirect &&
+                    resolvedSiteRedirect.redirect?.permanent &&
                     !resolvedSiteRedirect.redirect.draft &&
-                    'permanent' in resolvedSiteRedirect.redirect &&
-                    resolvedSiteRedirect.redirect.permanent === true &&
                     isPublicLiveContext
                 ) {
                     return permanentRedirect(destination);


### PR DESCRIPTION
Follow-up to #4586. Drops the `'permanent' in` guard now that the field exists in the API spec.

Blocked until `@gitbook/api` publishes a version with `SiteRedirect.permanent` (0.199.0 does not have it). Then bump the catalog in `package.json`, refresh `bun.lock`, and typecheck will pass.