### PR TITLE
Resolve stable refs in HTML blocks of published markdown pages

### DIFF
--- a/.changeset/resolve-html-links-in-markdown.md
+++ b/.changeset/resolve-html-links-in-markdown.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Resolve stable page, space and file refs in images, definitions and HTML blocks of published markdown pages, instead of leaking internal `/pages/{id}`, `/spaces/{id}` and `/files/{id}` URLs.

--- a/packages/gitbook/src/lib/markdownPage.test.ts
+++ b/packages/gitbook/src/lib/markdownPage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { GitBookAnyContext } from './context';
+import { createLinker, linkerWithDirectPagePaths, linkerWithMarkdownPages } from './links';
+import { fromPageMarkdown, toPageMarkdown } from './markdownPage';
+
+const page = {
+    id: 'designer',
+    type: 'document',
+    title: 'About the Workflow Designer',
+    path: 'about-the-workflow-designer',
+    slug: 'about-the-workflow-designer',
+    pages: [],
+    layout: {},
+};
+const linker = linkerWithMarkdownPages(
+    linkerWithDirectPagePaths(
+        createLinker({ host: 'docs.example.com', spaceBasePath: '/workflows/', siteBasePath: '/' })
+    )
+);
+const context = {
+    space: {
+        id: 'workflows',
+        title: 'Workflows',
+        urls: { published: 'https://docs.example.com/workflows/' },
+    },
+    revision: { pages: [page], files: [] },
+    linker,
+} as unknown as GitBookAnyContext;
+
+async function rewrite(markdown: string) {
+    return toPageMarkdown(await fromPageMarkdown(context, { markdown, pagePath: 'workflows' }));
+}
+
+describe('HTML links in page markdown', () => {
+    it.each([
+        ['/pages/designer', linker.toPathForPagePath({ path: page.path })],
+        ['/spaces/workflows', context.space.urls.published],
+        ['/pages/missing', 'broken://pages/missing'],
+    ])(
+        'resolves an inline button targeting %s without changing its label or attributes',
+        async (ref, expected) => {
+            const button = `<a href="${ref}" class="button primary" data-icon="triple-chevrons-right">About the designer</a>`;
+            const markdown = `{% columns %}\n{% column %}\n\n${button}\n{% endcolumn %}\n{% endcolumns %}\n`;
+            expect(await rewrite(markdown)).toBe(
+                markdown.replace(`href="${ref}"`, `href="${expected}"`)
+            );
+        }
+    );
+
+    it('preserves title replacement for complete card anchors', async () => {
+        const markdown =
+            '<table><tr><td><a href="/pages/designer">/pages/designer</a></td></tr></table>\n';
+        expect(await rewrite(markdown)).toBe(
+            `<table><tr><td><a href="${linker.toPathForPagePath({ path: page.path })}">${page.title}</a></td></tr></table>\n`
+        );
+    });
+});

--- a/packages/gitbook/src/lib/markdownPage.ts
+++ b/packages/gitbook/src/lib/markdownPage.ts
@@ -1,4 +1,4 @@
-import type { Link, Root } from 'mdast';
+import type { Definition, Html, Image, Link, Root } from 'mdast';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { frontmatterFromMarkdown } from 'mdast-util-frontmatter';
 import { gfmFromMarkdown, gfmToMarkdown } from 'mdast-util-gfm';
@@ -28,6 +28,10 @@ import { DataFetcherError, throwIfDataError } from '@/lib/data';
 import type { ResolvedPagePath } from '@/lib/pages';
 import { getIndexablePages } from '@/lib/sitemap';
 import { getMarkdownForPagesTree } from '@/routes/llms';
