### PR TITLE
Restore Edit on Git page actions

### DIFF
--- a/.changeset/bright-pages-describe.md
+++ b/.changeset/bright-pages-describe.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Include published page descriptions in the page's Markdown output.

--- a/.changeset/preview-page-not-found.md
+++ b/.changeset/preview-page-not-found.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix pages resolving to "not found" when a root URL lookup resolves to a custom homepage, by no longer using the homepage pathname as a prefix for the requested page path.

--- a/.changeset/silly-wolves-cache.md
+++ b/.changeset/silly-wolves-cache.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Use cached Git metadata (via @gitbook/api 0.201.0's `cachedMetadata` param) when rendering Edit on Git actions.

--- a/.changeset/tidy-wolves-edit-git.md
+++ b/.changeset/tidy-wolves-edit-git.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Restore Edit on Git page actions for Git-synced pages.

--- a/bun.lock
+++ b/bun.lock
@@ -354,7 +354,7 @@
   },
   "catalog": {
     "@base-ui/react": "^1.7.0",
-    "@gitbook/api": "0.200.0",
+    "@gitbook/api": "0.201.0",
     "@scalar/api-client-react": "^1.3.46",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/strictest": "^2.0.6",
@@ -726,7 +726,7 @@
 
     "@fortawesome/fontawesome-svg-core": ["@fortawesome/fontawesome-svg-core@7.2.0", "", { "dependencies": { "@fortawesome/fontawesome-common-types": "7.2.0" } }, "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q=="],
 
-    "@gitbook/api": ["@gitbook/api@0.200.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-JgPosRwabDqw8FzTpSZdEWCUdwUxO2vIHJH9A8CXYXBmubjjj/Ft01qnzbL2T5q1CSLSQKe9PvW9t5V+R/8iJA=="],
+    "@gitbook/api": ["@gitbook/api@0.201.0", "", { "dependencies": { "event-iterator": "^2.0.0", "eventsource-parser": "^3.0.0" } }, "sha512-bI+FyExZrz9V8yaMBOo4k2QHb0nJvrHYKXE+Svb3Dr1/kYA1bdyL5swCDCH9MxaRQjjJlN3VilvPmblKOYLuVA=="],
 
     "@gitbook/browser-types": ["@gitbook/browser-types@workspace:packages/browser-types"],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
             "@tsconfig/strictest": "^2.0.6",
             "@tsconfig/node20": "^20.1.6",
             "@base-ui/react": "^1.7.0",
-            "@gitbook/api": "0.200.0",
+            "@gitbook/api": "0.201.0",
             "@scalar/api-client-react": "^1.3.46",
             "@types/react": "^19.0.0",
             "@types/react-dom": "^19.0.0",

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -10,6 +10,7 @@ import {
     CustomizationDepth,
     CustomizationHeaderPreset,
     CustomizationIconsStyle,
+    CustomizationPageActionType,
     CustomizationSidebarListStyle,
     SiteSocialAccountPlatform,
 } from '@gitbook/api';
@@ -1425,6 +1426,70 @@ const testCases: TestsCase[] = [
             {
                 name: 'All cases',
                 url: '',
+            },
+        ],
+    },
+    {
+        name: 'Edit on Git page actions',
+        contentBaseURL: 'https://gitbook-open-e2e-sites.gitbook.io/yjs/',
+        tests: [
+            {
+                name: 'With Edit on Git as the default action',
+                url: getCustomizationURL({
+                    pageActions: {
+                        items: [CustomizationPageActionType.Git],
+                    },
+                }),
+                run: async (page) => {
+                    await waitForHydration(page);
+                    await expect(
+                        page.getByRole('link', { name: 'Edit', exact: true })
+                    ).toHaveAttribute(
+                        'href',
+                        'https://github.com/taranvohra/yjs-docs/tree/main/README.md'
+                    );
+                },
+                screenshot: false,
+            },
+            {
+                name: 'With Edit on Git in the dropdown',
+                url: getCustomizationURL({
+                    pageActions: {
+                        items: [
+                            CustomizationPageActionType.Markdown,
+                            CustomizationPageActionType.Git,
+                        ],
+                    },
+                }),
+                run: async (page) => {
+                    await waitForHydration(page);
+                    await page.getByRole('button', { name: 'More' }).click();
+                    await expect(page.getByRole('menu')).toBeVisible();
+                    await expect(
+                        page.getByRole('menuitem', { name: 'Edit on GitHub' })
+                    ).toHaveAttribute(
+                        'href',
+                        'https://github.com/taranvohra/yjs-docs/tree/main/README.md'
+                    );
+                },
+                screenshot: false,
+            },
+            {
+                name: 'Without Edit on Git',
+                url: getCustomizationURL({
+                    pageActions: {
+                        items: [CustomizationPageActionType.Markdown],
+                    },
+                }),
+                run: async (page) => {
+                    await waitForHydration(page);
+                    await page.getByRole('button', { name: 'More' }).click();
+                    await expect(page.getByRole('menu')).toBeVisible();
+                    await expect(
+                        page.getByRole('menuitem', { name: 'Edit on GitHub' })
+                    ).toHaveCount(0);
+                },
+                screenshot: false,
             },
         ],
     },

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -10,6 +10,7 @@ import {
     CustomizationDepth,
     CustomizationHeaderPreset,
     CustomizationIconsStyle,
+    CustomizationPageActionType,
     CustomizationSidebarListStyle,
     SiteSocialAccountPlatform,
 } from '@gitbook/api';
