### PR TITLE
Fix set-cookie in RSC requests conflicting with logout requests

### DIFF
--- a/packages/gitbook/src/lib/visitors.test.ts
+++ b/packages/gitbook/src/lib/visitors.test.ts
@@ -229,6 +229,27 @@ describe('getVisitorAuthToken', () => {
 
 // The chunking mechanics themselves are covered in api-token-cookie.test.ts;
 // these tests cover the wiring into the visitor auth cookie.
+describe('getResponseCookiesForVisitorAuth write policy', () => {
+    const base64url = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url');
+    const token = `${base64url({ alg: 'none' })}.${base64url({ exp: 2_000_000_000 })}.sig`;
+
+    it('persists a token that arrived in the URL', () => {
+        expect(getResponseCookiesForVisitorAuth('/', { source: 'url', token })).toHaveLength(1);
+    });
+
+    it('only accepts a token that arrived in the URL', () => {
+        const fromVACookie = { source: 'visitor-auth-cookie', basePath: '/', token } as const;
+        const fromCustomCookie = { source: 'gitbook-visitor-cookie', token } as const;
+
+        // @ts-expect-error a token read back from a VA cookie must never be persisted again
+        const buildFromVACookie = () => getResponseCookiesForVisitorAuth('/', fromVACookie);
+        // @ts-expect-error a custom visitor cookie is owned by the customer's backend
+        const buildFromCustom = () => getResponseCookiesForVisitorAuth('/', fromCustomCookie);
+
+        expect([buildFromVACookie, buildFromCustom]).toHaveLength(2);
+    });
+});
+
 describe('getResponseCookiesForVisitorAuth chunking', () => {
     const base64url = (value: object) => Buffer.from(JSON.stringify(value)).toString('base64url');
 

--- a/packages/gitbook/src/lib/visitors.ts
+++ b/packages/gitbook/src/lib/visitors.ts
@@ -313,17 +313,19 @@ function getResponseCookieForVisitorParams(
 }
 
 /**
- * Return the lookup result for content served with visitor auth.
+ * Build the cookies persisting a visitor auth token that arrived in the URL.
+ *
+ * Only a token from URL is ever persisted into the VA cookie: a token read back from a VA cookie is already
+ * stored and its expiry derives from the token itself, so rewriting it achieves nothing except
+ * letting an in-flight request resurrect a cookie `~gitbook/auth/logout` has just deleted. A
+ * custom `gitbook-visitor-token` cookie is owned by the customer's backend and is never copied,
+ * to keep a single source of truth.
  */
 export function getResponseCookiesForVisitorAuth(
     basePath: string,
-    visitorTokenLookup: VisitorTokenLookup,
+    visitorTokenLookup: Extract<VisitorTokenLookup, { source: 'url' }>,
     requestCookies: RequestCookies = []
 ): ResponseCookies {
-    if (!visitorTokenLookup) {
-        return [];
-    }
-
     let decoded: JwtPayload;
     try {
         decoded = jwtDecode(visitorTokenLookup.token);
@@ -332,43 +334,29 @@ export function getResponseCookiesForVisitorAuth(
         return [];
     }
 
-    /**
-     * If the visitor token has been retrieve from the URL, or if its a VA cookie and the basePath is the same, set it
-     * as a cookie on the response.
-     *
-     * Note that we do not re-store the gitbook-visitor-cookie in another cookie, to maintain a single source of truth.
-     */
-    if (
-        visitorTokenLookup?.source === 'url' ||
-        (visitorTokenLookup?.source === 'visitor-auth-cookie' &&
-            visitorTokenLookup.basePath === basePath)
-    ) {
-        const name = getVisitorAuthCookieName(basePath);
-        const value = getVisitorAuthCookieValue(basePath, visitorTokenLookup.token);
-        const options = {
-            httpOnly: true,
-            sameSite: process.env.NODE_ENV === 'production' ? ('none' as const) : undefined,
-            secure: process.env.NODE_ENV === 'production',
-            maxAge: getVisitorAuthCookieMaxAge(decoded),
-        };
+    const name = getVisitorAuthCookieName(basePath);
+    const value = getVisitorAuthCookieValue(basePath, visitorTokenLookup.token);
+    const options = {
+        httpOnly: true,
+        sameSite: process.env.NODE_ENV === 'production' ? ('none' as const) : undefined,
+        secure: process.env.NODE_ENV === 'production',
+        maxAge: getVisitorAuthCookieMaxAge(decoded),
+    };
 
-        // Chunk the cookie when the value exceeds the single-cookie size limit,
-        // as browsers silently drop oversized Set-Cookie headers which causes
-        // an infinite auth redirect loop.
-        if (value.length > MAX_CHUNKED_COOKIE_LENGTH) {
-            // Too large even for chunking: fall back to a single cookie (best effort).
-            return [{ name, value, options }];
-        }
-
-        return getChunkedResponseCookies({
-            cookies: requestCookies,
-            cookieName: name,
-            value,
-            options,
-        });
+    // Chunk the cookie when the value exceeds the single-cookie size limit,
+    // as browsers silently drop oversized Set-Cookie headers which causes
+    // an infinite auth redirect loop.
+    if (value.length > MAX_CHUNKED_COOKIE_LENGTH) {
+        // Too large even for chunking: fall back to a single cookie (best effort).
+        return [{ name, value, options }];
     }
 
-    return [];
+    return getChunkedResponseCookies({
+        cookies: requestCookies,
+        cookieName: name,
+        value,
+        options,
+    });
 }
 
 /**

--- a/packages/gitbook/src/middleware.ts
+++ b/packages/gitbook/src/middleware.ts
@@ -312,19 +312,6 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
             });
         }
 
-        const normalizedSitePathname = removeLeadingSlash(
-            removeTrailingSlash(siteURLData.pathname)
-        );
-        if (normalizedSitePathname !== '~gitbook/auth/logout') {
-            cookies.push(
-                ...getResponseCookiesForVisitorAuth(
-                    getVisitorAuthBasePath(siteRequestURL, siteURLData),
-                    visitorToken,
-                    request.cookies.getAll()
-                )
-            );
-        }
-
         // We use the host/origin from the canonical URL to ensure the links are
         // correctly generated when the site is proxied. e.g. https://proxy.gitbook.com/site/siteId/...
         const siteCanonicalURL = new URL(siteURLData.canonicalUrl);
@@ -352,6 +339,16 @@ async function serveSiteRoutes(requestURL: URL, request: NextRequest) {
             normalizedVisitorURL.toString() !== incomingURL.toString() &&
             !isRevalidationRequest(request.headers)
         ) {
+            if (visitorToken?.source === 'url') {
+                cookies.push(
+                    ...getResponseCookiesForVisitorAuth(
+                        getVisitorAuthBasePath(siteRequestURL, siteURLData),
+                        visitorToken,
+                        request.cookies.getAll()
+                    )
+                );
+            }
+
             return writeResponseCookies(
                 NextResponse.redirect(normalizedVisitorURL.toString()),
                 cookies


### PR DESCRIPTION
While investigating a customer issue where the `gitbook-visitor-token` cookie was not being cleared on some logout attempts, I found that the logout request does correctly return the `Set-Cookie` header to delete the cookie, but just after (or at the same time), another RSC request fires which also has a `Set-Cookie` header, and that one sets the cookie with the token again, leaving me still logged in.

Here's the sequence from my repro:
```
    T1 -->  GET ~gitbook/auth/logout          (clears VA cookie)
    T1+16ms -->  GET /core/get-started?_rsc=…      (sends VA cookie — logout still in flight)
    T2 -->  logout 307   Set-Cookie: …=; Expires=Thu, 01 Jan 1970   ✅ deleted
    T2+20ms -->  prefetch 307 Set-Cookie: …=…; Max-Age=3529              ❌ set again
```

The root cause is that we were setting the visitor auth cookie on every requests, not just the one that carries the token. That was carried over from multiple code rewrites and ended up placed at the wrong level in the middleware. 

We should only ever be setting the cookie when the token is passed via the URL.

This moves the cookie write onto the redirect that strips `jwt_token` from the URL, guarded by an explicit source check, and narrows `getResponseCookiesForVisitorAuth` so it can only be called with a URL-borne token.