### PR TITLE
Fix page not found in preview links for sites with a custom homepage

### DIFF
--- a/.changeset/preview-page-not-found.md
+++ b/.changeset/preview-page-not-found.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix pages resolving to "not found" when a root URL lookup resolves to a custom homepage, by no longer using the homepage pathname as a prefix for the requested page path.

--- a/packages/gitbook/src/lib/data/lookup.ts
+++ b/packages/gitbook/src/lib/data/lookup.ts
@@ -3,7 +3,7 @@ import type { GitBookAPI, PublishedSiteContentLookup, SiteVisitorPayload } from 
 import { apiClient } from './api';
 import { getExposableError } from './errors';
 import type { DataFetcherResponse } from './types';
-import { getURLLookupAlternatives, stripURLSearch } from './urls';
+import { getURLLookupAlternatives, getURLLookupPathname, stripURLSearch } from './urls';
 import { isAPITokenExpired } from '@/lib/api-token';
 import { race, tryCatch } from '@/lib/async';
 import { getLogger } from '@/lib/logger';
@@ -134,7 +134,7 @@ export async function lookupPublishedContentByUrl(
                 ...data,
                 canonicalUrl: joinPathWithBaseURL(data.canonicalUrl, alternative.extraPath),
                 basePath: joinPath(data.basePath, lookup.basePath ?? ''),
-                pathname: joinPath(data.pathname, alternative.extraPath),
+                pathname: getURLLookupPathname(alternative, data),
                 ...(changeRequest ? { changeRequest } : {}),
                 ...(revision ? { revision } : {}),
             };

--- a/packages/gitbook/src/lib/data/urls.test.ts
+++ b/packages/gitbook/src/lib/data/urls.test.ts
@@ -1,6 +1,103 @@
 import { describe, expect, it } from 'bun:test';
 