@@ -1569,6 +1570,70 @@ const testCases: TestsCase[] = [
             {
                 name: 'All cases',
                 url: '',
+            },
+        ],
+    },
+    {
+        name: 'Edit on Git page actions',
+        contentBaseURL: 'https://gitbook-open-e2e-sites.gitbook.io/yjs/',
+        tests: [
+            {
+                name: 'With Edit on Git as the default action',
+                url: getCustomizationURL({
+                    pageActions: {
+                        items: [CustomizationPageActionType.Git],
+                    },
+                }),
+                run: async (page) => {
+                    await waitForHydration(page);
+                    await expect(
+                        page.getByRole('link', { name: 'Edit', exact: true })
+                    ).toHaveAttribute(
+                        'href',
+                        'https://github.com/taranvohra/yjs-docs/tree/main/README.md'
+                    );
+                },
+                screenshot: false,
+            },
+            {
+                name: 'With Edit on Git in the dropdown',
+                url: getCustomizationURL({
+                    pageActions: {
+                        items: [
+                            CustomizationPageActionType.Markdown,
+                            CustomizationPageActionType.Git,
+                        ],
+                    },
+                }),
+                run: async (page) => {
+                    await waitForHydration(page);
+                    await page.getByRole('button', { name: 'More' }).click();
+                    await expect(page.getByRole('menu')).toBeVisible();
+                    await expect(
+                        page.getByRole('menuitem', { name: 'Edit on GitHub' })
+                    ).toHaveAttribute(
+                        'href',
+                        'https://github.com/taranvohra/yjs-docs/tree/main/README.md'
+                    );
+                },
+                screenshot: false,
+            },
+            {
+                name: 'Without Edit on Git',
+                url: getCustomizationURL({
+                    pageActions: {
+                        items: [CustomizationPageActionType.Markdown],
+                    },
+                }),
+                run: async (page) => {
+                    await waitForHydration(page);
+                    await page.getByRole('button', { name: 'More' }).click();
+                    await expect(page.getByRole('menu')).toBeVisible();
+                    await expect(
+                        page.getByRole('menuitem', { name: 'Edit on GitHub' })
+                    ).toHaveCount(0);
+                },
+                screenshot: false,
             },
         ],
     },

--- a/packages/gitbook/e2e/util.ts
+++ b/packages/gitbook/e2e/util.ts
@@ -465,7 +465,11 @@ export function getCustomizationURL(partial: DeepPartial<SiteCustomizationSettin
         socialAccounts: [],
     };
 
