### PR TITLE
Support fit-content width sizing for ContentKit buttons

### DIFF
--- a/.changeset/contentkit-buttons-natural-width.md
+++ b/.changeset/contentkit-buttons-natural-width.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix ContentKit buttons to size to their content instead of stretching to the full container width.

--- a/packages/gitbook/src/components/DocumentView/Integration/contentkit.css
+++ b/packages/gitbook/src/components/DocumentView/Integration/contentkit.css
@@ -95,7 +95,7 @@
 
 /** Buttons */
 .contentkit-button {
-    @apply text-sm px-3 h-8 text-center inline-block py-1.5 rounded-md straight-corners:rounded-none place-self-start ring-1 ring-tint hover:ring-tint-hover shadow-sm shadow-tint dark:shadow-tint-1 hover:shadow-md active:shadow-none contrast-more:ring-tint-12 contrast-more:hover:ring-2 contrast-more:hover:ring-tint-12 hover:scale-105 active:scale-100 transition-all grow-0 shrink-0 truncate w-full;
+    @apply text-sm px-3 h-8 text-center inline-block py-1.5 rounded-md straight-corners:rounded-none ring-1 ring-tint hover:ring-tint-hover shadow-sm shadow-tint dark:shadow-tint-1 hover:shadow-md active:shadow-none contrast-more:ring-tint-12 contrast-more:hover:ring-2 contrast-more:hover:ring-tint-12 hover:scale-105 active:scale-100 transition-all truncate;
 }
 
 .contentkit-button-style-primary {
@@ -207,9 +207,6 @@
 }
 .contentkit-modal-confirm .contentkit-modal-footer {
     @apply flex gap-2 justify-end;
-}
-.contentkit-button-confirm {
-    @apply w-auto flex-grow-0 flex-shrink-0;
 }
 .contentkit-button-style-danger {
     @apply bg-danger text-danger hover:bg-danger-hover hover:text-danger-strong contrast-more:bg-tint-subtle;

--- a/packages/react-contentkit/src/ElementButton.tsx
+++ b/packages/react-contentkit/src/ElementButton.tsx
@@ -103,7 +103,7 @@ function ConfirmDialog({ open, onCancel, onConfirm, style, title, text, confirm 
                 <div className="contentkit-modal-footer">
                     <button
                         type="button"
-                        className="contentkit-button contentkit-button-confirm contentkit-button-style-secondary"
+                        className="contentkit-button contentkit-button-style-secondary"
                         onClick={onCancel}
                     >
                         Cancel
@@ -111,7 +111,7 @@ function ConfirmDialog({ open, onCancel, onConfirm, style, title, text, confirm 
                     <button
                         type="button"
                         className={classNames(
-                            'contentkit-button contentkit-button-confirm',
+                            'contentkit-button',
                             `contentkit-button-style-${style ?? 'primary'}`
                         )}
                         onClick={onConfirm}


### PR DESCRIPTION
## Summary
- Remove unnecessary width and flex constraints from ContentKit button base styles
- Allow buttons to size naturally to their content instead of stretching full width
- Simplify CSS by removing the dedicated `.contentkit-button-confirm` class

ContentKit buttons now properly render at their natural width when displayed inline, enabling correct layout for buttons with varying content lengths.

## Demo
<img width="2928" height="1820" alt="image" src="https://github.com/user-attachments/assets/13ff2bce-3a9d-4474-a436-f8f65f11f6ed" />