+
+const HTML_ANCHOR_RE = /<a\b([^>]*?)href="([^"]*)"([^>]*)>([\s\S]*?)<\/a>/g;
+const HTML_ANCHOR_OPEN_RE = /<a\b([^>]*?)href="([^"]*)"([^>]*)>/g;
+const HTML_SRC_RE = /\bsrc="([^"]*)"/g;
 
 /**
  * Generate a markdown version of a page.
@@ -219,7 +223,8 @@ async function renderGroupPageMarkdown(args: {
 
 /**
  * Re-writes URLs in a markdown content:
- * -
+ * - stable content refs (`/pages/:id`, `/spaces/:id/pages/:id`, `/files/:id`...) in links,
+ *   images, definitions and in the `href`/`src` of raw HTML blocks are resolved to site URLs.
  * - the URL of every relative <a> link so it is expressed from the site-root.
  */
 async function rewriteMarkdownLinks(
@@ -246,30 +251,13 @@ async function rewriteMarkdownLinks(
             pending.push(
                 (async () => {
                     const resolved = await resolveContentRef(contentRef, context);
-                    if (resolved?.href) {
-                        node.url = resolved.href;
-                    } else {
-                        // We use an absolute URL so that crawler don't follow it.
-                        node.url = `broken://${original.startsWith('/') ? original.slice(1) : original}`;
-                    }
+                    node.url = resolved?.href ?? toBrokenURL(original);
 
                     if (isMention) {
                         // Replace the text for mentions as otherwise it contains the raw ref
-                        if (resolved) {
-                            node.children = [
-                                {
-                                    type: 'text',
-                                    value: resolved.text,
-                                },
-                            ];
-                        } else {
-                            node.children = [
-                                {
-                                    type: 'text',
-                                    value: 'Broken mention',
-                                },
-                            ];
-                        }
+                        node.children = [
+                            { type: 'text', value: resolved?.text ?? 'Broken mention' },
+                        ];
                         node.title = undefined;
                     }
                 })()
@@ -288,11 +276,101 @@ async function rewriteMarkdownLinks(
         }
     });
 
+    visit(tree, 'image', (node: Image) => {
+        pending.push(rewriteNodeURL(context, node));
+    });
+
+    visit(tree, 'definition', (node: Definition) => {
+        pending.push(rewriteNodeURL(context, node));
+    });
+
+    // Blocks markdown cannot express (tables, cards, figures...) are emitted as raw HTML,
+    // with the same stable refs in their anchors and images.
+    visit(tree, 'html', (node: Html) => {
+        pending.push(rewriteHTMLRefs(context, node));
+    });
+
     if (pending.length > 0) {
         await Promise.all(pending);
     }
 
     return tree;
+}
+
+/**
+ * Resolve a URL if it is a stable content ref. Returns null for anything else
+ * (external URLs, anchors, plain paths) so the caller leaves it untouched.
+ */
+async function resolveRefURL(
+    context: GitBookAnyContext,
+    url: string
+): Promise<{ url: string; text: string | null } | null> {
+    if (checkIsExternalURL(url) || checkIsAnchor(url)) {
+        return null;
+    }
+    const contentRef = resolveStringContentRef(url);
+    if (!contentRef) {
+        return null;
+    }
+    const resolved = await resolveContentRef(contentRef, context);
+    return { url: resolved?.href ?? toBrokenURL(url), text: resolved?.text ?? null };
+}
+
+async function rewriteNodeURL(context: GitBookAnyContext, node: Image | Definition) {
+    const resolved = await resolveRefURL(context, node.url);
+    if (resolved) {
+        node.url = resolved.url;
+    }
+}
+
+async function rewriteHTMLRefs(context: GitBookAnyContext, node: Html): Promise<void> {
+    node.value = await replaceAsync(node.value, HTML_ANCHOR_RE, async (match) => {
+        const [full, before = '', href = '', after = '', text = ''] = match;
+        const resolved = await resolveRefURL(context, href);
+        if (!resolved) {
+            return full;
+        }
+        // The API emits the raw ref as the text; swap it for the resolved title.
+        const content = text === href ? escapeHTML(resolved.text ?? 'Broken link') : text;
+        return `<a${before}href="${escapeHTML(resolved.url)}"${after}>${content}</a>`;
+    });
+
+    node.value = await replaceAsync(node.value, HTML_ANCHOR_OPEN_RE, async (match) => {
+        const [full, before = '', href = '', after = ''] = match;
+        const resolved = await resolveRefURL(context, href);
+        return resolved ? `<a${before}href="${escapeHTML(resolved.url)}"${after}>` : full;
+    });
+
+    node.value = await replaceAsync(node.value, HTML_SRC_RE, async (match) => {
+        const [full, src = ''] = match;
+        const resolved = await resolveRefURL(context, src);
+        return resolved ? `src="${escapeHTML(resolved.url)}"` : full;
+    });
+}
+
+async function replaceAsync(
+    value: string,
+    re: RegExp,
+    replacer: (match: RegExpMatchArray) => Promise<string>
+): Promise<string> {
+    const replacements = await Promise.all(Array.from(value.matchAll(re), replacer));
+    let index = 0;
+    return value.replace(re, () => replacements[index++]!);
+}
+
+/**
+ * Use an absolute URL so that crawlers don't follow it.
+ */
+function toBrokenURL(original: string): string {
+    return `broken://${original.startsWith('/') ? original.slice(1) : original}`;
+}
+
+function escapeHTML(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
 }
 
 function isMentionLike(node: Link) {


### PR DESCRIPTION
Published `.md` pages (also used by `llms-full.txt` and MCP) contain raw HTML for blocks markdown cannot express (tables, cards, figures...). `rewriteMarkdownLinks` only resolved markdown `link` nodes, so the API's stable refs survived in other carriers: anchors and images inside HTML blocks (`<a href="/pages/{id}">/pages/{id}</a>`, `<img src="/files/{id}">`), markdown images and reference-style definitions. Crawlers and MCP clients then followed them on the customer's domain as broken links.

This resolves those carriers with the same content-ref resolution used for markdown links. Raw-ref anchor text is replaced with the page title, and unresolvable refs fall back to `broken://`.