### PR TITLE
Fix search section links not scrolling to the target section

### DIFF
--- a/.changeset/rnd-12844-search-section-links-scroll.md
+++ b/.changeset/rnd-12844-search-section-links-scroll.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix section links in search results opening the page without scrolling to the section.

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -246,6 +246,43 @@ const searchTestCases: Test[] = [
         },
     },
     {
+        // RND-12844: the popover's focus manager re-focused the closing popup and
+        // scrolled the page back to the top right after landing on the section.
+        name: 'Search - Section result scrolls to the section',
+        url: getCustomizationURL({
+            ai: {
+                mode: CustomizationAIMode.None,
+            },
+        }),
+        screenshot: false,
+        run: async (page) => {
+            await waitForCookiesDialog(page);
+            const searchInput = page.getByTestId('search-input');
+            await searchInput.focus();
+            // Type like a visitor: `fill()` doesn't trigger the remote search.
+            await searchInput.pressSequentially('tasks');
+
+            const sectionResult = page.locator(
+                '[data-testid="search-page-result"][href$="/blocks/lists#tasks"]'
+            );
+            // Section results come from the remote index, which can be slow to answer.
+            await expect(sectionResult).toBeVisible({ timeout: 30_000 });
+            await sectionResult.click();
+            await page.waitForURL(/\/blocks\/lists#tasks$/);
+
+            // The regression scrolled back to the top shortly after landing, so let
+            // that happen before asserting.
+            await page.waitForTimeout(1000);
+
+            // The heading is parked under the header, within its scroll margin.
+            const top = await page
+                .locator('#tasks')
+                .evaluate((heading) => heading.getBoundingClientRect().top);
+            expect(top).toBeGreaterThanOrEqual(0);
+            expect(top).toBeLessThanOrEqual(150);
+        },
+    },
+    {
         name: 'Ask - AI Mode: Assistant - Complete flow',
         url: getCustomizationURL({
             ai: {

--- a/packages/gitbook/src/components/Search/SearchResults.tsx
+++ b/packages/gitbook/src/components/Search/SearchResults.tsx
@@ -218,6 +218,12 @@ export const SearchResults = React.forwardRef(function SearchResults(
                                     addRecentSearchQuery(siteSpaceId, query, 'search');
                                 }
 
+                                // The popover's focus manager re-focuses the popup when the focused
+                                // result is torn down during close (base-ui `restoreFocus`), and that
+                                // focus() scrolls the popup — anchored at the top of the page — into
+                                // view, undoing the scroll to the section the result linked to.
+                                event.currentTarget.blur();
+
                                 onResultSelect?.();
                             };
                             const resultItemProps = {

--- a/packages/gitbook/src/components/Search/SearchResults.tsx
+++ b/packages/gitbook/src/components/Search/SearchResults.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import React from 'react';
 
 import { Button, SkeletonParagraph, SkeletonSmall } from '../primitives';
+import { isExternalLink } from '../utils/link';
 import { addRecentSearchQuery } from './recent-queries';
 import { SearchPageResultItem } from './SearchPageResultItem';
 import { SearchQuestionResultItem } from './SearchQuestionResultItem';
@@ -222,7 +223,11 @@ export const SearchResults = React.forwardRef(function SearchResults(
                                 // result is torn down during close (base-ui `restoreFocus`), and that
                                 // focus() scrolls the popup — anchored at the top of the page — into
                                 // view, undoing the scroll to the section the result linked to.
-                                event.currentTarget.blur();
+                                // A click that opens elsewhere leaves the search open, and keyboard
+                                // users should keep their place in it.
+                                if (navigatesCurrentWindow(event)) {
+                                    event.currentTarget.blur();
+                                }
 
                                 onResultSelect?.();
                             };
@@ -391,3 +396,19 @@ const SearchResultsSkeleton = (props: { items: number }) => {
         </>
     );
 };
+
+/**
+ * Whether clicking a result navigates the current window, and so closes the search — as opposed
+ * to opening a new tab or window (modifier keys, `target="_blank"`, or an external destination,
+ * which an embed opens in a new tab).
+ */
+function navigatesCurrentWindow(event: React.MouseEvent<HTMLAnchorElement>) {
+    const link = event.currentTarget;
+    return (
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        link.target !== '_blank' &&
+        !isExternalLink(link.href, window.location.origin)
+    );
+}


### PR DESCRIPTION
Fixes [RND-12844](https://linear.app/gitbook-x/issue/RND-12844/section-links-do-not-scroll-to-target-sections).

## What

In the search results, clicking a link to a page **section** opened the page at the top instead of at the section. This blurs the picked result link before it navigates, so the popover's focus manager has nothing to "restore" when the popover closes.

## Why

Traced in Playwright with hooks on every scroll path (`scrollIntoView`, `scrollTo`, `scrollTop`, `focus`). On a section result click:

1. Next.js (`layout-router`) and GitBook's `scrollToHash` both scroll to the hash — correct.
2. ~60ms later, base-ui's `FloatingFocusManager.handleFocusOutside` calls `.focus()` on the **closing search popup** (`<div role="dialog" tabindex="-1" data-closed data-ending-style>`). `PopoverPopup` hardwires `restoreFocus: "popup"`: when the focused element inside the popup stops being visible and focus falls to `body`, it re-focuses the popup, without `preventScroll`.
3. The popup is absolutely positioned under the header at the top of the document, so focusing it scrolls the window back to 0.

The trigger is the clicked result `<a>` holding focus while it is torn down during the popover's exit transition. `restoreFocus` is not configurable on `Popover.Popup`, so dropping focus from the result on select is the smallest lever.

This is search-specific: direct hash loads and in-content links to another page's section already landed correctly (verified in the same harness), and `useScrollPage` / `scrollToHash` are unchanged.

## Verification

Local dev server, cold Playwright browser, argos-ci.com docs:

| Scenario | Before | After |
| --- | --- | --- |
| Search result → `/reference/playwright#test-annotations` | target 6405px below viewport top (scrollY 0) | target at 108px (scroll margin) |
| In-content link → other page `#hash` | 108px | 108px |

## Test

`Search & AI › Search - Section result scrolls to the section` (e2e/internal.spec.ts): types `tasks` on the e2e test site — its only result is the `blocks/lists#tasks` section — clicks it, waits a second for the late re-scroll the regression caused, and asserts the heading sits within its scroll margin at the top of the viewport. Verified locally: passes with the fix, fails without it (`Received: 655.5`, the heading's unscrolled position).

The query is typed with `pressSequentially` because `fill()` doesn't trigger the remote search — the popover stays on skeleton placeholders, which also carry `data-testid="search-page-result"` with `href="#"`.

## Notes for review

Two related observations, deliberately not changed here:

- On a cross-section navigation with a hash the layout remounts and `NavigationStatusProvider` starts with an empty hash before its mount effect fills it, so `useScrollPage` briefly scrolls to top before `scrollToHash` corrects it (a visible jump, self-healing). Same root as the unmerged RND-11844 branch.
- A cold first load of a long page with a hash can land a few hundred px short when fonts/images size after the browser's fragment scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)