-    const encoded = rison.encode_object(deepMerge(DEFAULT_CUSTOMIZATION, partial));
+    const encoded = rison.encode_object(
+        deepMerge(DEFAULT_CUSTOMIZATION, partial, {
+            arrayMerge: (_target, source) => source,
+        })
+    );
 
     const searchParams = new URLSearchParams();
     searchParams.set('customization', encoded);

--- a/packages/gitbook/src/components/SitePage/fetch.test.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { CustomizationPageActionType, type RevisionPageDocument } from '@gitbook/api';
+
+import type { GitBookSiteContext } from '@/lib/context';
+
+mock.module('server-only', () => ({}));
+
+const { fetchPageData } = await import('./fetch');
+
+const page = {
+    id: 'page-1',
+    title: 'Introduction',
+    kind: 'sheet',
+    type: 'document',
+    path: 'readme',
+    slug: 'readme',
+    pages: [],
+} as RevisionPageDocument;
+
+const git = {
+    oid: 'abc123',
+    path: 'README.md',
+};
+
+function createContext(options: { gitEnabled: boolean; gitSync?: boolean }) {
+    const getRevisionPageByPath = mock(async () => ({
+        data: {
+            ...page,
+            git,
+        },
+    }));
+
+    const context = {
+        revision: { pages: [page] },
+        revisionId: 'revision-1',
+        customization: {
+            pageActions: {
+                items: options.gitEnabled ? [CustomizationPageActionType.Git] : [],
+            },
+        },
+        space: {
+            id: 'space-1',
+            gitSync:
+                options.gitSync === false
+                    ? undefined
+                    : {
+                          url: 'https://github.com/gitbook/example/tree/main',
+                      },
+        },
+        dataFetcher: { getRevisionPageByPath },
+    } as unknown as GitBookSiteContext;
+
+    return { context, getRevisionPageByPath };
+}
+
+describe('fetchPageData', () => {
+    it('fetches the Git metadata for an enabled Edit on Git action', async () => {
+        const { context, getRevisionPageByPath } = createContext({ gitEnabled: true });
+
+        const result = await fetchPageData(context, { pageId: page.id });
+
+        expect(getRevisionPageByPath).toHaveBeenCalledWith({
+            spaceId: 'space-1',
+            revisionId: 'revision-1',
+            path: 'readme',
+            metadata: true,
+        });
+        expect(result.pageTarget?.page.git).toEqual(git);
+        expect(result.context.page?.git).toEqual(git);
+    });
+
+    it('does not fetch Git metadata when the action is disabled', async () => {
+        const { context, getRevisionPageByPath } = createContext({ gitEnabled: false });
+
+        const result = await fetchPageData(context, { pageId: page.id });
+
+        expect(getRevisionPageByPath).not.toHaveBeenCalled();
+        expect(result.pageTarget?.page.git).toBeUndefined();
+    });
+
+    it('does not fetch Git metadata without Git Sync', async () => {
+        const { context, getRevisionPageByPath } = createContext({
+            gitEnabled: true,
+            gitSync: false,
+        });
+
+        const result = await fetchPageData(context, { pageId: page.id });
+
+        expect(getRevisionPageByPath).not.toHaveBeenCalled();
+        expect(result.pageTarget?.page.git).toBeUndefined();
+    });
+});

--- a/packages/gitbook/src/components/SitePage/fetch.test.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.test.ts
@@ -65,6 +65,7 @@ describe('fetchPageData', () => {
             revisionId: 'revision-1',
             path: 'readme',
             metadata: true,
+            cachedMetadata: true,
         });
         expect(result.pageTarget?.page.git).toEqual(git);
         expect(result.context.page?.git).toEqual(git);

