### PR TITLE
Fix fallback URL cleanup after successful page navigation

### DIFF
--- a/.changeset/tidy-variant-fallback.md
+++ b/.changeset/tidy-variant-fallback.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Remove the fallback query parameter after successful page navigation without adding a browser history entry.

--- a/packages/gitbook/e2e/internal.spec.ts
+++ b/packages/gitbook/e2e/internal.spec.ts
@@ -514,6 +514,24 @@ const testCases: TestsCase[] = [
         contentBaseURL: 'https://gitbook-open-e2e-sites.gitbook.io/',
         tests: [
             {
+                name: 'Strip fallback after loading a page without adding history',
+                url: 'api-multi-versions/reference/api-reference/pets',
+                screenshot: false,
+                run: async (page) => {
+                    await waitForHydration(page);
+                    const previousURL = page.url();
+                    const targetURL = new URL(previousURL);
+                    targetURL.searchParams.set('fallback', 'true');
+                    targetURL.searchParams.set('ref', 'variant');
+                    targetURL.hash = 'pets';
+                    await page.goto(targetURL.toString());
+                    targetURL.searchParams.delete('fallback');
+                    await expect(page).toHaveURL(targetURL.toString());
+                    await page.goBack();
+                    await expect(page).toHaveURL(previousURL);
+                },
+            },
+            {
                 name: 'Keep navigation path/route when switching variant (Public)',
                 url: 'api-multi-versions/reference/api-reference/pets',
                 screenshot: false,
@@ -535,8 +553,11 @@ const testCases: TestsCase[] = [
                         .click();
 
                     // It should keep the current page path, i.e "reference/api-reference/pets" when navigating to the new variant
-                    await page.waitForURL((url) =>
-                        url.pathname.includes('api-multi-versions/2.0/reference/api-reference/pets')
+                    await page.waitForURL(
+                        (url) =>
+                            url.pathname.includes(
+                                'api-multi-versions/2.0/reference/api-reference/pets'
+                            ) && !url.searchParams.has('fallback')
                     );
                 },
             },

--- a/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
+++ b/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import React from 'react';
 
 import type { PageMetaLinks } from './SitePage';
@@ -33,17 +33,17 @@ export function PageClientLayout({ pageMetaLinks }: { pageMetaLinks: PageMetaLin
  * so we need to remove the fallback parameter.
  */
 function useStripFallbackQueryParam() {
-    const router = useRouter();
     const pathname = usePathname();
     const searchParams = useSearchParams();
 
     React.useEffect(() => {
-        if (searchParams?.has('fallback')) {
-            const params = new URLSearchParams(searchParams.toString());
-            params.delete('fallback');
-            router.push(`${pathname}?${params.toString()}${window.location.hash ?? ''}`);
+        // Middleware strips fallback from the rewritten URL, so read the browser URL directly.
+        const url = new URL(window.location.href);
+        if (url.searchParams.has('fallback')) {
+            url.searchParams.delete('fallback');
+            window.history.replaceState(null, '', url);
         }
-    }, [router, pathname, searchParams]);
+    }, [pathname, searchParams]);
 }
 
 /**

--- a/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
+++ b/packages/gitbook/src/components/SitePage/PageClientLayout.tsx
@@ -37,11 +37,15 @@ function useStripFallbackQueryParam() {
     const searchParams = useSearchParams();
 
     React.useEffect(() => {
-        // Middleware strips fallback from the rewritten URL, so read the browser URL directly.
-        const url = new URL(window.location.href);
-        if (url.searchParams.has('fallback')) {
-            url.searchParams.delete('fallback');
-            window.history.replaceState(null, '', url);
+        if (searchParams?.has('fallback')) {
+            const params = new URLSearchParams(searchParams.toString());
+            params.delete('fallback');
+            const query = params.toString();
+            window.history.replaceState(
+                null,
+                '',
+                `${pathname}${query ? `?${query}` : ''}${window.location.hash}`
+            );
         }
     }, [pathname, searchParams]);
 }


### PR DESCRIPTION
Related to https://linear.app/gitbook-x/issue/RND-11894

Cleaning up `fallback=true` currently calls `router.push`, adding a history entry. Pressing Back then revisits the same URL and triggers cleanup again.

Use `history.replaceState` to clean up the current entry without another navigation. Keep using `pathname` and `searchParams` to construct the URL, preserving other query parameters and the anchor.