-import { getURLLookupAlternatives, normalizeURL } from './urls';
+import { getURLLookupAlternatives, getURLLookupPathname, normalizeURL } from './urls';
+
+describe('getURLLookupPathname', () => {
+    const previewRoot = 'https://sites.gitbook.com/preview/site_example/section';
+    const pagePath = 'guides/access/setup';
+    const homepagePath = '/welcome/overview';
+
+    it.each(['revisions', 'changes'])(
+        'resolves a page in a %s preview from the site-space root',
+        (kind) => {
+            const lookup = getURLLookupAlternatives(
+                new URL(`${previewRoot}/~/${kind}/revision-id/${pagePath}`)
+            );
+            const alternative = lookup.urls[0]!;
+
+            expect(
+                getURLLookupPathname(alternative, {
+                    basePath: '/preview/site_example/section/',
+                    pathname: homepagePath,
+                })
+            ).toBe(`/${pagePath}`);
+        }
+    );
+
+    it.each(['revisions', 'changes'])(
+        'preserves the custom homepage at a %s preview root',
+        (kind) => {
+            const lookup = getURLLookupAlternatives(
+                new URL(`${previewRoot}/~/${kind}/revision-id/`)
+            );
+
+            expect(
+                getURLLookupPathname(lookup.urls[0]!, {
+                    basePath: '/preview/site_example/section/',
+                    pathname: homepagePath,
+                })
+            ).toBe(`${homepagePath}/`);
+        }
+    );
+
+    it.each(['', '/section/variant'])('resolves a published page below the %s root', (basePath) => {
+        const rootURL = `https://docs.example.com${basePath}`;
+        const lookup = getURLLookupAlternatives(new URL(`${rootURL}/${pagePath}`));
+        const alternative = lookup.urls.find(({ url }) => url === new URL(rootURL).toString())!;
+
+        expect(alternative).toBeDefined();
+        expect(
+            getURLLookupPathname(alternative, {
+                basePath: `${basePath}/`,
+                pathname: homepagePath,
+            })
+        ).toBe(`/${pagePath}`);
+    });
+
+    it('preserves page resolution without a custom homepage', () => {
+        const lookup = getURLLookupAlternatives(
+            new URL(`${previewRoot}/~/revisions/revision-id/${pagePath}`)
+        );
+
+        expect(
+            getURLLookupPathname(lookup.urls[0]!, {
+                basePath: '/preview/site_example/section/',
+                pathname: '/',
+            })
+        ).toBe(`/${pagePath}`);
+    });
+
+    it.each(['/section/variant', '/section/variant/'])(
+        'recognizes a root lookup with base path %s',
+        (basePath) => {
+            expect(
+                getURLLookupPathname(
+                    {
+                        url: 'https://docs.example.com/section/variant/',
+                        extraPath: 'guide/page',
+                    },
+                    { basePath, pathname: homepagePath }
+                )
+            ).toBe('/guide/page');
+        }
+    );
+
+    it('preserves a legitimate page prefix for a non-root lookup', () => {
+        const lookup = getURLLookupAlternatives(
+            new URL('https://docs.example.com/section/guide/page')
+        );
+        const alternative = lookup.urls.find(
+            ({ url }) => url === 'https://docs.example.com/section/guide'
+        )!;
+
+        expect(
+            getURLLookupPathname(alternative, {
+                basePath: '/section/',
+                pathname: '/guide',
+            })
+        ).toBe('/guide/page');
+    });
+});
 
 describe('getURLLookupAlternatives', () => {
     it('should return all URLs up to the root', () => {

--- a/packages/gitbook/src/lib/data/urls.ts
+++ b/packages/gitbook/src/lib/data/urls.ts
@@ -1,3 +1,4 @@
+import { joinPath, removeTrailingSlash } from '../paths';
 import { isProxyRootRequest } from '../proxy';
 import { DataFetcherError, getExposableError } from './errors';
 
@@ -158,6 +159,23 @@ export function getURLLookupAlternatives(input: URL) {
     }
 
     return { urls: alternatives, basePath, changeRequest, revision };
+}
+
+/** Combine a resolved lookup with the remaining requested page path. */
+export function getURLLookupPathname(
+    alternative: { url: string; extraPath: string },
+    resolved: { basePath: string; pathname: string }
+) {
+    if (
+        alternative.extraPath &&
+        removeTrailingSlash(new URL(alternative.url).pathname) ===
+            removeTrailingSlash(resolved.basePath)
+    ) {
+        // A root lookup can resolve to a custom homepage, which is not a prefix for other pages.
+        return joinPath('/', alternative.extraPath);
+    }
+
+    return joinPath(resolved.pathname, alternative.extraPath);
 }
 
 /**


### PR DESCRIPTION
## Bug

Preview pages could show “Page not found” on sites with a custom homepage, even when opened from the preview’s sidebar.

The likely trigger was custom homepage support added in August ([API #24495](https://github.com/GitbookIO/gitbook-x/pull/24495), [renderer #4475](https://github.com/GitbookIO/gitbook/pull/4475)). Previously, looking up a section root returned `/`. It could now return the homepage’s path instead.

The renderer still appended the requested page to that result, producing `/welcome/overview/guides/setup` instead of `/guides/setup`. Production logs confirmed this malformed path for Harness. We haven’t established when their configuration first triggered it.

## Fix

When the renderer looks up a section root on behalf of another page, use the requested page path directly. Keep the custom homepage when the visitor actually requests the root.

This corrects the renderer’s assumption that the API’s returned path is always a prefix. It preserves the API’s intended homepage behavior and requires no customer-specific handling.

## Validation

- Generic regression tests reproduce the malformed path before the fix and pass afterward. Coverage includes revision/change-request previews, published URLs, homepage preservation, and nested paths.
- 61 focused tests passed, with 2 existing skips. Type-check and formatting checks pass.
- Tested Harness’s exact production revision locally: the failing parent and Okta SCIM pages render, the homepage still works, and sidebar navigation succeeds.