--- a/packages/gitbook/src/components/SitePage/fetch.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.ts
@@ -41,6 +41,7 @@ export async function fetchPageData(context: GitBookSiteContext, params: PagePar
             revisionId: context.revisionId,
             path: pageTarget.page.path,
             metadata: true,
+            cachedMetadata: true,
         });
         const pageWithMetadata = response.data;
 

--- a/packages/gitbook/src/components/SitePage/fetch.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.ts
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 
 import {
+    CustomizationPageActionType,
     SITE_REDIRECT_SOURCE_PATH_MAX_LENGTH,
     SITE_REDIRECT_SOURCE_PATH_PATTERN,
 } from '@gitbook/api';
@@ -26,7 +27,33 @@ export type PageParams = PagePathParams | PageIdParams;
  * Optimized to fetch in parallel as much as possible.
  */
 export async function fetchPageData(context: GitBookSiteContext, params: PageParams) {
-    const pageTarget = await resolvePage(context, params);
+    let pageTarget = await resolvePage(context, params);
+
+    // Revision trees omit metadata for cache efficiency, so load it only when this action needs the Git path.
+    if (
+        pageTarget &&
+        !pageTarget.page.git &&
+        context.space.gitSync?.url &&
+        context.customization.pageActions.items.includes(CustomizationPageActionType.Git)
+    ) {
+        const response = await context.dataFetcher.getRevisionPageByPath({
+            spaceId: context.space.id,
+            revisionId: context.revisionId,
+            path: pageTarget.page.path,
+            metadata: true,
+        });
+        const pageWithMetadata = response.data;
+
+        if (pageWithMetadata?.type === 'document' && pageWithMetadata.git) {
+            pageTarget = {
+                ...pageTarget,
+                page: {
+                    ...pageTarget.page,
+                    git: pageWithMetadata.git,
+                },
+            };
+        }
+    }
 
     return {
         context: {

--- a/packages/gitbook/src/components/SitePage/fetch.ts
+++ b/packages/gitbook/src/components/SitePage/fetch.ts
@@ -1,6 +1,7 @@
 import { permanentRedirect, redirect } from 'next/navigation';
 
 import {
+    CustomizationPageActionType,
     SITE_REDIRECT_SOURCE_PATH_MAX_LENGTH,
     SITE_REDIRECT_SOURCE_PATH_PATTERN,
 } from '@gitbook/api';
@@ -26,7 +27,33 @@ export type PageParams = PagePathParams | PageIdParams;
  * Optimized to fetch in parallel as much as possible.
  */
 export async function fetchPageData(context: GitBookSiteContext, params: PageParams) {
-    const pageTarget = await resolvePage(context, params);
+    let pageTarget = await resolvePage(context, params);
+
+    // Revision trees omit metadata for cache efficiency, so load it only when this action needs the Git path.
+    if (
+        pageTarget &&
+        !pageTarget.page.git &&
+        context.space.gitSync?.url &&
+        context.customization.pageActions.items.includes(CustomizationPageActionType.Git)
+    ) {
+        const response = await context.dataFetcher.getRevisionPageByPath({
+            spaceId: context.space.id,
+            revisionId: context.revisionId,
+            path: pageTarget.page.path,
+            metadata: true,
+        });
+        const pageWithMetadata = response.data;
+
+        if (pageWithMetadata?.type === 'document' && pageWithMetadata.git) {
+            pageTarget = {
+                ...pageTarget,
+                page: {
+                    ...pageTarget.page,
+                    git: pageWithMetadata.git,
+                },
+            };
+        }
+    }
 
     return {
         context: {

--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -87,6 +87,7 @@ export function createDataFetcher(
                 spaceId: params.spaceId,
                 revisionId: params.revisionId,
                 path: params.path,
+                metadata: params.metadata,
             });
         },
         getRevisionPageMarkdown(params) {
@@ -526,7 +527,7 @@ const getRevisionReusableContentDocument = cache(
 const getRevisionPageByPath = cache(
     async (
         input: DataFetcherInput,
-        params: { spaceId: string; revisionId: string; path: string }
+        params: { spaceId: string; revisionId: string; path: string; metadata?: boolean }
     ) => {
         'use cache';
         return wrapDataFetcherError(async () => {
@@ -540,7 +541,7 @@ const getRevisionPageByPath = cache(
                         params.revisionId,
                         encodedPath,
                         {
-                            metadata: false,
+                            metadata: params.metadata ?? false,
                         },
                         {
                             ...noCacheFetchOptions,

--- a/packages/gitbook/src/lib/data/api.ts
+++ b/packages/gitbook/src/lib/data/api.ts
@@ -88,6 +88,7 @@ export function createDataFetcher(
                 revisionId: params.revisionId,
                 path: params.path,
                 metadata: params.metadata,
+                cachedMetadata: params.cachedMetadata,
             });
         },
         getRevisionPageMarkdown(params) {
@@ -527,7 +528,13 @@ const getRevisionReusableContentDocument = cache(
 const getRevisionPageByPath = cache(
     async (
         input: DataFetcherInput,
-        params: { spaceId: string; revisionId: string; path: string; metadata?: boolean }
+        params: {
+            spaceId: string;
+            revisionId: string;
+            path: string;
+            metadata?: boolean;
+            cachedMetadata?: boolean;
+        }
     ) => {
         'use cache';
         return wrapDataFetcherError(async () => {
@@ -536,13 +543,15 @@ const getRevisionPageByPath = cache(
                 async () => {
                     const encodedPath = encodeURIComponent(params.path);
                     const api = apiClient(input);
+                    const query = {
+                        metadata: params.metadata ?? false,
+                        cachedMetadata: params.cachedMetadata ?? false,
+                    };
                     const res = await api.spaces.getPageInRevisionByPath(
                         params.spaceId,
                         params.revisionId,
                         encodedPath,
-                        {
-                            metadata: params.metadata ?? false,
-                        },
+                        query,
                         {
                             ...noCacheFetchOptions,
                         }

--- a/packages/gitbook/src/lib/data/lookup.ts
+++ b/packages/gitbook/src/lib/data/lookup.ts
@@ -3,7 +3,7 @@ import type { GitBookAPI, PublishedSiteContentLookup, SiteVisitorPayload } from 
 import { apiClient } from './api';
 import { getExposableError } from './errors';
 import type { DataFetcherResponse } from './types';
-import { getURLLookupAlternatives, stripURLSearch } from './urls';
+import { getURLLookupAlternatives, getURLLookupPathname, stripURLSearch } from './urls';
 import { isAPITokenExpired } from '@/lib/api-token';
 import { race, tryCatch } from '@/lib/async';
 import { getLogger } from '@/lib/logger';
@@ -134,7 +134,7 @@ export async function lookupPublishedContentByUrl(
                 ...data,
                 canonicalUrl: joinPathWithBaseURL(data.canonicalUrl, alternative.extraPath),
                 basePath: joinPath(data.basePath, lookup.basePath ?? ''),
-                pathname: joinPath(data.pathname, alternative.extraPath),
+                pathname: getURLLookupPathname(alternative, data),
                 ...(changeRequest ? { changeRequest } : {}),
                 ...(revision ? { revision } : {}),
             };

--- a/packages/gitbook/src/lib/data/types.ts
+++ b/packages/gitbook/src/lib/data/types.ts
@@ -98,6 +98,7 @@ export interface GitBookDataFetcher {
         revisionId: string;
         path: string;
         metadata?: boolean;
+        cachedMetadata?: boolean;
     }): Promise<DataFetcherResponse<api.RevisionPageDocument | api.RevisionPageGroup>>;
 
     /**

--- a/packages/gitbook/src/lib/data/types.ts
+++ b/packages/gitbook/src/lib/data/types.ts
@@ -97,6 +97,7 @@ export interface GitBookDataFetcher {
         spaceId: string;
         revisionId: string;
         path: string;
+        metadata?: boolean;
     }): Promise<DataFetcherResponse<api.RevisionPageDocument | api.RevisionPageGroup>>;
 
     /**

--- a/packages/gitbook/src/lib/data/urls.test.ts
+++ b/packages/gitbook/src/lib/data/urls.test.ts
@@ -1,6 +1,103 @@
 import { describe, expect, it } from 'bun:test';
 
-import { getURLLookupAlternatives, normalizeURL } from './urls';
+import { getURLLookupAlternatives, getURLLookupPathname, normalizeURL } from './urls';
+
+describe('getURLLookupPathname', () => {
+    const previewRoot = 'https://sites.gitbook.com/preview/site_example/section';
+    const pagePath = 'guides/access/setup';
+    const homepagePath = '/welcome/overview';
+
+    it.each(['revisions', 'changes'])(
+        'resolves a page in a %s preview from the site-space root',
+        (kind) => {
+            const lookup = getURLLookupAlternatives(
+                new URL(`${previewRoot}/~/${kind}/revision-id/${pagePath}`)
+            );
+            const alternative = lookup.urls[0]!;
+
+            expect(
+                getURLLookupPathname(alternative, {
+                    basePath: '/preview/site_example/section/',
+                    pathname: homepagePath,
+                })
+            ).toBe(`/${pagePath}`);
+        }
+    );
+
+    it.each(['revisions', 'changes'])(
+        'preserves the custom homepage at a %s preview root',
+        (kind) => {
+            const lookup = getURLLookupAlternatives(
+                new URL(`${previewRoot}/~/${kind}/revision-id/`)
+            );
+
+            expect(
+                getURLLookupPathname(lookup.urls[0]!, {
+                    basePath: '/preview/site_example/section/',
+                    pathname: homepagePath,
+                })
+            ).toBe(`${homepagePath}/`);
+        }
+    );
+
+    it.each(['', '/section/variant'])('resolves a published page below the %s root', (basePath) => {
+        const rootURL = `https://docs.example.com${basePath}`;
+        const lookup = getURLLookupAlternatives(new URL(`${rootURL}/${pagePath}`));
+        const alternative = lookup.urls.find(({ url }) => url === new URL(rootURL).toString())!;
+
+        expect(alternative).toBeDefined();
+        expect(
+            getURLLookupPathname(alternative, {
+                basePath: `${basePath}/`,
+                pathname: homepagePath,
+            })
+        ).toBe(`/${pagePath}`);
+    });
+
+    it('preserves page resolution without a custom homepage', () => {
+        const lookup = getURLLookupAlternatives(
+            new URL(`${previewRoot}/~/revisions/revision-id/${pagePath}`)
+        );
+
+        expect(
+            getURLLookupPathname(lookup.urls[0]!, {
+                basePath: '/preview/site_example/section/',
+                pathname: '/',
+            })
+        ).toBe(`/${pagePath}`);
+    });
+
+    it.each(['/section/variant', '/section/variant/'])(
+        'recognizes a root lookup with base path %s',
+        (basePath) => {
+            expect(
+                getURLLookupPathname(
+                    {
+                        url: 'https://docs.example.com/section/variant/',
+                        extraPath: 'guide/page',
+                    },
+                    { basePath, pathname: homepagePath }
+                )
+            ).toBe('/guide/page');
+        }
+    );
+
+    it('preserves a legitimate page prefix for a non-root lookup', () => {
+        const lookup = getURLLookupAlternatives(
+            new URL('https://docs.example.com/section/guide/page')
+        );
+        const alternative = lookup.urls.find(
+            ({ url }) => url === 'https://docs.example.com/section/guide'
+        )!;
+
+        expect(
+            getURLLookupPathname(alternative, {
+                basePath: '/section/',
+                pathname: '/guide',
+            })
+        ).toBe('/guide/page');
+    });
+});
 
 describe('getURLLookupAlternatives', () => {
     it('should return all URLs up to the root', () => {

--- a/packages/gitbook/src/lib/data/urls.ts
+++ b/packages/gitbook/src/lib/data/urls.ts
@@ -1,3 +1,4 @@
+import { joinPath, removeTrailingSlash } from '../paths';
 import { isProxyRootRequest } from '../proxy';
 import { DataFetcherError, getExposableError } from './errors';
 
@@ -158,6 +159,23 @@ export function getURLLookupAlternatives(input: URL) {
     }
 
     return { urls: alternatives, basePath, changeRequest, revision };
+}
+
+/** Combine a resolved lookup with the remaining requested page path. */
+export function getURLLookupPathname(
+    alternative: { url: string; extraPath: string },
+    resolved: { basePath: string; pathname: string }
+) {
+    if (
+        alternative.extraPath &&
+        removeTrailingSlash(new URL(alternative.url).pathname) ===
+            removeTrailingSlash(resolved.basePath)
+    ) {
+        // A root lookup can resolve to a custom homepage, which is not a prefix for other pages.
+        return joinPath('/', alternative.extraPath);
+    }
+
+    return joinPath(resolved.pathname, alternative.extraPath);
 }
 
 /**

--- a/packages/gitbook/src/lib/markdownPage.ts
+++ b/packages/gitbook/src/lib/markdownPage.ts
@@ -1,4 +1,4 @@
-import type { Definition, Html, Image, Link, Root } from 'mdast';
+import type { Definition, Html, Image, Link, Paragraph, Root } from 'mdast';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { frontmatterFromMarkdown } from 'mdast-util-frontmatter';
 import { gfmFromMarkdown, gfmToMarkdown } from 'mdast-util-gfm';
@@ -70,6 +70,7 @@ export async function getMarkdownForPage(
         markdown: rawMarkdown,
         pagePath: page.path,
     });
+    insertDescriptionAfterHeading(tree, page.description);
 
     // Handle empty document pages which have children
     if (isEmptyMarkdownPage(tree) && page.pages.length > 0) {
@@ -106,6 +107,7 @@ export async function getMarkdownForPageInSpace(
         markdown: rawMarkdown,
         pagePath: page.path,
     });
+    insertDescriptionAfterHeading(tree, page.description);
 
     // Handle empty document pages which have children (same as getMarkdownForPage)
     if (isEmptyMarkdownPage(tree) && page.pages.length > 0) {
@@ -144,6 +146,26 @@ export async function fromPageMarkdown(
  */
 export function toPageMarkdown(tree: Root): string {
     return toMarkdown(tree, { extensions: [gfmToMarkdown()] });
+}
+
+/** Keep page metadata immediately after the title for Markdown consumers. */
+function insertDescriptionAfterHeading(tree: Root, description?: string) {
+    if (!description) {
+        return;
+    }
+
+    const headingIndex = tree.children.findIndex(
+        (node) => node.type === 'heading' && node.depth === 1
+    );
+    if (headingIndex === -1) {
+        return;
+    }
+
+    const descriptionNode: Paragraph = {
+        type: 'paragraph',
+        children: [{ type: 'text', value: description }],
+    };
+    tree.children.splice(headingIndex + 1, 0, descriptionNode);
 }
 
 /**
@@ -203,6 +225,7 @@ async function renderGroupPageMarkdown(args: {
 }): Promise<string> {
     const { linker, page } = args;
     const indexablePages = getIndexablePages(page.pages);
+    const description = page.type === RevisionPageType.Document ? page.description : undefined;
 
     const markdownTree: Root = {
         type: 'root',
@@ -212,6 +235,14 @@ async function renderGroupPageMarkdown(args: {
                 depth: 1,
                 children: [{ type: 'text', value: page.title }],
             },
+            ...(description
+                ? [
+                      {
+                          type: 'paragraph',
+                          children: [{ type: 'text', value: description }],
+                      } satisfies Paragraph,
+                  ]
+                : []),
             ...(await getMarkdownForPagesTree(indexablePages, linker)),
         ],
     };

--- a/packages/gitbook/src/lib/visitors.test.ts
+++ b/packages/gitbook/src/lib/visitors.test.ts
@@ -10,6 +10,7 @@ import {
     getVisitorToken,
     getVisitorType,
     getVisitorUnsignedClaims,
+    isRevalidationRequest,
     normalizeVisitorURL,
 } from './visitors';
 
@@ -562,5 +563,18 @@ describe('getVisitorType', () => {
     it('should default to "human" when the user-agent is missing or empty', () => {
         expect(getVisitorType(requestWith({}))).toBe('human');
         expect(getVisitorType(requestWith({ 'user-agent': '' }))).toBe('human');
+    });
+});
+
+describe('isRevalidationRequest', () => {
+    it('should detect the revalidation worker regardless of casing', () => {
+        expect(
+            isRevalidationRequest(new Headers({ 'User-Agent': 'GitBook-Open-Revalidation-Worker' }))
+        ).toBe(true);
+    });
+
+    it('should not detect a regular request', () => {
+        expect(isRevalidationRequest(new Headers({ 'User-Agent': 'Mozilla/5.0' }))).toBe(false);
+        expect(isRevalidationRequest(new Headers())).toBe(false);
     });
 });

--- a/packages/gitbook/src/lib/visitors.ts
+++ b/packages/gitbook/src/lib/visitors.ts
@@ -133,6 +133,14 @@ export function getVisitorData({
 }
 
 /**
+ * Check if the request is coming from our revalidation worker. Such requests carry the visitor
+ * data they want to revalidate in the URL, so we must not redirect them to a normalized URL.
+ */
+export function isRevalidationRequest(headers: Headers): boolean {
+    return headers.get('user-agent')?.toLowerCase() === 'gitbook-open-revalidation-worker';
+}
+
+/**
  * Get the visitor token for the request. This token can either be in the
  * query parameters or stored as a cookie.
  */
@@ -154,7 +162,7 @@ export function getVisitorToken({
 
     // Allow the empty string to come through
     if (fromUrl !== null && fromUrl !== undefined) {
-        if (headers.get('user-agent')?.toLowerCase() === 'gitbook-open-revalidation-worker') {
+        if (isRevalidationRequest(headers)) {
             return { source: 'revalidation', token: fromUrl };
         }
 

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -56,6 +56,7 @@ import {
     getResponseCookiesForVisitorAuth,
     getVisitorData,
     getVisitorType,
+    isRevalidationRequest,
     normalizeVisitorURL,
     serveVisitorClaimsDataRequest,
 } from '@/lib/visitors';
@@ -339,7 +340,9 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         // Make sure the URL is clean of any va token after a successful lookup,
         // and of any visitor.* params that may have been passed to the URL.
         //
-        // We only redirect if the visitor token is not coming from a revalidation request, as we don't want to redirect in that case.
+        // We only redirect if the request is not coming from the revalidation worker, as we don't
+        // want to redirect in that case. It can carry unsigned claims without any token, so we rely
+        // on the request headers rather than on the visitor token source.
         //
         // The token and the visitor.* params value are stored in cookies that are set
         // on the redirect response.
@@ -347,7 +350,7 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
         const normalizedVisitorURL = normalizeVisitorURL(incomingURL);
         if (
             normalizedVisitorURL.toString() !== incomingURL.toString() &&
-            visitorToken?.source !== 'revalidation'
+            !isRevalidationRequest(request.headers)
         ) {
             return writeResponseCookies(
                 NextResponse.redirect(normalizedVisitorURL.toString()),


### PR DESCRIPTION
## Proposed changes

Restores the "Edit on Git" page action for Git-synced pages. When the `Git` page action is enabled in customization and Git Sync is active, the page data fetcher now lazy-loads Git metadata to provide the Edit on GitHub link in the page actions dropdown.

The implementation checks if the Git action is enabled and Git Sync is configured, then fetches metadata only when needed to avoid unnecessary API calls for pages that don't require it.

## Changelog

- [Feature] Restore Edit on Git page actions for Git-synced pages