### PR TITLE
Fix select filters on table and cards blocks

### DIFF
--- a/.changeset/chubby-adults-poke.md
+++ b/.changeset/chubby-adults-poke.md
@@ -1,0 +1,5 @@
+---
+"gitbook": patch
+---
+
+Fix select filters not working on table and cards blocks.

--- a/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
@@ -115,7 +115,6 @@ export function TableSearchProvider(props: {
         }),
         [query, selectedOptions, toggleOption, checkedColumns, toggleCheckbox, visibleIds, isEmpty]
     );
-    console.log('TEST ', { query, selectedOptions, checkedColumns, visibleIds, isEmpty });
 
     return (
         <TableSearchContext.Provider value={value}>{props.children}</TableSearchContext.Provider>

--- a/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
+++ b/packages/gitbook/src/components/DocumentView/Table/TableSearch.tsx
@@ -115,6 +115,7 @@ export function TableSearchProvider(props: {
         }),
         [query, selectedOptions, toggleOption, checkedColumns, toggleCheckbox, visibleIds, isEmpty]
     );
+    console.log('TEST ', { query, selectedOptions, checkedColumns, visibleIds, isEmpty });
 
     return (
         <TableSearchContext.Provider value={value}>{props.children}</TableSearchContext.Provider>
@@ -226,11 +227,10 @@ function SelectFilterDropdown(props: { column: TableSelectColumn }) {
                         key={option.value}
                         active={selected}
                         leadingIcon={selected ? 'check' : undefined}
-                        onSelect={(event) => {
-                            // Keep the menu open so several options can be toggled at once.
-                            event.preventDefault();
-                            toggleOption(column.id, option.value);
-                        }}
+                        // `closeOnClick={false}` keeps the menu open so several options can be
+                        // toggled at once.
+                        closeOnClick={false}
+                        onClick={() => toggleOption(column.id, option.value)}
                     >
                         {option.label || option.value}
                     </DropdownMenuItem>


### PR DESCRIPTION
## Problem

Select-field filters did nothing on published table and cards blocks. Clicking an option in the filter dropdown toggled no state, so nothing was filtered. Free-text search and the checkbox filter were unaffected.

## Cause

`SelectFilterDropdown` was wired with `onSelect`, the Radix convention:

```tsx
onSelect={(event) => {
    event.preventDefault();
    toggleOption(column.id, option.value);
}}
```

`DropdownMenuItem` renders Base UI's `Menu.Item`, whose API is `onClick` + `closeOnClick` — there is no `onSelect`. It typechecked because `MenuItemProps extends BaseUIComponentProps<'div', …>` and React's DOM props include `onSelect`, the *text-selection* event. The handler was spread onto the div as a `select` listener and never fired on click.

Every other menu item in the repo already uses `onClick`; this was the only `onSelect` call site.

## Fix

```tsx
closeOnClick={false}
onClick={() => toggleOption(column.id, option.value)}
```

`closeOnClick={false}` replaces what the `preventDefault()` was there for — the menu stays open so several options can be toggled at once.

Fixes RND-12890

🤖 Generated with [Claude Code](https://claude.com/claude-code)